### PR TITLE
migrate from peerconnection to transport

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -39,6 +39,10 @@ module.exports = (grunt) ->
           expand: true, cwd: 'build/rtc-to-net',
           src: ['**/*.js', '**/*.json'],
           dest: 'build/chrome-app/rtc-to-net'
+        }, {
+          expand: true, cwd: 'build/common',
+          src: ['**/*.js'],
+          dest: 'build/chrome-app/common'
         } ] }
     }
 
@@ -52,6 +56,11 @@ module.exports = (grunt) ->
       }
       rtc2net: {
         src: ['src/rtc-to-net/**/*.ts']
+        dest: 'build/'
+        options: { base_path: 'src' }
+      }
+      common: {
+        src: ['src/common/**/*.ts']
         dest: 'build/'
         options: { base_path: 'src' }
       }
@@ -102,6 +111,7 @@ module.exports = (grunt) ->
   grunt.registerTask 'build', [
     'typescript:socks2rtc'
     'typescript:rtc2net'
+    'typescript:common'
     'typescript:chromeProviders'
     'typescript:chromeApp'
     'copy:freedom'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -10,6 +10,10 @@ module.exports = (grunt) ->
         expand: true, cwd: 'node_modules/freedom-runtime-chrome/'
         src: ['freedom.js']
         dest: 'build/chrome-app/' } ] }
+      freedomProviders: { files: [ {
+        expand: true, cwd: 'node_modules/freedom/providers/transport/webrtc/'
+        src: ['*']
+        dest: 'build/chrome-app/freedom-providers' } ] }
 
       # User should include the compiled source directly from:
       #   - build/socks-to-rtc
@@ -101,6 +105,7 @@ module.exports = (grunt) ->
     'typescript:chromeProviders'
     'typescript:chromeApp'
     'copy:freedom'
+    'copy:freedomProviders'
     'copy:socks2rtc'
     'copy:rtc2net'
     'copy:chromeApp'

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   },
   "scripts": {
     "test": "grunt --verbose"
+  },
+  "dependencies": {
+    "freedom": "~0.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "webdriverjs": "~1.3.1",
     "grunt-env": "~0.4.1",
     "freedom-runtime-chrome": "~0.1.1",
-    "freedom-typescript-api": "~0.1.3"
+    "freedom-typescript-api": "~0.1.4"
   },
   "scripts": {
     "test": "grunt --verbose"

--- a/src/chrome-app/socks_rtc.json
+++ b/src/chrome-app/socks_rtc.json
@@ -12,7 +12,6 @@
   },
   "permissions": [
     "core.socket",
-    "core.udpsocket",
-    "core.peerconnection"
+    "core.udpsocket"
   ]
 }

--- a/src/common/arraybuffers.ts
+++ b/src/common/arraybuffers.ts
@@ -1,0 +1,44 @@
+module ArrayBuffers {
+  /**
+   * Converts an ArrayBuffer to a string.
+   *
+   * @param {ArrayBuffer} buffer The buffer to convert.
+   */
+  export function arrayBufferToString(buffer:ArrayBuffer) : string {
+    var bytes = new Uint8Array(buffer);
+    var a = [];
+    for (var i = 0; i < bytes.length; ++i) {
+      a.push(String.fromCharCode(bytes[i]));
+    }
+    return a.join('');
+  }
+
+  /**
+   * Converts a string to an ArrayBuffer.
+   *
+   * @param {string} s The string to convert.
+   */
+  export function stringToArrayBuffer(s:string) : ArrayBuffer {
+    var buffer = new ArrayBuffer(s.length);
+    var bytes = new Uint8Array(buffer);
+    for (var i = 0; i < s.length; ++i) {
+      bytes[i] = s.charCodeAt(i);
+    }
+    return buffer;
+  }
+
+  /**
+   * Converts an ArrayBuffer to a string of hex codes and interpretations as
+   * a char code.
+   *
+   * @param {ArrayBuffer} buffer The buffer to convert.
+   */
+  export function arrayBufferToHexString(buffer:ArrayBuffer) : string {
+    var bytes = new Uint8Array(buffer);
+    var a = [];
+    for (var i = 0; i < buffer.byteLength; ++i) {
+      a.push(bytes[i].toString(16));
+    }
+    return a.join('.');
+  }
+}

