### PR TITLE
Yangoon core.udpsocket

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -117,7 +117,7 @@ module.exports = (grunt) ->
   # This is the target run by Travis. Targets in here should run locally
   # and on Travis/Sauce Labs.
   grunt.registerTask 'test', [
-    'build',
+    'chrome',
     'jasmine'
   ]
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -74,7 +74,10 @@ module.exports = (grunt) ->
     jasmine: {
       # Eventually, this should be a wildcard once we've figured out how to run
       # more dependencies under Jasmine.
-      src: 'chrome/js/socks-to-rtc/socks.js',
+      src: [
+        'chrome/js/socks-to-rtc/socks.js',
+        'chrome/js/chrome-udpsocket.js'
+      ],
       options : {
         specs : 'spec/**/*_spec.js'
       }

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -53,8 +53,8 @@ module.exports = (grunt) ->
           sourceMap: false
         }
       }
-      chromeFSocket: {
-        src: ['src/chrome-fsocket.ts'],
+      chromeSockets: {
+        src: ['src/chrome-*socket.ts'],
         outDir: 'build/',
         options: { sourceMap: false; }
       }
@@ -110,7 +110,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'build', [
     'ts:socks2rtc',
     'ts:rtc2net',
-    'ts:chromeFSocket',
+    'ts:chromeSockets',
     'copy:json'
   ]
 

--- a/chrome/lib/boilerplate.js
+++ b/chrome/lib/boilerplate.js
@@ -4,4 +4,5 @@
 window.freedomcfg = function(register) {
   // Necessary so we can actually use chrome sockets.
   register('core.socket', Sockets.Chrome);  // src/chrome-fsocket.ts
+  register('core.udpsocket', UdpSocket.Chrome);  // src/chrome-udpsocket.ts
 }

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -12,7 +12,7 @@
     }
   },
   "permissions": [
-    { "socket": ["tcp-connect", "tcp-listen", "udp-send-to"] },
+    { "socket": ["tcp-connect", "tcp-listen", "udp-bind", "udp-send-to"] },
     "https://*.appspot.com/"
   ]
 }

--- a/chrome/socks_rtc.html
+++ b/chrome/socks_rtc.html
@@ -3,6 +3,7 @@
   <head>
     <title>socks-rtc</title>
     <script type='text/javascript' src='js/chrome-fsocket.js'></script>
+    <script type='text/javascript' src='js/chrome-udpsocket.js'></script>
     <script type='text/javascript' src='lib/boilerplate.js'></script>
     <script src='js/freedom.js' data-manifest='socks_rtc.json'>
       {

--- a/chrome/socks_rtc.json
+++ b/chrome/socks_rtc.json
@@ -13,6 +13,7 @@
   },
   "permissions": [
     "core.socket",
+    "core.udpsocket",
     "core.peerconnection"
   ]
 }

--- a/spec/chrome-udpsocket_spec.js
+++ b/spec/chrome-udpsocket_spec.js
@@ -65,7 +65,7 @@ describe("chrome-udpsocket", function() {
         'localhost',
         7000,
         jasmine.any(Function));
-    expect(continuation).toHaveBeenCalled();
+    expect(continuation).toHaveBeenCalledWith(sendToResult.bytesWritten);
   });
 
   // TODO(yangoon): test for recvFrom

