### PR TITLE
Switch to freedom-runtime-chrome dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ node_js:
  - "0.8"
 before_script:
  - npm install -g grunt-cli
- - grunt setup

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -14,7 +14,7 @@ module.exports = (grunt) ->
             expand: true,
             cwd: 'build'
           }, {
-            src: 'node_modules/freedom/freedom.js'
+            src: 'node_modules/freedom-runtime-chrome/freedom.js'
             dest: 'chrome/js/freedom.js'
           }, {
             src: ['**/*.json']
@@ -60,17 +60,6 @@ module.exports = (grunt) ->
       }
     }
 
-    shell: {
-      freedom_setup: {
-        command: 'npm install',
-        options: {stdout: true, stderr: true, failOnError: true, execOptions: {cwd: 'node_modules/freedom'}}
-      }
-      freedom_build: {
-        command: 'grunt',
-        options: {stdout: true, stderr: true, failOnError: true, execOptions: {cwd: 'node_modules/freedom'}}
-      }
-    }
-
     jasmine: {
       # Eventually, this should be a wildcard once we've figured out how to run
       # more dependencies under Jasmine.
@@ -102,7 +91,6 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-copy'
   grunt.loadNpmTasks 'grunt-contrib-clean'
   grunt.loadNpmTasks 'grunt-contrib-jasmine'
-  grunt.loadNpmTasks 'grunt-shell'
   grunt.loadNpmTasks 'grunt-ts'
   grunt.loadNpmTasks 'grunt-jasmine-node'
   grunt.loadNpmTasks 'grunt-env'
@@ -137,11 +125,4 @@ module.exports = (grunt) ->
   grunt.registerTask 'chrome', [
     'build',
     'copy:app'
-  ]
-
-  # Freedom doesn't build correctly by itself - run this task when in a clean
-  # directory.
-  grunt.registerTask 'setup', [
-    'shell:freedom_setup',
-    'shell:freedom_build'
   ]

--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ webserver, and serves the response back to _socks-to-rtc_.
 #### Requirements
 
 - node + npm
-- grunt `npm install -g grunt-cli`
+- `npm install -g grunt-cli`
+- `grunt`
 
 #### Initial Setup
 
 - Run `npm install` from the base directory to obtain all prerequisites.
-- Run `grunt setup` to prepare the freedom installation. (This step should
-  disappear with future versions of freedom)
 
 #### Build
 - Running `grunt` compiles all the typescript into javascript which goes into

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "test": "grunt --verbose"
   },
   "dependencies": {
-    "freedom-runtime-chrome": "0.0.2"
+    "freedom-runtime-chrome": "0.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,14 +13,15 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-shell": "~0.3.1",
     "grunt-ts": "~1.6.4",
-    "freedom": "~0.2.2",
     "grunt-jasmine-node": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
     "webdriverjs": "~1.3.1",
     "grunt-env": "~0.4.1"
   },
   "scripts": {
     "test": "grunt --verbose"
+  },
+  "dependencies": {
+    "freedom-runtime-chrome": "0.0.2"
   }
 }


### PR DESCRIPTION
Hopefully simplifies things.
Also will allow removal of chrome/lib/boilerplate.js and src/chrome-fsocket.ts
