### PR TITLE
promises - socks-to-rtc side

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,7 +29,7 @@ module.exports = (grunt) ->
       socks2rtc: {
         src: ['src/interfaces/*.d.ts',
               'src/socks-to-rtc/*.ts'],
-        outDir: 'tmp/socks-to-rtc',
+        outDir: 'tmp/',
         options: {
           sourceMap: false
         }
@@ -37,7 +37,7 @@ module.exports = (grunt) ->
       rtc2net: {
         src: ['src/interfaces/*.d.ts',
               'src/rtc-to-net/*.ts'],
-        outDir: 'tmp/rtc-to-net',
+        outDir: 'tmp/',
         options: {
           sourceMap: false
         }

--- a/src/interfaces/promise.d.ts
+++ b/src/interfaces/promise.d.ts
@@ -13,8 +13,8 @@ interface Thenable<F,R> {
  */
 declare class Promise<F,R> {
 
-  constructor (onFulfilled:(fulfillObj : F) => void,
-               onRejected:(rejectObj? : R) => void);
+  constructor (f:(onFulfilled:(fulfillObj:F)=>void,
+                  onRejected:(rejectObj?:R)=>void)=>void);
 
   then<F2,R2> (onFulfilled:(F) => Promise<F2,R2>,
                onRejected?:(R) => void)

--- a/src/interfaces/promise.d.ts
+++ b/src/interfaces/promise.d.ts
@@ -1,47 +1,48 @@
 // Based on http://www.html5rocks.com/en/tutorials/es6/promises/#toc-api
 
-interface Thenable<F,R> {
-  then:(onFulfilled:(F) => void,
-        onRejected:(R) => void) => Thenable<F,R>;
+interface Thenable<T> {
+  then:(fulfill:(t:T) => void,
+        reject?:(e:Error) => void) => Thenable<T>;
 }
 
 /**
- * Generic Promise class.
+ * Generic Promise for built-in js Promises.
  *
- * F is the `fullfilled` type given to onFulfilled function.
- * R is the `rejected` type given to the onRejected object.
+ * T is the `fullfillment object` type given to onTulfilled function.
+ *
+ * The rejection object is always a javascript Error.
  */
-declare class Promise<F,R> {
+declare class Promise<T> {
 
-  constructor (f:(onFulfilled:(fulfillObj:F)=>void,
-                  onRejected:(rejectObj?:R)=>void)=>void);
+  constructor (f:(fulfill:(t:T)=>void,
+                  reject:(e:Error)=>void)=>void);
 
-  // |onFulfilled| either returns a promise...
-  then<F2,R2> (onFulfilled?:(F) => Promise<F2,R2>,
-               onRejected?:(R) => void)
-      :Promise<F2,R2>;
+  // |onTulfilled| either returns a promise...
+  then<T2> (fulfill:(t:T) => Promise<T2>,
+            reject?:(e:Error) => void)
+      :Promise<T2>;
 
   // or the next fulfillment object directly.
-  then<F2,R2> (onFulfilled?:(F) => F2,
-               onRejected?:(R) => void)
-      :Promise<F2,R2>;
+  then<T2> (fulfill?:(t:T) => T2,
+            reject?:(e:Error) => void)
+      :Promise<T2>;
 
-  catch (catchFn:(rejectObj:R) => void)
-      :Promise<F,R>;
+  catch (catchTn:(e:Error) => void)
+      :Promise<T>;
 
-  static resolve<F,R> (thenable:Thenable<F,R>)
-      :Promise<F,R>;
+  static resolve<T> (thenable:Thenable<T>)
+      :Promise<T>;
 
-  static resolve<F,R> (fulfillObj:F)
-      :Promise<F,R>;
+  static resolve<T> (t?:T)
+      :Promise<T>;
 
-  static reject<F,R>  (rejectObj:R)
-      :Promise<F,R>;
+  static reject<T> (e:Error)
+      :Promise<T>;
 
-  static all<F,R> (...args:Thenable<F,R>[])
-      :Promise<F,R>;
+  static all<T> (...args:Thenable<T>[])
+      :Promise<T>;
 
-  static race<F,R> (...args:Thenable<F,R>[])
-      :Promise<F,R>;
+  static race<T> (...args:Thenable<T>[])
+      :Promise<T>;
 
 }

--- a/src/interfaces/promise.d.ts
+++ b/src/interfaces/promise.d.ts
@@ -1,7 +1,7 @@
 // Based on http://www.html5rocks.com/en/tutorials/es6/promises/#toc-api
 
 interface Thenable<T> {
-  then:(fulfill:(t:T) => void,
+  then:(fulfill:(t?:T) => void,
         reject?:(e:Error) => void) => Thenable<T>;
 }
 
@@ -14,7 +14,7 @@ interface Thenable<T> {
  */
 declare class Promise<T> {
 
-  constructor (f:(fulfill:(t:T)=>void,
+  constructor (f:(fulfill:(t?:T)=>void,
                   reject:(e:Error)=>void)=>void);
 
   // |onTulfilled| either returns a promise...

--- a/src/interfaces/promise.d.ts
+++ b/src/interfaces/promise.d.ts
@@ -1,4 +1,5 @@
 // Based on http://www.html5rocks.com/en/tutorials/es6/promises/#toc-api
+// Promise Spec: http://promises-aplus.github.io/promises-spec/
 
 interface Thenable<T> {
   then:(fulfill:(t?:T) => void,
@@ -46,3 +47,10 @@ declare class Promise<T> {
       :Promise<T>;
 
 }
+
+
+// Add .stack attribute to Errors (which actually does exist in js).
+interface Error {
+  stack?:any;
+}
+

--- a/src/interfaces/promise.d.ts
+++ b/src/interfaces/promise.d.ts
@@ -16,7 +16,13 @@ declare class Promise<F,R> {
   constructor (f:(onFulfilled:(fulfillObj:F)=>void,
                   onRejected:(rejectObj?:R)=>void)=>void);
 
-  then<F2,R2> (onFulfilled:(F) => Promise<F2,R2>,
+  // |onFulfilled| either returns a promise...
+  then<F2,R2> (onFulfilled?:(F) => Promise<F2,R2>,
+               onRejected?:(R) => void)
+      :Promise<F2,R2>;
+
+  // or the next fulfillment object directly.
+  then<F2,R2> (onFulfilled?:(F) => F2,
                onRejected?:(R) => void)
       :Promise<F2,R2>;
 

--- a/src/interfaces/promise.d.ts
+++ b/src/interfaces/promise.d.ts
@@ -18,18 +18,19 @@ declare class Promise<T> {
   constructor (f:(fulfill:(t?:T)=>void,
                   reject:(e:Error)=>void)=>void);
 
-  // |onTulfilled| either returns a promise...
+  // |onFulfilled| either returns a promise...
   then<T2> (fulfill:(t:T) => Promise<T2>,
-            reject?:(e:Error) => void)
+            reject?:(e:Error) => Promise<T2>)
       :Promise<T2>;
 
   // or the next fulfillment object directly.
   then<T2> (fulfill?:(t:T) => T2,
-            reject?:(e:Error) => void)
+            reject?:(e:Error) => T2)
       :Promise<T2>;
 
-  catch (catchFn:(e:Error) => void)
-      :Promise<T>;
+  catch (catchFn:(e:Error) => Promise<T>):Promise<T>;
+  catch (catchFn:(e:Error) => T):Promise<T>;
+  catch (catchFn:(e:Error) => void):Promise<void>;
 
   static resolve<T> (thenable:Thenable<T>)
       :Promise<T>;

--- a/src/interfaces/promise.d.ts
+++ b/src/interfaces/promise.d.ts
@@ -28,14 +28,17 @@ declare class Promise<T> {
             reject?:(e:Error) => void)
       :Promise<T2>;
 
-  catch (catchTn:(e:Error) => void)
+  catch (catchFn:(e:Error) => void)
       :Promise<T>;
 
   static resolve<T> (thenable:Thenable<T>)
       :Promise<T>;
 
-  static resolve<T> (t?:T)
+  static resolve<T> (t:T)
       :Promise<T>;
+
+  static resolve ()
+      :Promise<void>;
 
   static reject<T> (e:Error)
       :Promise<T>;

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -110,6 +110,7 @@ module SocksToRTC {
 
     /**
      * Setup data channel and tie to corresponding SOCKS5 session.
+     * Returns: IP and port of destination.
      */
     private onConnection_ = (session:Socks.Session, address, port,
                              connectedCallback) => {
@@ -118,6 +119,7 @@ module SocksToRTC {
                       'SCTP peer connection.');
         return;
       }
+      console.log('New SOCKS session - setting up data channel.');
       var channelLabel = obtainChannelLabel();
       this.socksSessions[channelLabel] = session;
       // When the TCP-connection receives data, send to sctp peer.
@@ -135,7 +137,9 @@ module SocksToRTC {
 
       // Allow SOCKs headers
       // TODO: determine if these need to be accurate.
-      connectedCallback({ ipAddrString: '127.0.0.1', port: 0 });
+      // connectedCallback({ ipAddrString: '127.0.0.1', port: 0 });
+      console.log('responding...');
+      return { ipAddrString: '127.0.0.1', port: 0 };
     }
 
     /**

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -123,7 +123,7 @@ module SocksToRTC {
       // When the TCP-connection receives data, send to sctp peer.
       // When it disconnects, clear the |channelLabel|.
       session.onRecv((buf) => { this.sendToPeer_(channelLabel, buf); });
-      session.onDisconnect()
+      session.oncenDisconnected()
           .then(() => {
             this.closeConnection_(channelLabel);
           });

--- a/src/socks-to-rtc/socks.ts
+++ b/src/socks-to-rtc/socks.ts
@@ -156,10 +156,6 @@ module Socks {
         ) {
       var tcpServer = new TCP.Server(address || 'localhost',
                                      port    || 1080);
-      tcpServer.on('listening', () => {
-        // When we start listening, print it out.
-        console.log('LISTENING ' + tcpServer.addr + ':' + tcpServer.port);
-      });
 
       // Each new TCP connection attaches a |recv| handler which creates a new
       // Socks.Session.
@@ -179,7 +175,12 @@ module Socks {
       this.tcpServer = tcpServer;
     }
 
-    listen()     { this.tcpServer.listen(); }
+    listen() {
+      return this.tcpServer.listen().then(() => {
+        console.log('LISTENING ' + this.tcpServer.addr + ':' + this.tcpServer.port);
+        return null;
+      });
+    }
     disconnect() { this.tcpServer.disconnect(); }
 
   }  // Socks.Server

--- a/src/socks-to-rtc/socks.ts
+++ b/src/socks-to-rtc/socks.ts
@@ -357,7 +357,7 @@ module Socks {
     /**
      * Return disconnection promise from underlying TCP connection.
      */
-    public onDisconnect = () => { return this.tcpConnection.onDisconnect(); }
+    public onceDisconnected = () => { return this.tcpConnection.onDisconnect(); }
 
     public toString() {
       return 'Socks.Session[' + this.tcpConnection.socketId + ']';

--- a/src/socks-to-rtc/tcp.ts
+++ b/src/socks-to-rtc/tcp.ts
@@ -154,7 +154,7 @@ module TCP {
           fSockets.destroy(serverSocketId).fail(R);
         }
         this.serverSocketId = 0;
-        for (var i in this.conns) { //openConnections) {
+        for (var i in this.conns) {
           try {
             this.conns[i]
                 .then(Connection.disconnect)
@@ -373,16 +373,10 @@ module TCP {
         return;
       }
       this.isConnected = false;
-      // Temporarily remember disconnect callback.
       // var disconnectCallback = this.callbacks.disconnect;
-      // Remove all callbacks.
-      // this.callbacks.disconnect = null;
-      // this.callbacks.recv = null;
-      // this.callbacks.sent = null;
       // Close the socket.
       fSockets.disconnect(this.socketId);
       fSockets.destroy(this.socketId);
-      // Make disconnect callback if not null
       // disconnectCallback && disconnectCallback(this);
       return this;
     }

--- a/src/socks-to-rtc/tcp.ts
+++ b/src/socks-to-rtc/tcp.ts
@@ -75,7 +75,7 @@ module TCP {
      *
      * Returns: Promise that this server is now listening.
      */
-    public listen():Promise<any,Error> {
+    public listen():Promise<void> {
       var listenPromise = this.createSocket_()
           .then(this.startListening_)
           .then(this.attachSocketHandlers_);
@@ -89,8 +89,7 @@ module TCP {
      * Promise the creation of a freedom socket.
      * TODO: When freedom uses promises, simplify this function away.
      */
-    private createSocket_ = ()
-        : Promise<ICreateInfo,Error> => {
+    private createSocket_ = ():Promise<ICreateInfo> => {
       return new Promise((F, R) => {
         fSockets.create('tcp', {}).done(F).fail(R);
       });
@@ -99,8 +98,7 @@ module TCP {
     /**
      * Promise that socket begins listening.
      */
-    private startListening_ = (createInfo:ICreateInfo)
-        : Promise<number,Error>  => {
+    private startListening_ = (createInfo:ICreateInfo):Promise<number>  => {
       this.serverSocketId = createInfo.socketId;
       if (this.serverSocketId <= 0) {
         return Promise.reject(new Error('failed to create socket on ' +

--- a/src/socks-to-rtc/tcp.ts
+++ b/src/socks-to-rtc/tcp.ts
@@ -94,8 +94,7 @@ module TCP {
     private startListening_ = (createInfo:ICreateInfo):Promise<number>  => {
       this.serverSocketId = createInfo.socketId;
       if (this.serverSocketId <= 0) {
-        return Promise.reject(new Error('failed to create socket on ' +
-                                        this.endpoint_));
+        return Util.Reject('failed to create socket on ' + this.endpoint_);
       }
       console.log('TCP.Server: created socket ' + this.serverSocketId +
           ' listening at ' + this.endpoint_);
@@ -111,9 +110,8 @@ module TCP {
      */
     private attachSocketHandlers_ = (resultCode:number) => {
       if (0 !== resultCode) {
-        return Promise.reject(new Error(
-            'listen failed on ' + this.endpoint_ +
-            ' \n Result Code: ' + resultCode));
+        return Util.Reject('listen failed on ' + this.endpoint_ +
+                             ' \n Result Code: ' + resultCode);
       }
       // Success. Attach connect, disconnect, and data handlers.
       fSockets.on('onConnection', this.accept_);
@@ -126,8 +124,8 @@ module TCP {
      */
     private accept_ = (acceptValue) => {
       if (this.serverSocketId !== acceptValue.serverSocketId) {
-        return Promise.reject(new Error('cannot accept unexpected socket ID: ' +
-            this.serverSocketId + ' vs ' + acceptValue.serverSocketId));
+        return Util.Reject('cannot accept unexpected socket ID: ' +
+            this.serverSocketId + ' vs ' + acceptValue.serverSocketId);
       }
       var socketId = acceptValue.clientSocketId;
       var connectionsCount = Object.keys(this.conns).length;
@@ -135,7 +133,7 @@ module TCP {
         // Stop too many connections.
         fSockets.disconnect(socketId);
         fSockets.destroy(socketId);
-        return Promise.reject(new Error('too many connections: ' + connectionsCount));
+        return Util.Reject('too many connections: ' + connectionsCount);
       }
       var promise = this.conns[socketId] = Connection.Create(
           socketId, this.connectionCallbacks);
@@ -301,7 +299,7 @@ module TCP {
     /**
      * Obtain a promise for a buffer as the result of a recv.
      */
-    public promiseRecv = (minByteLength?:number):Promise<any> => {
+    public receive = (minByteLength?:number):Promise<any> => {
       return new Promise((F, R) => {
         if (minByteLength) {
           this.recvOptions = {
@@ -482,6 +480,13 @@ module Util {
       callback(e.target.result);
     };
     f.readAsArrayBuffer(bb);
+  }
+
+  /**
+   * Wrapper around creating a Promise rejection with Error.
+   */
+  export function Reject(msg:string) {
+    return Promise.reject(new Error(msg));
   }
 
 }  // module Util


### PR DESCRIPTION
Convert most callbacks floating between SOCKS server and TCP server to promises.
- TCP server listening, accept, disconnect
- TCP connection create and disconnect
- SOCKs handshake and request handling
- Slightly cleaner documentation

Tested: manual end-to-end