--- a/spec/chrome-udpsocket_spec.js
+++ b/spec/chrome-udpsocket_spec.js
@@ -1,0 +1,72 @@
+// White-box test for the Chrome APIs implementation of
+// Freedom's UDP socket provider.
+// Modeled on Freedom's social.loopback.unit.spec.js.
+describe("chrome-udpsocket", function() {
+  var provider;
+  // Supplied as an argument to the mock chrome.socket.create callback.
+  var createResult;
+  // Supplied as an argument to the mock chrome.socket.bind callback.
+  var bindResult;
+  // Supplied as an argument to the mock chrome.socket.sendTo callback.
+  var sendToResult;
+  var continuation = jasmine.createSpy('continuation');
+
+  beforeEach(function() {
+    provider = new UdpSocket.Chrome(
+        jasmine.createSpy('channel'),
+        jasmine.createSpy('dispatchEvent'));
+
+    chrome = {
+      socket: {
+        create: function(protocol, args, callback) {
+          callback(createResult);
+        },
+        bind: function(socketId, address, port, callback) {
+          callback(bindResult);
+        },
+        sendTo: function(socketId, data, address, port, callback) {
+          callback(sendToResult);
+        }
+      }
+    };
+
+    spyOn(chrome.socket, 'create').and.callThrough();
+    spyOn(chrome.socket, 'bind').and.callThrough();
+    spyOn(chrome.socket, 'sendTo').and.callThrough();
+  });
+
+  it('bind', function() {
+    createResult = { socketId: 1025 };
+    bindResult = -1, // failure! don't want an infinite loop.
+    provider.bind('localhost', 5000, continuation);
+    expect(chrome.socket.create).toHaveBeenCalledWith(
+        'udp',
+        jasmine.any(Object),
+        jasmine.any(Function));
+    expect(chrome.socket.bind).toHaveBeenCalledWith(
+        createResult.socketId,
+        'localhost',
+        5000,
+        jasmine.any(Function));
+    expect(continuation).toHaveBeenCalled();
+  });
+
+  it('sendTo', function() {
+    createResult = { socketId: 1025 };
+    bindResult = -1, // failure! don't want an infinite loop.
+    sendToResult = {
+      bytesWritten: 4
+    };
+    provider.bind('localhost', 5000, continuation);
+    provider.sendTo(new ArrayBuffer(), 'localhost', 7000, continuation);
+    expect(chrome.socket.sendTo).toHaveBeenCalledWith(
+        createResult.socketId,
+        jasmine.any(ArrayBuffer),
+        'localhost',
+        7000,
+        jasmine.any(Function));
+    expect(continuation).toHaveBeenCalled();
+  });
+
+  // TODO(yangoon): test for recvFrom
+});

--- a/src/chrome-udpsocket.ts
+++ b/src/chrome-udpsocket.ts
@@ -3,20 +3,19 @@
  */
 /// <reference path='interfaces/udpsocket.d.ts' />
 
