### PR TITLE
Build path update

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,4 @@
 spec/*
 test/*
 tmp/*
-build/*
+build/chrome-app/*

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -10,18 +10,33 @@ module.exports = (grunt) ->
         expand: true, cwd: 'node_modules/freedom-runtime-chrome/'
         src: ['freedom.js']
         dest: 'build/chrome-app/' } ] }
-      chromeApp: { files: [ {
-        expand: true, cwd: 'src/chrome-app'
-        src: ['**/*.json', '**/*.js', '**/*.html', '**/*.css']
-        dest: 'build/chrome-app/' } ] }
+
+      # User should include the compiled source directly from:
+      #   - build/socks-to-rtc
+      #   - build/rtc-to-net
       socks2rtc: { files: [ {
         expand: true, cwd: 'src/'
         src: ['socks-to-rtc/**/*.json']
-        dest: 'build/chrome-app/' } ] }
+        dest: 'build/' } ] }
       rtc2net: { files: [ {
         expand: true, cwd: 'src/'
         src: ['rtc-to-net/**/*.json']
-        dest: 'build/chrome-app/' } ] }
+        dest: 'build/' } ] }
+
+      chromeApp: { files: [
+        {
+          expand: true, cwd: 'src/chrome-app'
+          src: ['**/*.json', '**/*.js', '**/*.html', '**/*.css']
+          dest: 'build/chrome-app/'
+        }, {
+          expand: true, cwd: 'build/socks-to-rtc',
+          src: ['**/*.js', '**/*.json'],
+          dest: 'build/chrome-app/socks-to-rtc'
+        }, {
+          expand: true, cwd: 'build/rtc-to-net',
+          src: ['**/*.js', '**/*.json'],
+          dest: 'build/chrome-app/rtc-to-net'
+        } ] }
     }
 
     #-------------------------------------------------------------------------
@@ -29,12 +44,12 @@ module.exports = (grunt) ->
     typescript: {
       socks2rtc: {
         src: ['src/socks-to-rtc/**/*.ts']
-        dest: 'build/chrome-app/'
+        dest: 'build/'
         options: { base_path: 'src' }
       }
       rtc2net: {
         src: ['src/rtc-to-net/**/*.ts']
-        dest: 'build/chrome-app/'
+        dest: 'build/'
         options: { base_path: 'src' }
       }
       chromeProviders: {
@@ -87,9 +102,9 @@ module.exports = (grunt) ->
     'typescript:chromeProviders'
     'typescript:chromeApp'
     'copy:freedom'
-    'copy:chromeApp'
     'copy:socks2rtc'
     'copy:rtc2net'
+    'copy:chromeApp'
   ]
 
   # This is the target run by Travis. Targets in here should run locally

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -23,8 +23,7 @@ module.exports = (grunt) ->
         src: ['rtc-to-net/**/*.json']
         dest: 'build/' } ] }
 
-      chromeApp: { files: [
-        {
+      chromeApp: { files: [ {
           expand: true, cwd: 'src/chrome-app'
           src: ['**/*.json', '**/*.js', '**/*.html', '**/*.css']
           dest: 'build/chrome-app/'

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ There are two modules: _socks-to-rtc_ and _rtc-to-net_.
 
 #### Usage
 
-To make use of this library, one needs to include `socks-to-rtc.json` and `rtc-to-net.json` (the freedom manifests for these) as dependencies in the parent application's freedom manifest. Three things must occur for the two components to speak to each other:
+To make use of this library, one needs to include `socks-to-rtc.json`
+and `rtc-to-net.json` (the freedom manifests for the two freedom modules)
+as dependencies in the parent application's freedom manifest. There will be
+the compiled javascript in `build/socks-to-rtc/` and `/build/rtc-to-net/`.
+Three things must occur for the two components to speak to each other:
 
 - In the your 'parent freedom' create instances of the modules. (i.e. `var socksToRtc = freedom.SocksToRtc();` and `var rtcToNet = freedom.RtcToNet();`
 - `rtcToNet.emit('start')` begins the remote peer server.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "socks-rtc",
   "description": "Library for proxying SOCKS5 over WebRTC",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/socks-rtc"


### PR DESCRIPTION
Puts `socks-to-rtc` and `rtc-to-net` back in the root level of `build/`, so that the user of this repo can use the library without caring about `build/chrome-app`.

Tested: `grunt test` and manual End-to-End
