### PR TITLE
remove unnecessary include

### DIFF
--- a/chrome/socks_rtc.json
+++ b/chrome/socks_rtc.json
@@ -3,7 +3,6 @@
   "description": "socks-rtc Freedom manifest",
   "app": {
     "script": [
-      "js/socks-to-rtc/tcp.js",
       "smell_socks.js"
     ]
   },


### PR DESCRIPTION
Oops -- please ignore my earlier pull request (https://github.com/uProxy/socks-rtc/pull/26).

This removes what I think is an unnecessary include because the socks-to-rtc Freedom module also pulls in tcp.js. Tested locally with curl running against the Chrome app.