+// TODO(yangoon): use DefinitelyTyped.
 declare var chrome:any;
 
 module UdpSocket {
 
   // Type for the chrome.socket.create callback:
   //   http://developer.chrome.com/apps/socket#method-create
-  // TODO(yangoon): use DefinitelyTyped.
   interface CreateSocketInfo {
     socketId:number;
   }
 
   // Type for the chrome.socket.recvFrom callback:
   //   http://developer.chrome.com/apps/socket#method-recvFrom
-  // TODO(yangoon): use DefinitelyTyped.
   interface RecvFromInfo {
     resultCode:number;
     address:string;
@@ -26,7 +25,6 @@ module UdpSocket {
 
   // Type for the chrome.socket.sendTo callback:
   //   http://developer.chrome.com/apps/socket#type-WriteInfo
-  // TODO(yangoon): use DefinitelyTyped.
   interface WriteInfo {
     bytesWritten:number;
   }

--- a/src/chrome-udpsocket.ts
+++ b/src/chrome-udpsocket.ts
@@ -1,0 +1,82 @@
+/**
+ * Freedom UDP sockets over the Chrome APIs.
+ */
+/// <reference path='interfaces/udpsocket.d.ts' />
+
+declare var chrome:any;
+
+module UdpSocket {
+
+  interface CreateSocketInfo {
+    socketId:number;
+  }
+
+  export class Chrome implements UdpSocket.API {
+    private socketId:number;
+
+    constructor (
+        private channel,
+        private dispatchEvent:(event:string, data:any) => void) {
+    }
+
+    public bind = (address:string, port:number, continuation) => {
+      // TODO(yangoon): throw error if socketId already set.
+      chrome.socket.create('udp', {}, (createResult:CreateSocketInfo) => {
+        // TODO(yangoon): can create() fail?
+        this.socketId = createResult.socketId;
+        chrome.socket.bind(this.socketId, address, port, (resultCode:number) => {
+          dbg('socket ' + this.socketId + ' listening on ' + address + ':' + port);
+          continuation(resultCode);
+          if (resultCode >= 0) {
+            this.recvFromLoop();
+          }
+        });
+      });
+    }
+
+    /**
+     * Initialises an infinite read loop.
+     * The socket must be successfully bound.
+     */
+    private recvFromLoop = () => {
+      // TODO(yangoon): throw error if socketId unset.
+      dbg('starting recvFrom loop for socket ' + this.socketId);
+      chrome.socket.recvFrom(this.socketId, null, (recvFromInfo) => {
+        if (recvFromInfo.resultCode >= 0) {
+          dbg('dispatching onData event for socket ' + this.socketId);
+          this.dispatchEvent('onData', {
+            resultCode: recvFromInfo.resultCode,
+            address: recvFromInfo.address,
+            port: recvFromInfo.port,
+            data: recvFromInfo.data
+          });
+        } else {
+          // TODO(yangoon): Give the client an opportunity to handle errors.
+          dbgErr('code ' + recvFromInfo.resultCode +
+              ' while trying to accept connection on socket ' + this.socketId);
+        }
+        this.recvFromLoop();
+      });
+    }
+
+    public sendTo = (data:ArrayBuffer, address:string, port:number, continuation) => {
+      // TODO(yangoon): throw error if socketId unset.
+      chrome.socket.sendTo(this.socketId, data, address, port, (writeInfo) => {
+        console.log(writeInfo);
+      });
+      continuation();
+    }
+
+    public destroy = (continuation) => {
+      if (this.socketId) {
+        chrome.socket.destroy(this.socketId);
+      }
+      continuation();
+    }
+  }
+
+  var modulePrefix_ = '[udp-socket] ';
+  function dbg(msg:string) { console.log(modulePrefix_ + msg); }
+  function dbgWarn(msg:string) { console.warn(modulePrefix_ + msg); }
+  function dbgErr(msg:string) { console.error(modulePrefix_ + msg); }
+}

--- a/src/chrome-udpsocket.ts
+++ b/src/chrome-udpsocket.ts
@@ -62,9 +62,8 @@ module UdpSocket {
     public sendTo = (data:ArrayBuffer, address:string, port:number, continuation) => {
       // TODO(yangoon): throw error if socketId unset.
       chrome.socket.sendTo(this.socketId, data, address, port, (writeInfo) => {
-        console.log(writeInfo);
+        continuation(writeInfo.bytesWritten);
       });
-      continuation();
     }
 
     public destroy = (continuation) => {

--- a/src/interfaces/udpsocket.d.ts
+++ b/src/interfaces/udpsocket.d.ts
@@ -4,13 +4,6 @@
 
 declare module UdpSocket {
 
-  export interface RecvFromInfo {
-    resultCode:number;
-    address:string;
-    port:number;
-    data:ArrayBuffer
-  }
-
   export interface API {
     bind:any;
     sendTo:any;

--- a/src/interfaces/udpsocket.d.ts
+++ b/src/interfaces/udpsocket.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Interface for a UDP socket.
+ */
+
+declare module UdpSocket {
+
+  export interface RecvFromInfo {
+    resultCode:number;
+    address:string;
+    port:number;
+    data:ArrayBuffer
+  }
+
+  export interface API {
+    bind:any;
+    sendTo:any;
+    destroy:any;
+    on?:any;
+  }
+
+}

--- a/src/socks-to-rtc/socks-to-rtc.json
+++ b/src/socks-to-rtc/socks-to-rtc.json
@@ -12,6 +12,7 @@
   },
   "permissions": [
     "core.socket",
+    "core.udpsocket",
     "core.peerconnection"
   ]
 }


### PR DESCRIPTION
This adds a provider for core.udpsocket:
UWNetworksLab/freedom#52

Based quite heavily on chrome-fsocket.ts.

Also some bits and bobs of plumbing which aren't strictly necessary right now but will be useful for the next merge, which will consist of a "UDP server" (basically, a counterpart of tcp.ts).

This works pretty well with some toy code I have which adds UDP support to the proxy (pretty far from ready for review).

There's also a test. It's far from bulletproof but it does check that we're making the right calls to chrome.sockets.*.
