### PR TITLE
travis config with a jasmine test for socks.ts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: node_js
 node_js:
  - "0.11"
 before_install:
- - npm install -g grunt grunt-cli
+ - npm install -g grunt-cli
  - grunt setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
  - "0.11"
+ - "0.10"
+ - "0.8"
+ - "0.6"
 before_script:
  - npm install -g grunt-cli
  - grunt setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: node_js
 node_js:
  - "0.11"
 before_install:
- - npm install -g grunt-cli
+ - npm install -g grunt grunt-cli
  - grunt setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
  - "0.11"
-before_install:
+before_script:
  - npm install -g grunt-cli
  - grunt setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+ - "0.11"
+before_install:
+ - npm install -g grunt-cli
+ - grunt setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
  - "0.11"
  - "0.10"
  - "0.8"
- - "0.6"
 before_script:
  - npm install -g grunt-cli
  - grunt setup

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -81,11 +81,20 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-shell'
   grunt.loadNpmTasks 'grunt-ts'
 
-  grunt.registerTask 'default', [
+  grunt.registerTask 'build', [
     'ts:socks2rtc',
     'ts:rtc2net',
     'ts:chromeFSocket',
     'copy:app'
+  ]
+
+  grunt.registerTask 'test', [
+    'build',
+    'jasmine'
+  ]
+
+  grunt.registerTask 'default', [
+    'build'
   ]
 
   # Freedom doesn't build correctly by itself - run this task when in a clean

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,7 +29,7 @@ module.exports = (grunt) ->
       socks2rtc: {
         src: ['src/interfaces/*.d.ts',
               'src/socks-to-rtc/*.ts'],
-        outDir: 'tmp/',
+        outDir: 'tmp/socks-to-rtc/',
         options: {
           sourceMap: false
         }
@@ -37,7 +37,7 @@ module.exports = (grunt) ->
       rtc2net: {
         src: ['src/interfaces/*.d.ts',
               'src/rtc-to-net/*.ts'],
-        outDir: 'tmp/',
+        outDir: 'tmp/rtc-to-net/',
         options: {
           sourceMap: false
         }
@@ -60,6 +60,15 @@ module.exports = (grunt) ->
       }
     }
 
+    jasmine: {
+      # Eventually, this should be a wildcard once we've figured out how to run
+      # more dependencies under Jasmine.
+      src: 'chrome/js/socks-to-rtc/socks.js',
+      options : {
+        specs : 'spec/**/*_spec.js'
+      }
+    }
+
     clean: [
       'tmp/**',
       'chrome/js/**'
@@ -68,6 +77,7 @@ module.exports = (grunt) ->
 
   grunt.loadNpmTasks 'grunt-contrib-copy'
   grunt.loadNpmTasks 'grunt-contrib-clean'
+  grunt.loadNpmTasks 'grunt-contrib-jasmine'
   grunt.loadNpmTasks 'grunt-shell'
   grunt.loadNpmTasks 'grunt-ts'
 

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ For example:
 
 `curl -x socks5h://localhost:9999 www.google.com`
 
-There will more tests soon!
+There will be more tests soon!

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ For example:
 
 `curl -x socks5h://localhost:9999 www.google.com`
 
-There will be actual tests soon!
+There will more tests soon!

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-contrib-jasmine": "~0.5.2",
+    "grunt-contrib-jasmine": "~0.6.1",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-coffee": "~0.7.0",

--- a/spec/socks-to-rtc/socks_spec.js
+++ b/spec/socks-to-rtc/socks_spec.js
@@ -1,0 +1,43 @@
+describe("socks", function() {
+  // A valid SOCKS5/IPV4 request.
+  var ipv4Request;
+
+  beforeEach(function() {
+    ipv4Request = new Uint8Array([
+      Socks.VERSION5,
+      Socks.REQUEST_CMD.CONNECT,
+      0, // reserved
+      Socks.ATYP.IP_V4,
+      192, 168, 1, 1, // IP: 192.168.1.1
+      1200 >> 8, 1200 & 0xFF]); // port: 1200
+  });
+
+  it("reject wrongly sized requests", function() {
+    var result = Socks.interpretSocksRequest(
+      new Uint8Array(new ArrayBuffer(8)));
+    expect(result.failure).toEqual(Socks.RESPONSE.FAILURE);
+  });
+
+  it("parse ipv4 request", function() {
+    var result = Socks.interpretSocksRequest(ipv4Request);
+    expect(result.failure).toBeUndefined();
+    expect(result.version).toEqual(Socks.VERSION5);
+    expect(result.cmd).toEqual(Socks.REQUEST_CMD.CONNECT);
+    expect(result.atyp).toEqual(Socks.ATYP.IP_V4);
+    expect(result.addressString).toEqual('192.168.1.1');
+    expect(result.port).toEqual(1200);
+  });
+
+  it("wrong socks version", function() {
+    ipv4Request[0] = 4;
+    var result = Socks.interpretSocksRequest(ipv4Request);
+    expect(result.failure).toEqual(Socks.RESPONSE.FAILURE);
+  });
+
+  it("unsupported command", function() {
+    ipv4Request[1] = Socks.REQUEST_CMD.UDP_ASSOCIATE;
+    var result = Socks.interpretSocksRequest(ipv4Request);
+    expect(result.failure).toEqual(Socks.RESPONSE.UNSUPPORTED_COMMAND);
+  });
+});
+

--- a/spec/socks-to-rtc/socks_spec.js
+++ b/spec/socks-to-rtc/socks_spec.js
@@ -12,13 +12,13 @@ describe("socks", function() {
       1200 >> 8, 1200 & 0xFF]); // port: 1200
   });
 
