### PR TITLE
And an end-to-end Selenium-based test

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1,5 +1,7 @@
 module.exports = (grunt) ->
 
+  path = require('path');
+
   grunt.initConfig {
     pkg: grunt.file.readJSON('package.json'),
 
@@ -69,6 +71,17 @@ module.exports = (grunt) ->
       }
     }
 
+    env: {
+      jasmine_node: {
+        # Will be available to tests as process.env['CHROME_EXTENSION_PATH'].
+        CHROME_EXTENSION_PATH: path.resolve('chrome')
+      }
+    }
+
+    jasmine_node: {
+      projectRoot: 'spec/selenium'
+    }
+
     clean: [
       'tmp/**',
       'chrome/js/**'
@@ -80,6 +93,8 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-jasmine'
   grunt.loadNpmTasks 'grunt-shell'
   grunt.loadNpmTasks 'grunt-ts'
+  grunt.loadNpmTasks 'grunt-jasmine-node'
+  grunt.loadNpmTasks 'grunt-env'
 
   grunt.registerTask 'build', [
     'ts:socks2rtc',
@@ -88,9 +103,25 @@ module.exports = (grunt) ->
     'copy:app'
   ]
 
+  # This is the target run by Travis. Targets in here should run locally
+  # and on Travis.
   grunt.registerTask 'test', [
     'build',
     'jasmine'
+  ]
+
+  # Right now, the Selenium tests only run locally and require that
+  # selenium-server be running on localhost:4444. You can do that by:
+  #  - downloading the "Standalone Server" from
+  #    http://docs.seleniumhq.org/download/
+  #  - running java -jar selenium-server-standalone-*.jar
+  # TODO(yangoon): Figure out how to run our Selenium tests on Sauce Labs,
+  #                add them to the test target, and remove this target.
+  # TODO(yangoon): Have this task spin up a selenium server.
+  grunt.registerTask 'endtoend', [
+    'build',
+    'env',
+    'jasmine_node'
   ]
 
   grunt.registerTask 'default', [

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -78,6 +78,8 @@ module.exports = (grunt) ->
       }
     }
 
+    # TODO(yangoon): Figure out how to use Node modules with
+    #                grunt-jasmine-contrib and move these to the jasmine target.
     jasmine_node: {
       projectRoot: 'spec/selenium'
     }
@@ -104,20 +106,15 @@ module.exports = (grunt) ->
   ]
 
   # This is the target run by Travis. Targets in here should run locally
-  # and on Travis.
+  # and on Travis/Sauce Labs.
   grunt.registerTask 'test', [
     'build',
     'jasmine'
   ]
 
-  # Right now, the Selenium tests only run locally and require that
-  # selenium-server be running on localhost:4444. You can do that by:
-  #  - downloading the "Standalone Server" from
-  #    http://docs.seleniumhq.org/download/
-  #  - running java -jar selenium-server-standalone-*.jar
-  # TODO(yangoon): Figure out how to run our Selenium tests on Sauce Labs,
-  #                add them to the test target, and remove this target.
-  # TODO(yangoon): Have this task spin up a selenium server.
+  # TODO(yangoon): Figure out how to run our Selenium tests on Sauce Labs and
+  #                move this to the test target.
+  # TODO(yangoon): Figure out how to spin up Selenium server automatically.
   grunt.registerTask 'endtoend', [
     'build',
     'env',

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ running locally (on localhost:4444). To do this:
 
  - downloading the "Standalone Server" from http://docs.seleniumhq.org/download/
  - running the server, e.g. `java -jar selenium-server-standalone-*.jar`
- - `grunt selenium`
+ - `grunt endtoend`
 
 #### Manual
 At the moment, the way to test that this works is to just curl a webpage

--- a/README.md
+++ b/README.md
@@ -28,6 +28,17 @@ Assuming you've done initial setup:
 - Reload extension.
 
 ### End-to-End Test
+
+#### Automated
+We have a Selenium test which starts Chrome with the proxy loaded and its proxy
+settings pointing at the proxy. You will need to have the Selenium server
+running locally (on localhost:4444). To do this:
+
+ - downloading the "Standalone Server" from http://docs.seleniumhq.org/download/
+ - running the server, e.g. `java -jar selenium-server-standalone-*.jar`
+ - `grunt selenium`
+
+#### Manual
 At the moment, the way to test that this works is to just curl a webpage
 through the proxy which socks-rtc sets up if you've built it successfully.
 For example:

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ We have a Selenium test which starts Chrome with the proxy loaded and its proxy
 settings pointing at the proxy. You will need to have the Selenium server
 running locally (on localhost:4444). To do this:
 
- - downloading the "Standalone Server" from http://docs.seleniumhq.org/download/
- - running the server, e.g. `java -jar selenium-server-standalone-*.jar`
- - `grunt endtoend`
+ - download the "Standalone Server" from http://docs.seleniumhq.org/download/
+ - run the Selenium server, e.g. `java -jar selenium-server-standalone-*.jar`
+ - run the test with `grunt endtoend`
 
 #### Manual
 At the moment, the way to test that this works is to just curl a webpage

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-shell": "~0.3.1",
     "grunt-ts": "~1.6.4",
-    "freedom": "~0.2.1"
+    "freedom": "~0.2.1",
+    "grunt-jasmine-node": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
+    "webdriverjs": "~1.3.1",
+    "grunt-env": "~0.4.1"
   },
   "scripts": {
     "test": "grunt --verbose"

--- a/spec/selenium/endtoend_spec.js
+++ b/spec/selenium/endtoend_spec.js
@@ -1,0 +1,48 @@
+var webdriverjs = require('webdriverjs');
+
+describe('end-to-end smoke test', function() {
+  var client = {};
+  jasmine.getEnv().defaultTimeoutInterval = 30000;
+
+  beforeEach(function() {
+    client = webdriverjs.remote({
+      desiredCapabilities: {
+        browserName: 'chrome',
+        chromeOptions: {
+          args: [
+            // ChromeDriver doesn't know about SOCKS proxies.
+            // (see its webdriver_capabilities_parser.cc)
+            '--proxy-server=socks5://localhost:9999',
+            '--load-extension=' + process.env['CHROME_EXTENSION_PATH']
+          ]
+        }
+      }
+    });
+    client.init();
+  });
+
+  it('example.com', function(done) {
+    client
+      .url('http://example.com/')
+      .getTitle(function(err, title) {
+        expect(err).toBe(null);
+        expect(title).toBe('Example Domain');
+      })
+      .call(done);
+   });
+
+  it('guardian.co.uk', function(done) {
+    client
+      .url('http://www.guardian.co.uk/')
+      .getTitle(function(err, title) {
+        expect(err).toBe(null);
+        expect(title).toContain('The Guardian');
+      })
+      .call(done);
+   });
+
+   afterEach(function(done) {
+     client.end(done);
+   });
+});
+


### PR DESCRIPTION
This adds a test which:
- starts Chrome, with the app installed and the browser's proxy settings pointed to localhost:9999
- fetches a few pages and verifies they load

I added m.guardian.co.uk because right now it _doesn't_ load via the proxy. No idea why!

Caveats:
- requires the selenium server to be running locally (there are a few grunt plugins which purport to do this but I couldn't get them to work)
- no Travis/Sauce Labs connection yet...uploading the extension will take a little more work (it seems to be possible but let's take this in stages, there's other things to do too!)