--- a/src/interfaces/communications.d.ts
+++ b/src/interfaces/communications.d.ts
@@ -1,10 +1,18 @@
 // Types for communications between socks-to-rtc and rtc-to-net.
 
 declare module Channel {
+
+  export enum COMMANDS {
+    NET_CONNECT_REQUEST = 1,
+    NET_CONNECT_RESPONSE = 2,
+    NET_DISCONNECTED = 3,
+    SOCKS_DISCONNECTED = 4
+  }
+
   // "Top-level" message for the control channel.
   export interface Command {
     // Name of message, e.g. NetConnectRequest.
-    type:string;
+    type:COMMANDS;
     // Datachannel with which this message is associated.
     tag?:string;
     // JSON-encoded message, e.g. NetConnectRequest.

--- a/src/interfaces/communications.d.ts
+++ b/src/interfaces/communications.d.ts
@@ -1,22 +1,38 @@
 // Types for communications between socks-to-rtc and rtc-to-net.
 
 declare module Channel {
+  // "Top-level" message for the control channel.
+  export interface Command {
+    // Name of message, e.g. NetConnectRequest.
+    type:string;
+    // Datachannel with which this message is associated.
+    tag?:string;
+    // JSON-encoded message, e.g. NetConnectRequest.
+    data?:string;
+  }
 
-  export interface Message {
-    channelLabel:string;
-    text?:string;
-    buffer?:ArrayBuffer;
+  // Sent to request a connection be established with a remote server.
+  export interface NetConnectRequest {
+    // 'tcp' or 'udp'.
+    protocol:string;
+    // Destination address and port.
+    address:string;
+    port:number;
+  }
+
+  export interface NetConnectResponse {
+    // Address and port on which we have made the connection to the
+    // remote server, or both undefined if the connection could not be
+    // made.
+    address?:string;
+    port?:number;
   }
 
   // Should be returned after tieing a data-channel with SOCKS, back to form an
   // endpoint response to the local TCP server.
-  interface EndpointInfo {
+  export interface EndpointInfo {
     ipAddrString:string;
     port:number;
-  }
-
-  interface CloseData {
-    channelId:string;
   }
 
 }  // module Channel

--- a/src/rtc-to-net/netclient.ts
+++ b/src/rtc-to-net/netclient.ts
@@ -47,11 +47,19 @@ module Net {
       this.disconnectPromise = new Promise<void>((F, R) => {
         this.fulfillDisconnect = F;  // To be fired on close.
       });
-      this.createSocket_()  // Initialize client TCP socket.
+    }
+
+    // TODO: this should probably just be a static creation function
+    public create = () : Promise<Channel.EndpointInfo> => {
+      return this.createSocket_()  // Initialize client TCP socket.
           .then(this.connect_)
           .then(this.attachHandlers_)
-          .catch((e) => { dbgErr(e.message); });
-      dbg('created connection to ' + JSON.stringify(destination));
+          .then(() => {
+            return {
+              ipAddrString: '192.168.1.1',
+              port: 1000
+            };
+          });
     }
 
     /**

--- a/src/rtc-to-net/netclient.ts
+++ b/src/rtc-to-net/netclient.ts
@@ -56,8 +56,9 @@ module Net {
           .then(this.attachHandlers_)
           .then(() => {
             return {
-              ipAddrString: '192.168.1.1',
-              port: 1000
+              // TODO: return the real address from which we are connected
+              ipAddrString: '127.0.0.1',
+              port: 0
             };
           });
     }

--- a/src/rtc-to-net/rtc-to-net.json
+++ b/src/rtc-to-net/rtc-to-net.json
@@ -8,9 +8,12 @@
     ]
   },
   "dependencies": {
+    "transport": {
+      "url": "../freedom-providers/transport.webrtc.json",
+      "api": "transport"
+    }
   },
   "permissions": [
-    "core.socket",
-    "core.peerconnection"
+    "core.socket"
   ]
 }

--- a/src/rtc-to-net/rtc-to-net.json
+++ b/src/rtc-to-net/rtc-to-net.json
@@ -4,7 +4,8 @@
   "app": {
     "script": [
       "netclient.js",
-      "rtc-to-net.js"
+      "rtc-to-net.js",
+      "../common/arraybuffers.js"
     ]
   },
   "dependencies": {

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -104,20 +104,12 @@ module RtcToNet {
     }
 
     /**
-     * Return data from Net to Peer.
-     */
-    private serveDataToPeer_ = (tag:string, data:ArrayBuffer) => {
-      dbg('reply ' + data.byteLength + ' bytes ---> ' + tag);
-      this.transport.send(tag, data);
-    }
-
-    /**
      * Tie a Net.Client for Destination |dest| to data-channel |tag|.
      */
     private prepareNetChannelLifecycle_ =
         (tag:string, dest:Net.Destination) => {
       var netClient = this.netClients[tag] = new Net.Client(
-          (data) => { this.serveDataToPeer_(tag, data); },  // onResponse
+          (data) => { this.transport.send(tag, data); },  // onResponse
           dest);
       // Send NetClient remote disconnections back to SOCKS peer, then shut the
       // data channel locally.

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -83,7 +83,7 @@ module RtcToNet {
       if (message.tag == 'control') {
         var command:Channel.Command = JSON.parse(
             ArrayBuffers.arrayBufferToString(message.data));
-        if (command.type == 'NetConnectRequest') {
+        if (command.type === Channel.COMMANDS.NET_CONNECT_REQUEST) {
           var request:Channel.NetConnectRequest = JSON.parse(command.data);
           if (command.tag in this.netClients) {
             dbgWarn('Net.Client already exists for datachannel: ' + command.tag);
@@ -107,7 +107,7 @@ module RtcToNet {
                   response.port = endpointInfo.port;
                 }
                 var out:Channel.Command = {
-                    type: 'NetConnectResponse',
+                    type: Channel.COMMANDS.NET_CONNECT_RESPONSE,
                     tag: command.tag,
                     data: JSON.stringify(response)
                 }
@@ -145,7 +145,7 @@ module RtcToNet {
         // data channel locally.
         netClient.onceDisconnected().then(() => {
           var command:Channel.Command = {
-              type: 'NetDisconnected',
+              type: Channel.COMMANDS.NET_DISCONNECTED,
               tag: tag
           };
           this.transport.send('control', ArrayBuffers.stringToArrayBuffer(

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -84,10 +84,7 @@ module RtcToNet {
         var commandText = ArrayBuffers.arrayBufferToString(message.data);
         var command:any = JSON.parse(commandText);
         if (command.command == 'SOCKS-CONNECT') {
-          // Text from the peer indicates request for a new destination.
-          // Assumes |message.text| is a Net.Destination.
           if (command.tag in this.netClients) {
-            // TODO: This shouldn't be fired! This is bad!
             dbgWarn('Net.Client already exists for datachannel: ' + command.tag);
             return;
           }

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -4,6 +4,7 @@
 /// <reference path='netclient.ts' />
 /// <reference path='../../node_modules/freedom-typescript-api/interfaces/freedom.d.ts' />
 /// <reference path='../../node_modules/freedom-typescript-api/interfaces/peer-connection.d.ts' />
+/// <reference path='../common/arraybuffers.ts' />
 /// <reference path='../interfaces/communications.d.ts' />
 
 console.log('WEBWORKER - RtcToNet: ' + self.location.href);

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -81,15 +81,39 @@ module RtcToNet {
       }
 
       if (message.tag == 'control') {
-        var commandText = ArrayBuffers.arrayBufferToString(message.data);
-        var command:any = JSON.parse(commandText);
-        if (command.command == 'SOCKS-CONNECT') {
+        var command:Channel.Command = JSON.parse(
+            ArrayBuffers.arrayBufferToString(message.data));
+        if (command.type == 'NetConnectRequest') {
+          var request:Channel.NetConnectRequest = JSON.parse(command.data);
           if (command.tag in this.netClients) {
             dbgWarn('Net.Client already exists for datachannel: ' + command.tag);
             return;
           }
-          var dest:Net.Destination = JSON.parse(commandText);
-          this.prepareNetChannelLifecycle_(command.tag, dest);
+          var dest:Net.Destination = {
+            host: request.address,
+            port: request.port
+          };
+          // This is what we'll send to the client.
+          // If we successfully connect to the remote host then we'll
+          // populate the address and port fields.
+          var response:Channel.NetConnectResponse = {};
+          this.prepareNetChannelLifecycle_(command.tag, dest)
+              .then((endpointInfo:Channel.EndpointInfo) => {
+                response.address = endpointInfo.ipAddrString;
+                response.port = endpointInfo.port;
+              })
+              .then(() => {
+                var out:Channel.Command = {
+                    type: 'NetConnectResponse',
+                    tag: command.tag,
+                    data: JSON.stringify(response)
+                }
+                this.transport.send('control', ArrayBuffers.stringToArrayBuffer(
+                    JSON.stringify(out)));
+              });
+        } else {
+          // TODO: support SocksDisconnected command
+          dbgWarn('unsupported control command: ' + command.type);
         }
       } else {
         dbg(message.tag + ' <--- received ' + JSON.stringify(message));
@@ -104,38 +128,34 @@ module RtcToNet {
     }
 
     /**
-     * Tie a Net.Client for Destination |dest| to data-channel |tag|.
+     * Returns a promise to tie a Net.Client for Destination |dest| to
+     * data-channel |tag|.
      */
     private prepareNetChannelLifecycle_ =
-        (tag:string, dest:Net.Destination) => {
-      var netClient = this.netClients[tag] = new Net.Client(
+        (tag:string, dest:Net.Destination) : Promise<Channel.EndpointInfo> => {
+      var netClient = new Net.Client(
           (data) => { this.transport.send(tag, data); },  // onResponse
           dest);
-      // Send NetClient remote disconnections back to SOCKS peer, then shut the
-      // data channel locally.
-      netClient.onceDisconnected().then(() => {
-        var commandText = JSON.stringify({
-          command: 'NET-DISCONNECTED',
-          tag: tag
+      return netClient.create().then((endpointInfo:Channel.EndpointInfo) => {
+        this.netClients[tag] = netClient;
+        // Send NetClient remote disconnections back to SOCKS peer, then shut the
+        // data channel locally.
+        netClient.onceDisconnected().then(() => {
+          var command:Channel.Command = {
+              type: 'NetDisconnected',
+              tag: tag
+          };
+          this.transport.send('control', ArrayBuffers.stringToArrayBuffer(
+              JSON.stringify(command)));
+          dbg('send NET-DISCONNECTED ---> ' + tag);
         });
-        var buffer = ArrayBuffers.stringToArrayBuffer(commandText);
-        this.transport.send('control', buffer);
-        dbg('send NET-DISCONNECTED ---> ' + tag);
+        return endpointInfo;
       });
     }
 
-    /**
-     * Close an individual Net.Client when its data channel closes.
-     */
-    private closeNetClient_ = (channelData:Channel.CloseData) => {
-      var channelId = channelData.channelId;
-      if (!(channelId in this.netClients)) {
-        dbgWarn('no Net.Client to close for ' + channelId)
-        return;
-      }
-      dbg('closing Net.Client for closed datachannel ' + channelId);
-      this.netClients[channelId].close();
-      delete this.netClients[channelId];
+    // TODO: it's not clear what to do here
+    private closeNetClient_ = () => {
+      dbg('transport closed');
     }
   }  // class RtcToNet.Peer
 

--- a/src/socks-to-rtc/socks-to-rtc.json
+++ b/src/socks-to-rtc/socks-to-rtc.json
@@ -11,10 +11,13 @@
     ]
   },
   "dependencies": {
+    "transport": {
+      "url": "../freedom-providers/transport.webrtc.json",
+      "api": "transport"
+    }
   },
   "permissions": [
     "core.socket",
-    "core.udpsocket",
-    "core.peerconnection"
+    "core.udpsocket"
   ]
 }

--- a/src/socks-to-rtc/socks-to-rtc.json
+++ b/src/socks-to-rtc/socks-to-rtc.json
@@ -7,7 +7,8 @@
       "socks.js",
       "socks-headers.js",
       "socks-to-rtc.js",
-      "udprelay.js"
+      "udprelay.js",
+      "../common/arraybuffers.js"
     ]
   },
   "dependencies": {

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -4,6 +4,7 @@
 /// <reference path='socks.ts' />
 /// <reference path='../../node_modules/freedom-typescript-api/interfaces/freedom.d.ts' />
 /// <reference path='../../node_modules/freedom-typescript-api/interfaces/peer-connection.d.ts' />
+/// <reference path='../common/arraybuffers.ts' />
 /// <reference path='../interfaces/communications.d.ts' />
 
 // TODO replace with a reference to freedom ts interface once it exists.

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -45,7 +45,7 @@ module SocksToRTC {
       // SOCKS sessions biject to peerconnection datachannels.
       this.transport = freedom['transport']();
       this.transport.on('onData', this.onDataFromPeer);
-      this.transport.on('onClose', this.closeConnection_);
+      this.transport.on('onClose', this.closeConnectionToPeer);
       // Messages received via signalling channel must reach the remote peer
       // through something other than the peerconnection. (e.g. XMPP)
       fCore.createChannel().then((chan) => {
@@ -76,7 +76,7 @@ module SocksToRTC {
         this.socksServer = null;
       }
       for (var tag in this.socksSessions) {
-        this.closeConnection_(tag);
+        this.closeConnectionToPeer(tag);
       }
       this.socksSessions = {};
       if(this.transport) {
@@ -166,7 +166,7 @@ module SocksToRTC {
         if (command.command == 'NET-DISCONNECTED') {
           // Receiving a disconnect on the remote peer should close SOCKS.
           dbg(command.tag + ' <--- received NET-DISCONNECTED');
-          this.closeConnection_(command.tag);
+          this.closeConnectionToPeer(command.tag);
           return;
         }
       } else {
@@ -182,7 +182,7 @@ module SocksToRTC {
     /**
      * Close a particular SOCKS session.
      */
-    private closeConnection_ = (tag:string) => {
+    private closeConnectionToPeer = (tag:string) => {
       dbg('datachannel ' + tag + ' has closed. ending SOCKS session for channel.');
       this.socksServer.endSession(this.socksSessions[tag]);
       delete this.socksSessions[tag];

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -3,7 +3,7 @@
 */
 /// <reference path='socks.ts' />
 /// <reference path='../../node_modules/freedom-typescript-api/interfaces/freedom.d.ts' />
-/// <reference path='../../node_modules/freedom-typescript-api/interfaces/peer-connection.d.ts' />
+/// <reference path='../../node_modules/freedom-typescript-api/interfaces/transport.d.ts' />
 /// <reference path='../common/arraybuffers.ts' />
 /// <reference path='../interfaces/communications.d.ts' />
 
@@ -24,10 +24,10 @@ module SocksToRTC {
 
     private socksServer:Socks.Server = null;  // Local SOCKS server.
     private signallingChannel:any = null;     // NAT piercing route.
-    private sctpPc:freedom.PeerConnection = null;     // For actual proxying.
+    private transport:freedom.Transport = null;     // For actual proxying.
 
-    // Active SOCKS sessions by corresponding SCTP channel id.
-    private socksSessions:{[label:number]:Socks.Session} = {};
+    // Active SOCKS sessions, by datachannel tag name.
+    private socksSessions:{[tag:string]:Socks.Session} = {};
     private peerId:string = null;         // Of the remote rtc-to-net peer.
 
     /**
@@ -43,14 +43,13 @@ module SocksToRTC {
         return false;
       }
       // SOCKS sessions biject to peerconnection datachannels.
-      this.sctpPc = freedom['core.peerconnection']();
-      this.sctpPc.on('onReceived', this.replyToSOCKS_);
-      this.sctpPc.on('onCloseDataChannel', this.closeConnection_);
+      this.transport = freedom['transport']();
+      this.transport.on('onData', this.replyToSOCKS_);
+      this.transport.on('onClose', this.closeConnection_);
       // Messages received via signalling channel must reach the remote peer
       // through something other than the peerconnection. (e.g. XMPP)
       fCore.createChannel().then((chan) => {
-        var stunServers = [];  // TODO: actually pass stun servers.
-        this.sctpPc.setup(chan.identifier, 'SocksToRtc-' + peerId, stunServers);
+        this.transport.setup('SocksToRtc-' + peerId, chan.identifier);
         this.signallingChannel = chan.channel;
         this.signallingChannel.on('message', function(msg) {
           freedom.emit('sendSignalToPeer', {
@@ -76,13 +75,13 @@ module SocksToRTC {
         this.socksServer.disconnect();  // Disconnects internal TCP server.
         this.socksServer = null;
       }
-      for (var channelLabel in this.socksSessions) {
-        this.closeConnection_(channelLabel);
+      for (var tag in this.socksSessions) {
+        this.closeConnection_(tag);
       }
       this.socksSessions = {};
-      if(this.sctpPc) {
-        this.sctpPc.close();
-        this.sctpPc = null;
+      if(this.transport) {
+        this.transport.close();
+        this.transport = null;
       }
       if (this.signallingChannel) {  // TODO: is this actually right?
         this.signallingChannel.emit('close');
@@ -105,137 +104,103 @@ module SocksToRTC {
         return Promise.resolve({ ipAddrString: '127.0.0.1', port: 0 });
       }
 
-      if (!this.sctpPc) {
-        dbgErr('onConnection called without SCTP peer connection.');
+      if (!this.transport) {
+        dbgWarn('transport not ready');
         return;
       }
 
-      var channelLabel = obtainChannelLabel();
-      return this.createDataChannel_(channelLabel)
-          .then(() => {
-            dbg('created datachannel ' + channelLabel);
-            this.tieSessionToChannel_(session, channelLabel);
-          })
-          // Send initial request header to remote peer over the data channel.
-          .then(() => {
-            var newRequest = {
-                channelLabel: channelLabel,
-                text: JSON.stringify({ host: address, port: port })
-            };
-            this.sctpPc.send(newRequest);
-            dbg('new request -----> ' + channelLabel +
-                ' \n' + JSON.stringify(newRequest));
+      // Generate a name for this connection and associate it with the SOCKS session.
+      var tag = obtainTag();
+      this.tieSessionToChannel_(session, tag);
+
+      // Send initial request header to remote peer over the data channel.
+      var commandText = JSON.stringify({
+        command: 'SOCKS-CONNECT',
+        tag: tag,
+        host: address,
+        port: port });
+      var buffer = ArrayBuffers.stringToArrayBuffer(commandText);
+      return this.transport.send('control', buffer).then(() => {
       // TODO: we are not connected yet... should we have some message passing
       // back from the other end of the data channel to tell us when it has
       // happened, instead of just pretended?
       // TODO: Allow SOCKs headers
-          })
-          .then(() => {
+        dbg('created datachannel ' + tag + ' for ' + address + ':' + port);
             // TODO: determine if these need to be accurate.
             return { ipAddrString: '127.0.0.1', port: 0 };
           });
     }
 
-    private createDataChannel_ = (label:string):Promise<void> => {
-      return this.sctpPc.openDataChannel(label);
-    }
-
     /**
-     * Create one-to-one relationship between a SOCKS session and
-     * peer-connection data channel.
+     * Create one-to-one relationship between a SOCKS session and a datachannel.
      */
-    private tieSessionToChannel_ = (session:Socks.Session, label:string) => {
-      this.socksSessions[label] = session;
+    private tieSessionToChannel_ = (session:Socks.Session, tag:string) => {
+      this.socksSessions[tag] = session;
       // When the TCP-connection receives data, send to sctp peer.
-      // When it disconnects, clear the |channelLabel|.
-      session.onRecv((buf) => { this.sendToPeer_(label, buf); });
-      session.onceDisconnected()
-          // TODO: When we start re-using datachannels, stop closing the
-          // datachannels but remap them instead.
-          .then(() => {
-            // TODO: For now, signal the remote that this datachannel is
-            // disconnected.
-            this.sctpPc.send({
-              channelLabel: label,
-              text: 'SOCKS-DISCONNECTED'
-            });
-            dbg('send SOCKS-DISCONNECTED ---> ' + label);
-            this.sctpPc.closeDataChannel(label);
-          });
-
+      // When it disconnects, clear the |tag|.
+      session.onRecv((buf) => { this.sendToPeer_(tag, buf); });
+      session.onceDisconnected().then(() => {
+        var commandText = JSON.stringify({
+          command: 'SOCKS-DISCONNECTED',
+          tag: tag
+        });
+        var buffer = ArrayBuffers.stringToArrayBuffer(commandText);
+        this.transport.send('control', buffer);
+      });
     }
 
     /**
      * Receive replies proxied back from the remote RtcToNet.Peer and pass them
      * back across underlying SOCKS session / TCP socket.
      */
-    private replyToSOCKS_ = (msg:Channel.Message) => {
-      var label = msg.channelLabel;
-      if (!label) {
-        dbgErr('received message without channelLabel! msg: ' +
-            JSON.stringify(msg));
+    private replyToSOCKS_ = (msg:freedom.Transport.IncomingMessage) => {
+      dbg(msg.tag + ' <--- received ' + msg.data.byteLength);
+      if (!msg.tag) {
+        dbgErr('received message without datachannel tag!: ' + JSON.stringify(msg));
         return;
       }
-      if (!(label in this.socksSessions)) {
-        dbgErr(label + ' not associated with SOCKS session!');
-        return;
-      }
-      var session = this.socksSessions[label];
-      if (msg.buffer) {
-        dbg(msg.channelLabel + ' <--- received ' + msg.buffer.byteLength);
-        session.sendData(msg.buffer);
-      } else if (msg.text) {
-        if ('NET-DISCONNECTED' == msg.text) {
+
+      if (msg.tag == 'control') {
+        var command:any = JSON.parse(
+            ArrayBuffers.arrayBufferToString(msg.data));
+        if (command.command == 'NET-DISCONNECTED') {
           // Receiving a disconnect on the remote peer should close SOCKS.
-          dbg(label + ' <--- received NET-DISCONNECTED');
-          this.closeConnection_({channelId:label});
+          dbg(command.tag + ' <--- received NET-DISCONNECTED');
+          this.closeConnection_(command.tag);
           return;
         }
-        // TODO: we should use text as a signalling/control channel, e.g. to
-        // give back the actual address that was connected to as per socks
-        // official spec.
-        dbg(msg.channelLabel + ' <--- received TEXT: ' + msg.text);
-        session.sendData(msg.text);
-        // TODO: send socket close when the remote closes. Right now *something*
-        // isn't being closed/cleaned up properly.
       } else {
-        dbgErr('message type isn\'t specified properly. Msg: ' +
-            JSON.stringify(msg));
+        if (!(msg.tag in this.socksSessions)) {
+          dbgErr('unknown datachannel ' + msg.tag);
+          return;
+        }
+        var session = this.socksSessions[msg.tag];
+        session.sendData(msg.data);
       }
     }
 
     /**
-     * Close a particular SOCKS session - data channel pair.
+     * Close a particular SOCKS session.
      */
-    private closeConnection_ = (channel:Channel.CloseData) => {
-      var label = channel.channelId;
-      dbg('datachannel ' + label + ' has closed. ending SOCKS session for channel.');
-      if (!(label in this.socksSessions)) {
-        // This can happen if both peers send disconnection signals at the same
-        // time.
-        dbgWarn('No SOCKs session to close for ' + label);
-        return;
-      }
-      // End SOCKS session.
-      this.socksServer.endSession(this.socksSessions[label]);
-      delete this.socksSessions[label];
+    private closeConnection_ = (tag:string) => {
+      dbg('datachannel ' + tag + ' has closed. ending SOCKS session for channel.');
+      this.socksServer.endSession(this.socksSessions[tag]);
+      delete this.socksSessions[tag];
     }
 
     /**
-     * Send data over SCTP to peer, via data channel |channelLabel|.
+     * Send data over SCTP to peer, via data channel |tag|.
      *
-     * Side note: When PeerConnection encounters a 'new' |channelLabel|, it
+     * Side note: When Transport encounters a 'new' |tag|, it
      * implicitly creates a new data channel.
      */
-    private sendToPeer_ = (channelLabel:string, buffer:ArrayBuffer) => {
-      if (!this.sctpPc) {
-        dbgWarn('SCTP peer connection not ready.');
+    private sendToPeer_ = (tag:string, buffer:ArrayBuffer) => {
+      if (!this.transport) {
+        dbgWarn('transport not ready');
         return;
       }
-      var payload = { channelLabel: channelLabel, 'buffer': buffer };
-      dbg('send ' + buffer.byteLength + ' bytes ' +
-          '-----> ' + channelLabel + ' \n ' + JSON.stringify(payload));
-      this.sctpPc.send(payload);
+      dbg('send ' + buffer.byteLength + ' bytes on datachannel ' + tag);
+      this.transport.send(tag, buffer);
     }
 
     /**
@@ -257,7 +222,7 @@ module SocksToRTC {
       var ret ='<SocksToRTC.Peer: failed toString()>';
       try {
         ret = JSON.stringify({ socksServer: this.socksServer,
-                               sctpPc: this.sctpPc,
+                               transport: this.transport,
                                peerId: this.peerId,
                                signallingChannel: this.signallingChannel,
                                socksSessions: this.socksSessions });
@@ -267,9 +232,8 @@ module SocksToRTC {
 
   }  // SocksToRTC.Peer
 
-
-  // TODO: reuse channelLabels from a pool.
-  function obtainChannelLabel() {
+  // TODO: reuse tag names from a pool.
+  function obtainTag() {
     return 'c' + Math.random();
   }
 

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -44,7 +44,7 @@ module SocksToRTC {
       }
       // SOCKS sessions biject to peerconnection datachannels.
       this.transport = freedom['transport']();
-      this.transport.on('onData', this.replyToSOCKS_);
+      this.transport.on('onData', this.onDataFromPeer);
       this.transport.on('onClose', this.closeConnection_);
       // Messages received via signalling channel must reach the remote peer
       // through something other than the peerconnection. (e.g. XMPP)
@@ -153,7 +153,7 @@ module SocksToRTC {
      * Receive replies proxied back from the remote RtcToNet.Peer and pass them
      * back across underlying SOCKS session / TCP socket.
      */
-    private replyToSOCKS_ = (msg:freedom.Transport.IncomingMessage) => {
+    private onDataFromPeer = (msg:freedom.Transport.IncomingMessage) => {
       dbg(msg.tag + ' <--- received ' + msg.data.byteLength);
       if (!msg.tag) {
         dbgErr('received message without datachannel tag!: ' + JSON.stringify(msg));

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -138,7 +138,7 @@ module SocksToRTC {
           port: port
         };
         var command:Channel.Command = {
-            type: 'NetConnectRequest',
+            type: Channel.COMMANDS.NET_CONNECT_REQUEST,
             tag: tag,
             data: JSON.stringify(request)
         };
@@ -157,7 +157,7 @@ module SocksToRTC {
       session.onRecv((buf) => { this.sendToPeer_(tag, buf); });
       session.onceDisconnected().then(() => {
         var command:Channel.Command = {
-            type: 'SocksDisconnected',
+            type: Channel.COMMANDS.SOCKS_DISCONNECTED,
             tag: tag
         };
         this.transport.send('control', ArrayBuffers.stringToArrayBuffer(
@@ -180,7 +180,7 @@ module SocksToRTC {
         var command:Channel.Command = JSON.parse(
             ArrayBuffers.arrayBufferToString(msg.data));
 
-        if (command.type == 'NetConnectResponse') {
+        if (command.type === Channel.COMMANDS.NET_CONNECT_RESPONSE) {
           // Call the associated callback and forget about it.
           // The callback should fulfill or reject the promise on
           // which the client is waiting, completing the connection flow.
@@ -193,7 +193,7 @@ module SocksToRTC {
             dbgWarn('received connect callback for unknown datachannel: ' +
                 command.tag);
           }
-        } else if (command.type == 'NetDisconnected') {
+        } else if (command.type === Channel.COMMANDS.NET_DISCONNECTED) {
           // Receiving a disconnect on the remote peer should close SOCKS.
           dbg(command.tag + ' <--- received NET-DISCONNECTED');
           this.closeConnectionToPeer(command.tag);

--- a/src/socks-to-rtc/socks.ts
+++ b/src/socks-to-rtc/socks.ts
@@ -263,36 +263,3 @@ module Socks {
   function dbgErr(msg:string) { console.error(modulePrefix_ + msg); }
 
 }  // module Socks
-
-
-module Util {
-
-  /**
-   * Converts an array buffer to a string of hex codes and interpretations as
-   * a char code.
-   *
-   * @param {ArrayBuffer} buf The buffer to convert.
-   */
-  export function getHexStringOfArrayBuffer(buf) {
-    var uInt8Buf = new Uint8Array(buf);
-    var a = [];
-    for (var i = 0; i < buf.byteLength; ++i) {
-      a.push(uInt8Buf[i].toString(16));
-    }
-    return a.join('.');
-  }
-
-  /**
-   * Converts an array buffer to a string.
-   *
-   * @param {ArrayBuffer} buf The buffer to convert.
-   */
-  export function getStringOfArrayBuffer(buf) {
-    var uInt8Buf = new Uint8Array(buf);
-    var a = [];
-    for (var i = 0; i < buf.byteLength; ++i) {
-      a.push(String.fromCharCode(buf[i]));
-    }
-    return a.join('');
-  }
-}


### PR DESCRIPTION
This moves socks-to-rtc and rtc-to-net over to the new transport API. I ran into some issues with message delivery on Chrome 33 (on Linux) that delayed this by a day.

Two caveats:
- The Transport API provider isn't in freedom-runtime-chrome. So, for right now, I've added Freedom as a runtime dependency just to grab the provider. We can get rid of that as soon as we're ready to move to freedom-for-chrome.
- Peerconnection messages had both text and ArrayBuffer fields -- Transport just has an ArrayBuffer. So, for the "commands" (SOCKS-CONNECT, SOCKS-DISCONNECTED, NET-DISCONNECTED) I've taken to sending them on a special "control" datachannel. Those messages aren't typed, and we should review the general asynchronicity-ness of SOCKS <-> RTC <-> NET events some more (especially since we're now establishing the net connection on its own datachannel) but this seems to work quite well (there were already some TODOs concerning asynchronicity...I'll make this a followup commit).

Tested with grunt test and grunt endtoend (UDP still works, too).