-  it("reject wrongly sized requests", function() {
+  it('reject wrongly sized requests', function() {
     var result = Socks.interpretSocksRequest(
       new Uint8Array(new ArrayBuffer(8)));
     expect(result.failure).toEqual(Socks.RESPONSE.FAILURE);
   });
 
-  it("parse ipv4 request", function() {
+  it('parse ipv4 request', function() {
     var result = Socks.interpretSocksRequest(ipv4Request);
     expect(result.failure).toBeUndefined();
     expect(result.version).toEqual(Socks.VERSION5);
@@ -28,13 +28,13 @@ describe("socks", function() {
     expect(result.port).toEqual(1200);
   });
 
-  it("wrong socks version", function() {
+  it('wrong socks version', function() {
     ipv4Request[0] = 4;
     var result = Socks.interpretSocksRequest(ipv4Request);
     expect(result.failure).toEqual(Socks.RESPONSE.FAILURE);
   });
 
-  it("unsupported command", function() {
+  it('unsupported command', function() {
     ipv4Request[1] = Socks.REQUEST_CMD.UDP_ASSOCIATE;
     var result = Socks.interpretSocksRequest(ipv4Request);
     expect(result.failure).toEqual(Socks.RESPONSE.UNSUPPORTED_COMMAND);

--- a/src/socks-to-rtc/socks.ts
+++ b/src/socks-to-rtc/socks.ts
@@ -74,12 +74,14 @@ module Socks {
           o  DST.PORT desired destination port in network octet
              order
   // TODO: typescript the SOCKS Request interface
+  // TODO: document all fields populated by interpretSocksRequest
   interface Request {
     version:number;
     cmd:REQUEST_CMD;
-    rsv:number;
     atyp:ATYP;
     failure:RESPONSE;
+    addressString:string;
+    port:number;
   }
   */
 
@@ -88,10 +90,14 @@ module Socks {
    * Parse byte array into a SOCKS request object.
    */
   export function interpretSocksRequest(byteArray:Uint8Array) {
-    if(byteArray.length < 9) {
-      return null;
-    }
     var result:any = {};
+
+    // Fail if the request is too short to be valid.
+    if(byteArray.length < 9) {
+      result.failure = RESPONSE.FAILURE;
+      return result;
+    }
+
     // Fail if client is not talking Socks version 5.
     result.version = byteArray[0];
     if (result.version !== VERSION5) {
@@ -104,7 +110,7 @@ module Socks {
     // Fail unless we got a CONNECT (to TCP) command.
     if (result.cmd != REQUEST_CMD.CONNECT) {
       result.failure = RESPONSE.UNSUPPORTED_COMMAND;
-      return;
+      return result;
     }
 
     // Parse address and port and set the callback to be handled by the


### PR DESCRIPTION
This adds a config for Travis and a near-trivial test for socks.ts, which I picked because it has a few functions without any dependencies (no need for the DOM or to load Freedom, etc.). It's just a start to get us setup with a continuous build!

Caveats:
- no Selenium tests yet (that's a whole different kettle of balls of wax and I don't want it to block us adding more unit tests)
- this doesn't test any Freedom-dependant code...hopefully that won't be hard
- we'll probably want to write tests in TypeScript at some point...I don't think anything here precludes that

There are several commits in this branch so I'll be sure to rebase rather than merging to keep the history clean :-)
