### PR TITLE
disconnections - end-to-end works both ways

### DIFF
--- a/src/chrome-fsocket.ts
+++ b/src/chrome-fsocket.ts
@@ -70,6 +70,7 @@ module Sockets {
 
     public disconnect = (socketId:number, continuation) => {
       chrome.socket.disconnect(socketId);
+      dbg(socketId + ' locally disconnected.');
       continuation();
     }
 

--- a/src/rtc-to-net/netclient.ts
+++ b/src/rtc-to-net/netclient.ts
@@ -33,8 +33,8 @@ module Net {
     private queue:any[] = [];
     private state:State = State.CLOSED;
 
-    private closePromise:Promise<void>;
-    private fulfillClose:()=>void;
+    private disconnectPromise:Promise<void>;
+    private fulfillDisconnect:()=>void;
 
     /**
      * Constructing a Net.Client immediately begins a socket connection.
@@ -44,8 +44,8 @@ module Net {
         private onResponse:(buffer:ArrayBuffer)=>any,
         private destination:Destination) {
       this.state = State.CREATING_SOCKET;
-      this.closePromise = new Promise<void>((F, R) => {
-        this.fulfillClose = F;  // To be fired on close.
+      this.disconnectPromise = new Promise<void>((F, R) => {
+        this.fulfillDisconnect = F;  // To be fired on close.
       });
       this.createSocket_()  // Initialize client TCP socket.
           .then(this.connect_)
@@ -69,7 +69,13 @@ module Net {
       }
     }
 
-    public close = () => { this.onClose_(); };
+    /**
+     * Close the Net.Client locally.
+     */
+    public close = () => {
+      dbg('closing ' + this.socketId + ' of ' + JSON.stringify(this.destination));
+      this.closeSocket_();
+    };
 
     /**
      * Wrapper which returns a promise for a created socket.
@@ -107,13 +113,7 @@ module Net {
       }
       this.state = State.CONNECTED;
       fSockets.on('onData', this.readData_);
-      fSockets.on('onDisconnect', (socketInfo:Sockets.DisconnectInfo) => {
-        if (socketInfo.socketId != this.socketId) {
-          return;  // duplicity of socket events.
-        }
-        dbg('closed ' + this.socketId + ' - ' + socketInfo.error);
-        this.close();
-      });
+      fSockets.on('onDisconnect', this.onDisconnect_);
       if (0 < this.queue.length) {
         this.send(this.queue.shift());
       }
@@ -140,7 +140,7 @@ module Net {
       // TODO: change sockets to having an explicit failure rather than giving -1
       // in the bytesWritten field.
       if (0 >= writeInfo.bytesWritten) {
-        this.onClose_();
+        this.close();
         return;
       }
       // If there is more to write, send it again.
@@ -151,26 +151,34 @@ module Net {
     }
 
     /**
-     * Close socket and fire external close handlers.
+     * Fired by closes remotely.
      */
-    private onClose_ = () => {
+    private onDisconnect_ = (socketInfo:Sockets.DisconnectInfo) => {
+      if (socketInfo.socketId != this.socketId) {
+        return;  // duplicity of socket events.
+      }
+      dbg(this.socketId + ' - ' + socketInfo.error);
+      this.closeSocket_();
+      this.fulfillDisconnect();
+    }
+
+    private closeSocket_ = () => {
       if (State.CLOSED == this.state) {
         return;
       }
       this.state = State.CLOSED;
-      dbg('closing ' + this.socketId + ' of ' + JSON.stringify(this.destination));
       if (this.socketId) {
         fSockets.disconnect(this.socketId);
         fSockets.destroy(this.socketId);
       }
       this.socketId = null;
-      this.fulfillClose();
     }
 
     /**
-     * Promise the future closing of this client.
+     * Promise the future closing of this client. This only gets fired by remote
+     * disconnections, not from active close() calls locally.
      */
-    public onceClosed = () => { return this.closePromise; }
+    public onceDisconnected = () => { return this.disconnectPromise; }
 
   }  // Net.Client
 

--- a/src/rtc-to-net/netclient.ts
+++ b/src/rtc-to-net/netclient.ts
@@ -73,8 +73,16 @@ module Net {
      * Close the Net.Client locally.
      */
     public close = () => {
+      if (State.CLOSED == this.state) {
+        return;
+      }
       dbg('closing ' + this.socketId + ' of ' + JSON.stringify(this.destination));
-      this.closeSocket_();
+      this.state = State.CLOSED;
+      if (this.socketId) {
+        fSockets.disconnect(this.socketId);
+        fSockets.destroy(this.socketId);
+      }
+      this.socketId = null;
     };
 
     /**
@@ -151,27 +159,15 @@ module Net {
     }
 
     /**
-     * Fired by closes remotely.
+     * Fired only when underlying socket closes remotely.
      */
     private onDisconnect_ = (socketInfo:Sockets.DisconnectInfo) => {
       if (socketInfo.socketId != this.socketId) {
         return;  // duplicity of socket events.
       }
       dbg(this.socketId + ' - ' + socketInfo.error);
-      this.closeSocket_();
+      this.close();
       this.fulfillDisconnect();
-    }
-
-    private closeSocket_ = () => {
-      if (State.CLOSED == this.state) {
-        return;
-      }
-      this.state = State.CLOSED;
-      if (this.socketId) {
-        fSockets.disconnect(this.socketId);
-        fSockets.destroy(this.socketId);
-      }
-      this.socketId = null;
     }
 
     /**

--- a/src/rtc-to-net/netclient.ts
+++ b/src/rtc-to-net/netclient.ts
@@ -69,7 +69,7 @@ module Net {
       }
     }
 
-    public close = () => { this.onClose_ };
+    public close = () => { this.onClose_(); };
 
     /**
      * Wrapper which returns a promise for a created socket.

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -145,11 +145,11 @@ module RtcToNet {
      */
     private closeNetClient_ = (channelData:Channel.CloseData) => {
       var channelId = channelData.channelId;
-      dbg('closing Net.Client for closed datachannel ' + channelId);
       if (!(channelId in this.netClients)) {
         dbgWarn('no Net.Client to close for ' + channelId)
         return;
       }
+      dbg('closing Net.Client for closed datachannel ' + channelId);
       this.netClients[channelId].close();
       delete this.netClients[channelId];
     }

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -76,7 +76,14 @@ module RtcToNet {
         return;
       }
       if (message.text) {
+        if ('SOCKS-DISCONNECTED' == message.text) {
+          // TODO: this is a temporary 'disconnect' signal.
+          dbg(label + ' <--- received SOCKS-DISCONNECTED');
+          this.closeDataChannel_(label);
+          return;
+        }
         dbg('encountered new datachannel ' + label);
+        var dest:Net.Destination = JSON.parse(message.text);
         // Text from the peer indicates request for a new destination.
         // Assumes |message.text| is a Net.Destination.
         dbg(label + ' <--- new request: ' + message.text);
@@ -85,7 +92,7 @@ module RtcToNet {
           dbgWarn('Net.Client already exists for data channel: ' + label);
           return;
         }
-        this.prepareNetChannelLifecycle_(label, JSON.parse(message.text));
+        this.prepareNetChannelLifecycle_(label, dest);
 
       } else if (message.buffer) {
         dbg(label + ' <--- received ' + JSON.stringify(message));
@@ -136,8 +143,9 @@ module RtcToNet {
     /**
      * Close an individual Net.Client when its data channel closes.
      */
-    private closeNetClient_ = (channelId:string) => {
-      dbg('closing datachannel ' + channelId);
+    private closeNetClient_ = (channelData:Channel.CloseData) => {
+      var channelId = channelData.channelId;
+      dbg('closing Net.Client for closed datachannel ' + channelId);
       if (!(channelId in this.netClients)) {
         dbgWarn('no Net.Client to close for ' + channelId)
         return;

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -143,6 +143,7 @@ module RtcToNet {
           channelLabel: label,
           text: 'NET-DISCONNECTED'
         });
+        dbg('send NET-DISCONNECTED ---> ' + label);
         this.closeDataChannel_(label);
       });
     }

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -204,8 +204,10 @@ module SocksToRTC {
       var label = channel.channelId;
       dbg('datachannel ' + label + ' has closed. ending SOCKS session for channel.');
       if (!(label in this.socksSessions)) {
-        throw Error('Unexpected missing SOCKs session to close for ' +
-                    label);
+        // This can happen if both peers send disconnection signals at the same
+        // time.
+        dbgWarn('No SOCKs session to close for ' + label);
+        return;
       }
       // End SOCKS session.
       this.socksServer.endSession(this.socksSessions[label]);

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -111,7 +111,7 @@ module SocksToRTC {
           .then(() => {
             var newRequest = {
                 channelLabel: channelLabel,
-                'text': JSON.stringify({ host: address, port: port })
+                text: JSON.stringify({ host: address, port: port })
             };
             this.sctpPc.send(newRequest);
             dbg('new request -----> ' + channelLabel +
@@ -145,7 +145,16 @@ module SocksToRTC {
       session.onceDisconnected()
           // TODO: When we start re-using datachannels, stop closing the
           // datachannels but remap them instead.
-          .then(() => { this.sctpPc.closeDataChannel(label); });
+          .then(() => {
+            // TODO: For now, signal the remote that this datachannel is
+            // disconnected.
+            this.sctpPc.send({
+              channelLabel: label,
+              text: 'SOCKS-DISCONNECTED'
+            });
+            dbg('send SOCKS-DISCONNECTED ---> ' + label);
+            this.sctpPc.closeDataChannel(label);
+          });
 
     }
 

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -178,6 +178,12 @@ module SocksToRTC {
         dbg(msg.channelLabel + ' <--- received ' + msg.buffer.byteLength);
         session.sendData(msg.buffer);
       } else if (msg.text) {
+        if ('NET-DISCONNECTED' == msg.text) {
+          // Receiving a disconnect on the remote peer should close SOCKS.
+          dbg(label + ' <--- received NET-DISCONNECTED');
+          this.closeConnection_({channelId:label});
+          return;
+        }
         // TODO: we should use text as a signalling/control channel, e.g. to
         // give back the actual address that was connected to as per socks
         // official spec.

--- a/src/socks-to-rtc/socks.ts
+++ b/src/socks-to-rtc/socks.ts
@@ -215,7 +215,14 @@ module Socks {
 
     disconnect() { this.tcpServer.disconnect(); }
 
+    /**
+     * Closes the underlying TCP connection for SOCKS |session|.
+     * Assumes |session| is valid.
+     */
     public endSession(session:Session) {
+      if (!session) {
+        throw Error('SOCKS session object undefined!');
+      }
       this.tcpServer.endConnection(session.tcpConnection.socketId);
     }
 

--- a/src/socks-to-rtc/tcp.ts
+++ b/src/socks-to-rtc/tcp.ts
@@ -73,6 +73,7 @@ module TCP {
     public listen():Promise<any> {
       return this.createSocket_()
           .then(this.startListening_)
+          // Success. Attach connect, disconnect, and data handlers.
           .then(this.attachSocketHandlers_)
           .catch(this.handleError_);
     }
@@ -99,19 +100,19 @@ module TCP {
       return new Promise((F, R) => {
         fSockets.listen(this.serverSocketId, this.addr, this.port)
             .done(F).fail(R);
+      }).then((resultCode:number) => {  // Ensure the listen was successful.
+        if (0 !== resultCode) {
+          return Util.reject('listen failed on ' + this.endpoint_ +
+                               ' \n Result Code: ' + resultCode);
+        }
       });
     }
 
     /**
-     * Promise attachment of connection and data handlers if socket listening
-     * was successful.
+     * Promise attachment of connection and data handlers.
+     * Assumes server socket is successfully listening.
      */
-    private attachSocketHandlers_ = (resultCode:number) => {
-      if (0 !== resultCode) {
-        return Util.reject('listen failed on ' + this.endpoint_ +
-                             ' \n Result Code: ' + resultCode);
-      }
-      // Success. Attach connect, disconnect, and data handlers.
+    private attachSocketHandlers_ = () => {
       fSockets.on('onConnection', this.accept_);
       fSockets.on('onData', this.readConnectionData_);
       fSockets.on('onDisconnect', this.disconnectSocket_);
@@ -184,6 +185,7 @@ module TCP {
 
     private removeFromServer_ = (conn:TCP.Connection) => {
       delete this.conns[conn.socketId];
+      return conn;
     }
 
     /**
@@ -209,9 +211,9 @@ module TCP {
         return;
       }
       dbg('disconnect ' + socketInfo.socketId + ' - ' + msg);
-      this.conns[socketId]
-          .then((conn:Connection) => { conn.fireRemoteDisconnect() });
-      this.endConnection(socketId);
+      return this.conns[socketId]
+          .then(Connection.disconnect)
+          .then(this.removeFromServer_);
     }
 
     /**
@@ -223,7 +225,7 @@ module TCP {
                  // tcp connections must be closed, so this is expected.
       }
       return this.conns[socketId]
-          .then(Connection.disconnect)
+          .then(Connection.close)
           .then(this.removeFromServer_);
     }
 
@@ -377,9 +379,9 @@ module TCP {
     }
 
     /**
-     * Disconnect underlying socket.
+     * Close underlying socket locally.
      */
-    public disconnect() {
+    public close() {
       if (!this.isConnected) { return; }
       this.isConnected = false;
       // Close the socket.
@@ -387,10 +389,16 @@ module TCP {
       fSockets.destroy(this.socketId);
       return this;
     }
-    public static disconnect(conn:Connection) { return conn.disconnect(); }
+    /**
+     * Fired when underlying socket disconnected remotely.
+     */
+    public disconnect = () => {
+      this.fulfillDisconnect(0);
+      return this.close();
+    }
 
-    // Fire the disconnect Promise.
-    public fireRemoteDisconnect = () => { this.fulfillDisconnect(0); }
+    public static close(conn:Connection) { return conn.close(); }
+    public static disconnect(conn:Connection) { return conn.disconnect(); }
 
     /**
      * Promise for the (remote) disconnection of this socket.


### PR DESCRIPTION
Use `msg.text` as payload to signal disconnections across the datachannel.
- `SOCKS-DISCONNECT` occurs when the SocksToRtc's TCP request socket disconnects, ending the SOCKS session. This signal crosses the data channel to close the RtcToNet's client socket.
- `NET-DISCONNECT` occurs when the RtcToNet socket connection to destination closes first. This signal crosses the data channel to close the SocksToRtc side SOCKS session / TCP connection.
- Fixed _local_ vs. _remote_ disconnection semantics. The `onceDisconnected`-like promises only fulfill for remote disconnection events. This prevents cyclical/redundant calls to disconnection handlers & checks, since the closing code paths can occur in either direction.

Eventually, when the freedom datachannels properly send closes across to the remote peer, this may be removed.

Tested: End-to-end
