### PR TITLE
promises - tcp and chrome sockets

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,7 +29,7 @@ module.exports = (grunt) ->
       socks2rtc: {
         src: ['src/interfaces/*.d.ts',
               'src/socks-to-rtc/*.ts'],
-        outDir: 'tmp/',
+        outDir: 'tmp/socks-to-rtc/',
         options: {
           sourceMap: false
         }
@@ -37,7 +37,7 @@ module.exports = (grunt) ->
       rtc2net: {
         src: ['src/interfaces/*.d.ts',
               'src/rtc-to-net/*.ts'],
-        outDir: 'tmp/',
+        outDir: 'tmp/rtc-to-net/',
         options: {
           sourceMap: false
         }

--- a/chrome/lib/boilerplate.js
+++ b/chrome/lib/boilerplate.js
@@ -3,5 +3,5 @@
 */
 window.freedomcfg = function(register) {
   // Necessary so we can actually use chrome sockets.
-  register('core.socket', ChromeSockets);  // src/chrome-fsocket.ts
+  register('core.socket', Sockets.Chrome);  // src/chrome-fsocket.ts
 }

--- a/src/chrome-fsocket.ts
+++ b/src/chrome-fsocket.ts
@@ -7,151 +7,157 @@
 
 declare var chrome:any;
 
-// https://developer.chrome.com/apps/socket.html#method-read
-interface ChromeReadInfo {
-  resultCode:number;
-  data:ArrayBuffer
-}
+module Sockets {
 
-// http://developer.chrome.com/apps/socket.html
-class ChromeSockets implements ISockets {
-
-  sid = null;
-  constructor (public channel) {}
-
-  public create = chrome.socket.create;
-  public write = chrome.socket.write;
-  public getInfo = chrome.socket.getInfo;
-
-  public connect = (socketId, hostname, port, callback) => {
-    chrome.socket.connect(socketId, hostname, port, (result) => {
-      console.log('connect socketId: ' + socketId + ' hostname=' + hostname + ' port=' + port)
-      callback(result);
-      this.doReadLoop_(socketId);
-    });
+  // https://developer.chrome.com/apps/socket.html#method-read
+  interface ChromeReadInfo {
+    resultCode:number;
+    data:ArrayBuffer
   }
 
-  public listen = (socketId, address, port, callback) => {
-    chrome.socket.listen(socketId, address, port, null, (result) => {
-      callback(result);
-      if (0 !== result) { return; }
-      // Begin accept-loop on this socket.
-      var acceptCallback = (acceptInfo) => {
-        if (0 === acceptInfo.resultCode) {
-          this.fireEvent('onConnection', {
-              serverSocketId: socketId,
-              clientSocketId: acceptInfo.socketId
-          });
-          chrome.socket.accept(socketId, acceptCallback);
-          this.doReadLoop_(acceptInfo.socketId);
-        // -15 is SOCKET_NOT_CONNECTED
-        } else if (-15 !== acceptInfo.resultCode) {
-          console.error('Error ' + acceptInfo.resultCode
-          + ' while trying to accept connection on socket '
-              + socketId);
-        }
-      };
-      chrome.socket.accept(socketId, acceptCallback);
-    });
-  }
-
-  public destroy = (socketId, continuation) => {
-    if (chrome && chrome.socket) {
-      chrome.socket.destroy(socketId);
-    }
-    continuation();
-  }
-
-  public disconnect = (socketId, continuation) => {
-    if (chrome && chrome.socket) {
-      chrome.socket.disconnect(socketId);
-    }
-    continuation();
-  }
-
-  /*
-   * Continuously reads data in from the given socket and dispatches the data to
-   * the socket user.
+  /**
+   * This class wraps the chrome socket API:
+   *   (http://developer.chrome.com/apps/socket.html)
+   * for the freedom interface.
    */
-  private doReadLoop_ = (socketId) => {
-    return this.promiseRead_(socketId)
-        .then(this.checkResultCode_)
-        .then((data) => {
-          // This still dispatches to *all* handlers attached to onData, and
-          // puts the responsibility on the user of this object to act only for
-          // the socket corresponding to |socketId|. Really bad.
-          // TODO: Make the events a bijection.
-          this.fireEvent('onData', {
-            socketId: socketId,
-            data: data
-          });
-          return socketId;
-        })
-        .then(this.doReadLoop_)
-        .catch((e) => {
-          console.log('ChromeSocket ' + socketId + ': ' + e.message);
-          this.fireEvent('onDisconnect', {
+  export class Chrome implements ISockets {
+
+    constructor (public channel) {}
+
+    public create = chrome.socket.create;
+    public write = chrome.socket.write;
+    public getInfo = chrome.socket.getInfo;
+
+    public connect = (socketId, hostname, port, callback) => {
+      chrome.socket.connect(socketId, hostname, port, (result) => {
+        console.log('connect socketId: ' + socketId + ' hostname=' + hostname + ' port=' + port)
+        callback(result);
+        this.doReadLoop_(socketId);
+      });
+    }
+
+    public listen = (socketId, address, port, callback) => {
+      chrome.socket.listen(socketId, address, port, null, (result) => {
+        callback(result);
+        if (0 !== result) { return; }
+        // Begin accept-loop on this socket.
+        var acceptCallback = (acceptInfo) => {
+          if (0 === acceptInfo.resultCode) {
+            this.fireEvent('onConnection', {
+                serverSocketId: socketId,
+                clientSocketId: acceptInfo.socketId
+            });
+            chrome.socket.accept(socketId, acceptCallback);
+            this.doReadLoop_(acceptInfo.socketId);
+          // -15 is SOCKET_NOT_CONNECTED
+          } else if (-15 !== acceptInfo.resultCode) {
+            console.error('Error ' + acceptInfo.resultCode
+            + ' while trying to accept connection on socket '
+                + socketId);
+          }
+        };
+        chrome.socket.accept(socketId, acceptCallback);
+      });
+    }
+
+    public destroy = (socketId:number, continuation) => {
+      if (chrome && chrome.socket) {
+        chrome.socket.destroy(socketId);
+      }
+      continuation();
+    }
+
+    public disconnect = (socketId:number, continuation) => {
+      if (chrome && chrome.socket) {
+        chrome.socket.disconnect(socketId);
+      }
+      continuation();
+    }
+
+    /*
+     * Continuously reads data in from the given socket and dispatches the data to
+     * the socket user.
+     */
+    private doReadLoop_ = (socketId:number) => {
+      return this.promiseRead_(socketId)
+          .then(this.checkResultCode_)
+          .then((data) => {
+            // This still dispatches to *all* handlers attached to onData, and
+            // puts the responsibility on the user of this object to act only for
+            // the socket corresponding to |socketId|. Really bad.
+            // TODO: Make the events a bijection.
+            this.fireEvent('onData', {
               socketId: socketId,
-              error: e.message
-          });
-        })
-  }
-
-  /**
-   * Create a promise for a future reading of this socket.
-   */
-  private promiseRead_ = (socketId:number):Promise<ChromeReadInfo> => {
-    return new Promise((F, R) => { chrome.socket.read(socketId, null, F); });
-  }
-
-  /**
-   * Check the result code of a read - if non-positive, reject the promise.
-   * Othrerwise, pass along read data.
-   */
-  private checkResultCode_ = (readInfo:ChromeReadInfo) => {
-    var code = readInfo.resultCode;
-    if (code <= 0) {
-      var msg = '' + code;
-      if (msg in ERROR_MAP) {
-        msg = ERROR_MAP[msg];
-      }
-      if (0 === code) {
-        return Promise.reject(new Error('remotely closed.'));
-      }
-      return Promise.reject(new Error(msg));
+              data: data
+            });
+            return socketId;
+          })
+          .then(this.doReadLoop_)
+          .catch((e) => {
+            console.log('ChromeSocket ' + socketId + ': ' + e.message);
+            this.fireEvent('onDisconnect', {
+                socketId: socketId,
+                error: e.message
+            });
+          })
     }
-    return Promise.resolve(readInfo.data);
-  }
 
-  /**
-   * Freedom currently attaches the 'dispatchEvent' function afterwards, which
-   * breaks type checking. TODO: Remove when that's fixed.
-   */
-  private fireEvent = (event:string, data:any) => {
-    this['dispatchEvent'](event, data);
-  }
+    /**
+     * Create a promise for a future reading of this socket.
+     */
+    private promiseRead_ = (socketId:number):Promise<ChromeReadInfo> => {
+      return new Promise((F, R) => { chrome.socket.read(socketId, null, F); });
+    }
 
-}  // class ChromeSockets
+    /**
+     * Check the result code of a read - if non-positive, reject the promise.
+     * Othrerwise, pass along read data.
+     */
+    private checkResultCode_ = (readInfo:ChromeReadInfo) => {
+      var code = readInfo.resultCode;
+      if (code <= 0) {
+        var msg = '' + code;
+        if (msg in ERROR_MAP) {
+          msg = ERROR_MAP[msg];
+        }
+        if (0 === code) {
+          return Promise.reject(new Error('remotely closed.'));
+        }
+        return Promise.reject(new Error(msg));
+      }
+      return Promise.resolve(readInfo.data);
+    }
 
+    /**
+     * Freedom currently attaches the 'dispatchEvent' function afterwards, which
+     * breaks type checking. TODO: Remove when that's fixed.
+     */
+    private fireEvent = (event:string, data:any) => {
+      this['dispatchEvent'](event, data);
+    }
 
-// Error codes can be found at:
-// https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
-var ERROR_MAP = {
-  '-1': 'IO_PENDING',
-  '-2': 'FAILED',
-  '-3': 'ABORTED',
-  '-4': 'INVALID_ARGUMENT',
-  '-5': 'INVALID_HANDLE',
-  '-7': 'TIMED_OUT',
-  '-13': 'OUT_OF_MEMORY',
-  '-15': 'SOCKET_NOT_CONNECTED',
-  '-21': 'NETWORK_CHANGED',
-  '-23': 'SOCKET_IS_CONNECTED',
-  '-100': 'CONNECTION_CLOSED',
-  '-101': 'CONNECTION_RESET',
-  '-102': 'CONNECTION_REFUSED',
-  '-103': 'CONNECTION_ABORTED',
-  '-104': 'CONNECTION_FAILED',
-  '-105': 'NAME_NOT_RESOLVED',
-  '-106': 'INTERNET_DISCONNECTED',
-};
+  }  // class ChromeSockets
+
+  // Error codes can be found at:
+  // https://code.google.com/p/chromium/codesearch#chromium/src/net/base/net_error_list.h
+  var ERROR_MAP = {
+    '-1': 'IO_PENDING',
+    '-2': 'FAILED',
+    '-3': 'ABORTED',
+    '-4': 'INVALID_ARGUMENT',
+    '-5': 'INVALID_HANDLE',
+    '-7': 'TIMED_OUT',
+    '-13': 'OUT_OF_MEMORY',
+    '-15': 'SOCKET_NOT_CONNECTED',
+    '-21': 'NETWORK_CHANGED',
+    '-23': 'SOCKET_IS_CONNECTED',
+    '-100': 'CONNECTION_CLOSED',
+    '-101': 'CONNECTION_RESET',
+    '-102': 'CONNECTION_REFUSED',
+    '-103': 'CONNECTION_ABORTED',
+    '-104': 'CONNECTION_FAILED',
+    '-105': 'NAME_NOT_RESOLVED',
+    '-106': 'INTERNET_DISCONNECTED',
+  };
+
+}  // module Sockets

--- a/src/chrome-fsocket.ts
+++ b/src/chrome-fsocket.ts
@@ -20,7 +20,7 @@ module Sockets {
    *   (http://developer.chrome.com/apps/socket.html)
    * for the freedom interface.
    */
-  export class Chrome implements ISockets {
+  export class Chrome implements Sockets.API {
 
     constructor (public channel) {}
 

--- a/src/interfaces/socket.d.ts
+++ b/src/interfaces/socket.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Interface for sockets.
+ */
+
+declare module Sockets {
+
+  export interface CreateInfo {
+    socketId:number;
+  }
+
+  export interface ReadInfo {
+    socketId:number;
+    data:ArrayBuffer;
+  }
+
+  // Platform independent, from Freedom.
+  export interface API {
+    create:any;
+    listen:any;
+    connect:any;
+    write:any;
+    getInfo:any;
+    disconnect:any;
+    destroy:any;
+    on?:any;
+  }
+
+}  // module Sockets

--- a/src/rtc-to-net/netclient.ts
+++ b/src/rtc-to-net/netclient.ts
@@ -1,13 +1,13 @@
 /*
   Wrapper which terminates relayed web requests through a native socket object.
 */
-/// <reference path='../chrome-fsocket.ts' />
+/// <reference path='../interfaces/socket.d.ts' />
 
 declare var freedom:any;
 
 module Net {
 
-  var fSockets:ISockets = freedom['core.socket']();
+  var fSockets:Sockets.API = freedom['core.socket']();
 
   enum State {
     CREATING_SOCKET,  // 'CREATING_SOCKET',


### PR DESCRIPTION
- No longer have TcpEchoServer messages going to the wrong socket. (fix #5)
- Change to using typed promises for the read loop in Sockets.Chrome

Tested: Manual end-to-end.
