### PR TITLE
jasmine tests and extended array buffers util code

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -64,6 +64,11 @@ module.exports = (grunt) ->
         dest: 'build/'
         options: { base_path: 'src' }
       }
+      commonSpec: {
+        src: ['spec/common/**/*.ts']
+        dest: 'build/spec/'
+        options: { base_path: 'spec' }
+      }
       chromeProviders: {
         src: ['src/chrome-providers/**/*.ts']
         dest: 'build/chrome-app/'
@@ -77,9 +82,14 @@ module.exports = (grunt) ->
     }
 
     jasmine: {
+      common:
+        src: ['build/common/**.js']
+        options : { specs : 'build/spec/common/**/*_spec.js' }
+      # TODO translate tests to TS.
       socksToRtc:
         src: ['build/chrome-app/socks-to-rtc/socks-headers.js']
         options : { specs : 'spec/socks-to-rtc/**/*_spec.js' }
+      # TODO translate tests to TS.
       chromeProvider:
         src: ['build/chrome-app/chrome-providers/chrome-udpsocket.js']
         options : { specs : 'spec/chrome-provider/**/*_spec.js' }
@@ -112,6 +122,7 @@ module.exports = (grunt) ->
     'typescript:socks2rtc'
     'typescript:rtc2net'
     'typescript:common'
+    'typescript:commonSpec'
     'typescript:chromeProviders'
     'typescript:chromeApp'
     'copy:freedom'
@@ -125,6 +136,7 @@ module.exports = (grunt) ->
   # and on Travis/Sauce Labs.
   grunt.registerTask 'test', [
     'build'
+    'jasmine:common'
     'jasmine:socksToRtc'
     'jasmine:chromeProvider'
   ]

--- a/spec/common/arraybuffers_spec.ts
+++ b/spec/common/arraybuffers_spec.ts
@@ -26,7 +26,7 @@ module ArrayBuffers {
     return true;
   }
 
-  describe("ArraBuffers <-> Hex Strings", function() {
+  describe("ArrayBuffers <-> Hex Strings", function() {
     it("arrayBufferEquality: emptyArray == emptyArray", function() {
       expect(arrayBufferEquality(emptyArray, emptyArray)).toBe(true);
     });
@@ -69,7 +69,7 @@ module ArrayBuffers {
   });
 
 
-  describe("ArraBuffers <-> strings", function() {
+  describe("ArrayBuffers <-> strings", function() {
     it("Empty Buffer -> Empty Hex", function() {
       expect(arrayBufferToHexString(emptyArray)).toEqual(emptyString);
     });

--- a/spec/common/arraybuffers_spec.ts
+++ b/spec/common/arraybuffers_spec.ts
@@ -1,0 +1,103 @@
+/// <reference path='../../third_party/DefinitelyTyped/jasmine/jasmine.d.ts' />
+/// <reference path='../../src/interfaces/arraybuffers.d.ts' />
+
+module ArrayBuffers {
+
+  var array1 = new Uint8Array([12,118,101,114,105,115]);
+  var string1 = '\x0C\x76\x65\x72\x69\x73';
+  var hexString1 = 'c.76.65.72.69.73';
+
+  var array2 = new Uint8Array([0,2,129,128,0,1,0,5,0]);
+  var string2 = '\x00\x02\x81\x80\x00\x01\x00\x05\x00';
+  var hexString2 = '0.2.81.80.0.1.0.5.0';
+
+  var emptyArray = new Uint8Array([]);
+  var emptyString = '';
+  var emptyHexString = '';
+
+  // Aux helper function for buffer equality by byte-value comparison.
+  function arrayBufferEquality(b1 :ArrayBuffer, b2 :ArrayBuffer) {
+    var a1 = new Uint8Array(b1);
+    var a2 = new Uint8Array(b2);
+    if(a1.byteLength !== a2.byteLength) return false;
+    for(var i:number = 0; i < a1.byteLength; ++i) {
+      if(a1[i] !== a2[i]) return false;
+    }
+    return true;
+  }
+
+  describe("ArraBuffers <-> Hex Strings", function() {
+    it("arrayBufferEquality: emptyArray == emptyArray", function() {
+      expect(arrayBufferEquality(emptyArray, emptyArray)).toBe(true);
+    });
+    it("arrayBufferEquality: array1 == array1", function() {
+      expect(arrayBufferEquality(array1, array1)).toBe(true);
+    });
+    it("arrayBufferEquality: array1 != emptyArray", function() {
+      expect(arrayBufferEquality(array1, emptyArray)).toBe(false);
+    });
+    it("arrayBufferEquality: array1 != array2", function() {
+      expect(arrayBufferEquality(array1, array2)).toBe(false);
+    });
+
+    it("Empty Buffer -> Empty Hex", function() {
+      expect(arrayBufferToHexString(emptyArray)).toEqual(emptyHexString);
+    });
+    it("Empty Hex -> Empty Buffer", function() {
+      expect(arrayBufferEquality(hexStringToArrayBuffer(emptyHexString),
+                                 emptyArray)).toBe(true);
+    });
+
+    it("Buffer -> Hex", function() {
+      expect(arrayBufferToHexString(emptyArray)).toEqual(emptyString);
+      expect(arrayBufferToHexString(array1)).toEqual(hexString1);
+      expect(arrayBufferToHexString(array2)).toEqual(hexString2);
+    });
+
+    it("Hex -> Buffer -> Hex = identity", function() {
+      expect(arrayBufferToHexString(hexStringToArrayBuffer(emptyString)))
+          .toEqual(emptyString);
+      expect(arrayBufferToHexString(hexStringToArrayBuffer(emptyString)))
+          .not.toEqual(hexString1);
+      expect(arrayBufferToHexString(hexStringToArrayBuffer(hexString1)))
+          .toEqual(hexString1);
+      expect(arrayBufferToHexString(hexStringToArrayBuffer(hexString2)))
+          .toEqual(hexString2);
+      expect(arrayBufferToHexString(hexStringToArrayBuffer(hexString1)))
+          .not.toEqual(hexString2);
+    });
+  });
+
+
+  describe("ArraBuffers <-> strings", function() {
+    it("Empty Buffer -> Empty Hex", function() {
+      expect(arrayBufferToHexString(emptyArray)).toEqual(emptyString);
+    });
+    it("Empty Hex -> Empty Buffer", function() {
+      expect(arrayBufferEquality(hexStringToArrayBuffer(emptyString),
+                                 emptyArray)).toBe(true);
+    });
+
+    it("Buffer -> String", function() {
+      expect(arrayBufferToHexString(emptyArray)).toEqual(emptyString);
+      expect(arrayBufferToHexString(array1)).toEqual(hexString1);
+      expect(arrayBufferToHexString(array1)).not.toEqual(hexString2);
+      expect(arrayBufferToHexString(array2)).toEqual(hexString2);
+    });
+
+    it("String -> Buffer -> String = identity", function() {
+      expect(arrayBufferToString(stringToArrayBuffer(emptyString)))
+          .toEqual(emptyString);
+      expect(arrayBufferToString(stringToArrayBuffer(emptyString)))
+          .not.toEqual(hexString1);
+      expect(arrayBufferToString(stringToArrayBuffer(string1)))
+          .toEqual(string1);
+      expect(arrayBufferToString(stringToArrayBuffer(string2)))
+          .toEqual(string2);
+      expect(arrayBufferToString(stringToArrayBuffer(string1)))
+          .not.toEqual(string2);
+    });
+  });
+
+
+}  // module ArrayBuffers

--- a/src/common/arraybuffers.ts
+++ b/src/common/arraybuffers.ts
@@ -41,4 +41,20 @@ module ArrayBuffers {
     }
     return a.join('.');
   }
+
+  /**
+   * Converts an HexString of the form /(hh\.)*hh/ where h is a hex-character
+   * to an ArrayBuffer.
+   *
+   * @param {string} hexString The hexString to convert.
+   */
+  export function hexStringToArrayBuffer(hexString:string) : ArrayBuffer {
+    var hexChars = hexString.split('.');
+    var buffer = new ArrayBuffer(hexChars.length);
+    var bytes = new Uint8Array(buffer);
+    for (var i = 0; i < hexChars.length; ++i) {
+        bytes[i] = parseInt('0x' + hexChars[i]);
+    }
+    return buffer;
+  }
 }

--- a/src/common/arraybuffers.ts
+++ b/src/common/arraybuffers.ts
@@ -43,12 +43,13 @@ module ArrayBuffers {
   }
 
   /**
-   * Converts an HexString of the form /(hh\.)*hh/ where h is a hex-character
-   * to an ArrayBuffer.
+   * Converts a HexString of the regexp form /(hh\.)*hh/ where `h` is a
+   * hex-character to an ArrayBuffer.
    *
    * @param {string} hexString The hexString to convert.
    */
   export function hexStringToArrayBuffer(hexString:string) : ArrayBuffer {
+    if(hexString === '') { return new ArrayBuffer(0); }
     var hexChars = hexString.split('.');
     var buffer = new ArrayBuffer(hexChars.length);
     var bytes = new Uint8Array(buffer);

--- a/src/interfaces/arraybuffers.d.ts
+++ b/src/interfaces/arraybuffers.d.ts
@@ -1,0 +1,28 @@
+declare module ArrayBuffers {
+    /**
+    * Converts an ArrayBuffer to a string.
+    *
+    * @param {ArrayBuffer} buffer The buffer to convert.
+    */
+    function arrayBufferToString(buffer: ArrayBuffer): string;
+    /**
+    * Converts a string to an ArrayBuffer.
+    *
+    * @param {string} s The string to convert.
+    */
+    function stringToArrayBuffer(s: string): ArrayBuffer;
+    /**
+    * Converts an ArrayBuffer to a string of hex codes and interpretations as
+    * a char code.
+    *
+    * @param {ArrayBuffer} buffer The buffer to convert.
+    */
+    function arrayBufferToHexString(buffer: ArrayBuffer): string;
+    /**
+    * Converts a HexString of the regexp form /(hh\.)*hh/ where `h` is a
+    * hex-character to an ArrayBuffer.
+    *
+    * @param {string} hexString The hexString to convert.
+    */
+    function hexStringToArrayBuffer(hexString: string): ArrayBuffer;
+}

--- a/third_party/DefinitelyTyped/jasmine/jasmine-1.3-tests.ts
+++ b/third_party/DefinitelyTyped/jasmine/jasmine-1.3-tests.ts
@@ -1,0 +1,449 @@
+/// <reference path="jasmine-1.3.d.ts" />
+
+describe("A suite", () => {
+    it("contains spec with an expectation", () => {
+        expect(true).toBe(true);
+    });
+});
+
+describe("A suite is just a function", () => {
+    var a: boolean;
+    it("and so is a spec", () => {
+        a = true;
+        expect(a).toBe(true);
+    });
+});
+
+describe("The 'toBe' matcher compares with ===", () => {
+    it("and has a positive case ", () => {
+        expect(true).toBe(true);
+    });
+    it("and can have a negative case", () => {
+        expect(false).not.toBe(true);
+    });
+});
+
+describe("Included matchers:", () => {
+    it("The 'toBe' matcher compares with ===", () => {
+        var a = 12;
+        var b = a;
+        expect(a).toBe(b);
+        expect(a).not.toBe(null);
+    });
+    describe("The 'toEqual' matcher", () => {
+        it("works for simple literals and variables", () => {
+            var a = 12;
+            expect(a).toEqual(12);
+        });
+        it("should work for objects", () => {
+            var foo = {
+                a: 12,
+                b: 34
+            };
+            var bar = {
+                a: 12,
+                b: 34
+            };
+            expect(foo).toEqual(bar);
+        });
+    });
+
+    it("The 'toMatch' matcher is for regular expressions", () => {
+        var message = 'foo bar baz';
+        expect(message).toMatch(/bar/);
+        expect(message).toMatch('bar');
+        expect(message).not.toMatch(/quux/);
+    });
+
+    it("The 'toBeDefined' matcher compares against `undefined`", () => {
+        var a = {
+            foo: 'foo'
+        };
+        expect(a.foo).toBeDefined();
+        expect((<any>a).bar).not.toBeDefined();
+    });
+
+    it("The `toBeUndefined` matcher compares against `undefined`", () => {
+        var a = {
+            foo: 'foo'
+        };
+        expect(a.foo).not.toBeUndefined();
+        expect((<any>a).bar).toBeUndefined();
+    });
+
+    it("The 'toBeNull' matcher compares against null", () => {
+        var a: string = null;
+        var foo = 'foo';
+        expect(null).toBeNull();
+        expect(a).toBeNull();
+        expect(foo).not.toBeNull();
+    });
+
+    it("The 'toBeTruthy' matcher is for boolean casting testing", () => {
+      var a: string, foo = 'foo';
+        expect(foo).toBeTruthy();
+        expect(a).not.toBeTruthy();
+    });
+
+    it("The 'toBeFalsy' matcher is for boolean casting testing", () => {
+      var a: string, foo = 'foo';
+        expect(a).toBeFalsy();
+        expect(foo).not.toBeFalsy();
+    });
+
+    it("The 'toContain' matcher is for finding an item in an Array", () => {
+        var a = ['foo', 'bar', 'baz'];
+        expect(a).toContain('bar');
+        expect(a).not.toContain('quux');
+    });
+
+    it("The 'toBeLessThan' matcher is for mathematical comparisons", () => {
+      var pi = 3.1415926, e = 2.78;
+        expect(e).toBeLessThan(pi);
+        expect(pi).not.toBeLessThan(e);
+    });
+
+    it("The 'toBeGreaterThan' is for mathematical comparisons", () => {
+      var pi = 3.1415926, e = 2.78;
+        expect(pi).toBeGreaterThan(e);
+        expect(e).not.toBeGreaterThan(pi);
+    });
+
+    it("The 'toBeCloseTo' matcher is for precision math comparison", () => {
+      var pi = 3.1415926, e = 2.78;
+        expect(pi).not.toBeCloseTo(e, 0.1);
+        expect(pi).toBeCloseTo(e, 0);
+    });
+
+    it("The 'toThrow' matcher is for testing if a function throws an exception", () => {
+        var foo = () => {
+            return 1 + 2;
+        };
+        var bar = () => {
+            //return a + 1;
+        };
+        expect(foo).not.toThrow();
+        expect(bar).toThrow();
+    });
+});
+
+describe("A spec", () => {
+    it("is just a function, so it can contain any code", () => {
+        var foo = 0;
+        foo += 1;
+        expect(foo).toEqual(1);
+    });
+
+    it("can have more than one expectation", () => {
+        var foo = 0;
+        foo += 1;
+        expect(foo).toEqual(1);
+        expect(true).toEqual(true);
+    });
+});
+
+describe("A spec (with setup and tear-down)", () => {
+    var foo: number;
+    beforeEach(() => {
+        foo = 0;
+        foo += 1;
+    });
+    afterEach(() => {
+        foo = 0;
+    });
+    it("is just a function, so it can contain any code", () => {
+        expect(foo).toEqual(1);
+    });
+    it("can have more than one expectation", () => {
+        expect(foo).toEqual(1);
+        expect(true).toEqual(true);
+    });
+});
+
+describe("A spec", () => {
+    var foo: number;
+    beforeEach(() => {
+        foo = 0;
+        foo += 1;
+    });
+    afterEach(() => {
+        foo = 0;
+    });
+    it("is just a function, so it can contain any code", () => {
+        expect(foo).toEqual(1);
+    });
+    it("can have more than one expectation", () => {
+        expect(foo).toEqual(1);
+        expect(true).toEqual(true);
+    });
+    describe("nested inside a second describe", () => {
+        var bar: number;
+        beforeEach(() => {
+            bar = 1;
+        });
+        it("can reference both scopes as needed ", () => {
+            expect(foo).toEqual(bar);
+        });
+    });
+});
+
+xdescribe("A spec", () => {
+    var foo: number;
+    beforeEach(() => {
+        foo = 0;
+        foo += 1;
+    });
+    xit("is just a function, so it can contain any code", () => {
+        expect(foo).toEqual(1);
+    });
+});
+
+describe("A spy", () => {
+  var foo: any, bar: any = null;
+    beforeEach(() => {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            }
+        };
+        spyOn(foo, 'setBar');
+        foo.setBar(123);
+        foo.setBar(456, 'another param');
+    });
+    it("tracks that the spy was called", () => {
+        expect(foo.setBar).toHaveBeenCalled();
+    });
+    it("tracks its number of calls", () => {
+        expect(foo.setBar.calls.length).toEqual(2);
+    });
+    it("tracks all the arguments of its calls", () => {
+        expect(foo.setBar).toHaveBeenCalledWith(123);
+        expect(foo.setBar).toHaveBeenCalledWith(456, 'another param');
+    });
+    it("allows access to the most recent call", () => {
+        expect(foo.setBar.mostRecentCall.args[0]).toEqual(456);
+    });
+    it("allows access to other calls", () => {
+        expect(foo.setBar.calls[0].args[0]).toEqual(123);
+    });
+    it("stops all execution on a function", () => {
+        expect(bar).toBeNull();
+    });
+});
+
+describe("A spy, when configured to call through", () => {
+  var foo: any, bar: any, fetchedBar: any;
+    beforeEach(() => {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            },
+            getBar: () => {
+                return bar;
+            }
+        };
+        spyOn(foo, 'getBar').andCallThrough();
+        foo.setBar(123);
+        fetchedBar = foo.getBar();
+    });
+    it("tracks that the spy was called", () => {
+        expect(foo.getBar).toHaveBeenCalled();
+    });
+    it("should not effect other functions", () => {
+        expect(bar).toEqual(123);
+    });
+    it("when called returns the requested value", () => {
+        expect(fetchedBar).toEqual(123);
+    });
+});
+
+describe("A spy, when faking a return value", () => {
+  var foo: any, bar: any, fetchedBar: any;
+    beforeEach(() => {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            },
+            getBar: () => {
+                return bar;
+            }
+        };
+        spyOn(foo, 'getBar').andReturn(745);
+        foo.setBar(123);
+        fetchedBar = foo.getBar();
+    });
+    it("tracks that the spy was called", () => {
+        expect(foo.getBar).toHaveBeenCalled();
+    });
+    it("should not effect other functions", () => {
+        expect(bar).toEqual(123);
+    });
+    it("when called returns the requested value", () => {
+        expect(fetchedBar).toEqual(745);
+    });
+});
+
+describe("A spy, when faking a return value", () => {
+  var foo: any, bar: any, fetchedBar: any;
+    beforeEach(() => {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            },
+            getBar: () => {
+                return bar;
+            }
+        };
+        spyOn(foo, 'getBar').andCallFake(() => {
+            return 1001;
+        });
+        foo.setBar(123);
+        fetchedBar = foo.getBar();
+    });
+    it("tracks that the spy was called", () => {
+        expect(foo.getBar).toHaveBeenCalled();
+    });
+    it("should not effect other functions", () => {
+        expect(bar).toEqual(123);
+    });
+    it("when called returns the requested value", () => {
+        expect(fetchedBar).toEqual(1001);
+    });
+});
+
+describe("A spy, when created manually", () => {
+    var whatAmI: any;
+
+    beforeEach(() => {
+        whatAmI = jasmine.createSpy('whatAmI');
+        whatAmI("I", "am", "a", "spy");
+    });
+    it("is named, which helps in error reporting", () => {
+        expect(whatAmI.identity).toEqual('whatAmI')
+    });
+    it("tracks that the spy was called", () => {
+        expect(whatAmI).toHaveBeenCalled();
+    });
+    it("tracks its number of calls", () => {
+        expect(whatAmI.calls.length).toEqual(1);
+    });
+    it("tracks all the arguments of its calls", () => {
+        expect(whatAmI).toHaveBeenCalledWith("I", "am", "a", "spy");
+    });
+    it("allows access to the most recent call", () => {
+        expect(whatAmI.mostRecentCall.args[0]).toEqual("I");
+    });
+});
+
+describe("Multiple spies, when created manually", () => {
+    var tape: any;
+    beforeEach(() => {
+        tape = jasmine.createSpyObj('tape', ['play', 'pause', 'stop', 'rewind']);
+        tape.play();
+        tape.pause();
+        tape.rewind(0);
+    });
+    it("creates spies for each requested function", () => {
+        expect(tape.play).toBeDefined();
+        expect(tape.pause).toBeDefined();
+        expect(tape.stop).toBeDefined();
+        expect(tape.rewind).toBeDefined();
+    });
+    it("tracks that the spies were called", () => {
+        expect(tape.play).toHaveBeenCalled();
+        expect(tape.pause).toHaveBeenCalled();
+        expect(tape.rewind).toHaveBeenCalled();
+        expect(tape.stop).not.toHaveBeenCalled();
+    });
+    it("tracks all the arguments of its calls", () => {
+        expect(tape.rewind).toHaveBeenCalledWith(0);
+    });
+});
+
+describe("jasmine.any", () => {
+    it("matches any value", () => {
+        expect({}).toEqual(jasmine.any(Object));
+        expect(12).toEqual(jasmine.any(Number));
+    });
+    describe("when used with a spy", () => {
+        it("is useful for comparing arguments", () => {
+            var foo = jasmine.createSpy('foo');
+            foo(12, () => {
+                return true
+            });
+            expect(foo).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Function));
+        });
+    });
+});
+
+describe("Manually ticking the Jasmine Mock Clock", () => {
+    var timerCallback: any;
+    beforeEach(() => {
+        timerCallback = jasmine.createSpy('timerCallback');
+        jasmine.Clock.useMock();
+    });
+    it("causes a timeout to be called synchronously", () => {
+        setTimeout(() => {
+            timerCallback();
+        }, 100);
+        expect(timerCallback).not.toHaveBeenCalled();
+        jasmine.Clock.tick(101);
+        expect(timerCallback).toHaveBeenCalled();
+    });
+
+    it("causes an interval to be called synchronously", () => {
+        setInterval(() => {
+            timerCallback();
+        }, 100);
+        expect(timerCallback).not.toHaveBeenCalled();
+        jasmine.Clock.tick(101);
+        expect(timerCallback.callCount).toEqual(1);
+        jasmine.Clock.tick(50);
+        expect(timerCallback.callCount).toEqual(1);
+        jasmine.Clock.tick(50);
+        expect(timerCallback.callCount).toEqual(2);
+    });
+});
+
+describe("Asynchronous specs", () => {
+  var value: number, flag: any;
+    it("should support async execution of test preparation and exepectations", () => {
+        runs(() => {
+            flag = false;
+            value = 0;
+            setTimeout(() => {
+                flag = true;
+            }, 500);
+        });
+        waitsFor(() => {
+            value++;
+            return flag;
+        }, "The Value should be incremented", 750);
+        runs(() => {
+            expect(value).toBeGreaterThan(0);
+        });
+    });
+});
+
+(() => {
+    var jasmineEnv = jasmine.getEnv();
+    jasmineEnv.updateInterval = 250;
+    var htmlReporter = new jasmine.HtmlReporter();
+    jasmineEnv.addReporter(htmlReporter);
+    jasmineEnv.specFilter = function (spec) {
+        return htmlReporter.specFilter(spec);
+    };
+    var currentWindowOnload = window.onload;
+    window.onload = () => {
+        if (currentWindowOnload) {
+            currentWindowOnload(null);
+        }
+
+        (<HTMLElement>document.querySelector('.version')).innerHTML = jasmineEnv.versionString();
+        execJasmine();
+    };
+
+    function execJasmine() {
+        jasmineEnv.execute();
+    }
+})();

--- a/third_party/DefinitelyTyped/jasmine/jasmine-1.3.d.ts
+++ b/third_party/DefinitelyTyped/jasmine/jasmine-1.3.d.ts
@@ -1,0 +1,392 @@
+// Type definitions for Jasmine 1.3
+// Project: http://pivotal.github.com/jasmine/
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>
+// DefinitelyTyped: https://github.com/borisyankov/DefinitelyTyped
+
+
+declare function describe(description: string, specDefinitions: () => void): void;
+declare function xdescribe(description: string, specDefinitions: () => void): void;
+
+declare function it(expectation: string, assertion: () => void): void;
+declare function it(expectation: string, assertion: (done: (err?: any) => void) => void): void;
+declare function xit(expectation: string, assertion: () => void): void;
+
+declare function beforeEach(action: () => void): void;
+declare function afterEach(action: () => void): void;
+
+declare function expect(spy: Function): jasmine.Matchers;
+//declare function expect(spy: jasmine.Spy): jasmine.Matchers;
+declare function expect(actual: any): jasmine.Matchers;
+
+declare function spyOn(object: any, method: string): jasmine.Spy;
+
+declare function runs(asyncMethod: Function): void;
+declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;
+declare function waits(timeout?: number): void;
+
+declare module jasmine {
+
+    var Clock: Clock;
+
+    function any(aclass: any): Any;
+    function objectContaining(sample: any): ObjectContaining;
+    function createSpy(name: string, originalFn?: Function): Spy;
+    function createSpyObj(baseName: string, methodNames: any[]): any;
+    function createSpyObj<T>(baseName: string, methodNames: any[]): T;
+    function pp(value: any): string;
+    function getEnv(): Env;
+
+    interface Any {
+
+        new (expectedClass: any): any;
+
+        jasmineMatches(other: any): boolean;
+        jasmineToString(): string;
+    }
+
+    interface ObjectContaining {
+        new (sample: any): any;
+
+        jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;
+        jasmineToString(): string;
+    }
+
+    interface Block {
+
+        new (env: Env, func: SpecFunction, spec: Spec): any;
+
+        execute(onComplete: () => void): void;
+    }
+
+    interface WaitsBlock extends Block {
+        new (env: Env, timeout: number, spec: Spec): any;
+    }
+
+    interface WaitsForBlock extends Block {
+        new (env: Env, timeout: number, latchFunction: SpecFunction, message: string, spec: Spec): any;
+    }
+
+    interface Clock {
+        reset(): void;
+        tick(millis: number): void;
+        runFunctionsWithinRange(oldMillis: number, nowMillis: number): void;
+        scheduleFunction(timeoutKey: any, funcToCall: () => void, millis: number, recurring: boolean): void;
+        useMock(): void;
+        installMock(): void;
+        uninstallMock(): void;
+        real: void;
+        assertInstalled(): void;
+        isInstalled(): boolean;
+        installed: any;
+    }
+
+    interface Env {
+        setTimeout: any;
+        clearTimeout: void;
+        setInterval: any;
+        clearInterval: void;
+        updateInterval: number;
+
+        currentSpec: Spec;
+
+        matchersClass: Matchers;
+
+        version(): any;
+        versionString(): string;
+        nextSpecId(): number;
+        addReporter(reporter: Reporter): void;
+        execute(): void;
+        describe(description: string, specDefinitions: () => void): Suite;
+        beforeEach(beforeEachFunction: () => void): void;
+        currentRunner(): Runner;
+        afterEach(afterEachFunction: () => void): void;
+        xdescribe(desc: string, specDefinitions: () => void): XSuite;
+        it(description: string, func: () => void): Spec;
+        xit(desc: string, func: () => void): XSpec;
+        compareRegExps_(a: RegExp, b: RegExp, mismatchKeys: string[], mismatchValues: string[]): boolean;
+        compareObjects_(a: any, b: any, mismatchKeys: string[], mismatchValues: string[]): boolean;
+        equals_(a: any, b: any, mismatchKeys: string[], mismatchValues: string[]): boolean;
+        contains_(haystack: any, needle: any): boolean;
+        addEqualityTester(equalityTester: (a: any, b: any, env: Env, mismatchKeys: string[], mismatchValues: string[]) => boolean): void;
+        specFilter(spec: Spec): boolean;
+    }
+
+    interface FakeTimer {
+
+        new (): any;
+
+        reset(): void;
+        tick(millis: number): void;
+        runFunctionsWithinRange(oldMillis: number, nowMillis: number): void;
+        scheduleFunction(timeoutKey: any, funcToCall: () => void, millis: number, recurring: boolean): void;
+    }
+
+    interface HtmlReporter {
+        new (): any;
+    }
+
+    interface Result {
+        type: string;
+    }
+
+    interface NestedResults extends Result {
+        description: string;
+
+        totalCount: number;
+        passedCount: number;
+        failedCount: number;
+
+        skipped: boolean;
+
+        rollupCounts(result: NestedResults): void;
+        log(values: any): void;
+        getItems(): Result[];
+        addResult(result: Result): void;
+        passed(): boolean;
+    }
+
+    interface MessageResult extends Result  {
+        values: any;
+        trace: Trace;
+    }
+
+    interface ExpectationResult extends Result  {
+        matcherName: string;
+        passed(): boolean;
+        expected: any;
+        actual: any;
+        message: string;
+        trace: Trace;
+    }
+
+    interface Trace {
+        name: string;
+        message: string;
+        stack: any;
+    }
+
+    interface PrettyPrinter {
+
+        new (): any;
+
+        format(value: any): void;
+        iterateObject(obj: any, fn: (property: string, isGetter: boolean) => void): void;
+        emitScalar(value: any): void;
+        emitString(value: string): void;
+        emitArray(array: any[]): void;
+        emitObject(obj: any): void;
+        append(value: any): void;
+    }
+
+    interface StringPrettyPrinter extends PrettyPrinter {
+    }
+
+    interface Queue {
+
+        new (env: any): any;
+
+        env: Env;
+        ensured: boolean[];
+        blocks: Block[];
+        running: boolean;
+        index: number;
+        offset: number;
+        abort: boolean;
+
+        addBefore(block: Block, ensure?: boolean): void;
+        add(block: any, ensure?: boolean): void;
+        insertNext(block: any, ensure?: boolean): void;
+        start(onComplete?: () => void): void;
+        isRunning(): boolean;
+        next_(): void;
+        results(): NestedResults;
+    }
+
+    interface Matchers {
+
+        new (env: Env, actual: any, spec: Env, isNot?: boolean): any;
+
+        env: Env;
+        actual: any;
+        spec: Env;
+        isNot?: boolean;
+        message(): any;
+
+        toBe(expected: any): boolean;
+        toNotBe(expected: any): boolean;
+        toEqual(expected: any): boolean;
+        toNotEqual(expected: any): boolean;
+        toMatch(expected: any): boolean;
+        toNotMatch(expected: any): boolean;
+        toBeDefined(): boolean;
+        toBeUndefined(): boolean;
+        toBeNull(): boolean;
+        toBeNaN(): boolean;
+        toBeTruthy(): boolean;
+        toBeFalsy(): boolean;
+        toHaveBeenCalled(): boolean;
+        wasNotCalled(): boolean;
+        toHaveBeenCalledWith(...params: any[]): boolean;
+        toContain(expected: any): boolean;
+        toNotContain(expected: any): boolean;
+        toBeLessThan(expected: any): boolean;
+        toBeGreaterThan(expected: any): boolean;
+        toBeCloseTo(expected: any, precision: any): boolean;
+        toContainHtml(expected: string): boolean;
+        toContainText(expected: string): boolean;
+        toThrow(expected?: any): boolean;
+        not: Matchers;
+
+        Any: Any;
+    }
+
+    interface Reporter {
+        reportRunnerStarting(runner: Runner): void;
+        reportRunnerResults(runner: Runner): void;
+        reportSuiteResults(suite: Suite): void;
+        reportSpecStarting(spec: Spec): void;
+        reportSpecResults(spec: Spec): void;
+        log(str: string): void;
+    }
+
+    interface MultiReporter extends Reporter {
+        addReporter(reporter: Reporter): void;
+    }
+
+    interface Runner {
+
+        new (env: Env): any;
+
+        execute(): void;
+        beforeEach(beforeEachFunction: SpecFunction): void;
+        afterEach(afterEachFunction: SpecFunction): void;
+        finishCallback(): void;
+        addSuite(suite: Suite): void;
+        add(block: Block): void;
+        specs(): Spec[];
+        suites(): Suite[];
+        topLevelSuites(): Suite[];
+        results(): NestedResults;
+    }
+
+    interface SpecFunction {
+        (spec?: Spec): void;
+    }
+
+    interface SuiteOrSpec {
+        id: number;
+        env: Env;
+        description: string;
+        queue: Queue;
+    }
+
+    interface Spec extends SuiteOrSpec {
+
+        new (env: Env, suite: Suite, description: string): any;
+
+        suite: Suite;
+
+        afterCallbacks: SpecFunction[];
+        spies_: Spy[];
+
+        results_: NestedResults;
+        matchersClass: Matchers;
+
+        getFullName(): string;
+        results(): NestedResults;
+        log(arguments: any): any;
+        runs(func: SpecFunction): Spec;
+        addToQueue(block: Block): void;
+        addMatcherResult(result: Result): void;
+        expect(actual: any): any;
+        waits(timeout: number): Spec;
+        waitsFor(latchFunction: SpecFunction, timeoutMessage?: string, timeout?: number): Spec;
+        fail(e?: any): void;
+        getMatchersClass_(): Matchers;
+        addMatchers(matchersPrototype: any): void;
+        finishCallback(): void;
+        finish(onComplete?: () => void): void;
+        after(doAfter: SpecFunction): void;
+        execute(onComplete?: () => void): any;
+        addBeforesAndAftersToQueue(): void;
+        explodes(): void;
+        spyOn(obj: any, methodName: string, ignoreMethodDoesntExist: boolean): Spy;
+        removeAllSpies(): void;
+    }
+
+    interface XSpec {
+        id: number;
+        runs(): void;
+    }
+
+    interface Suite extends SuiteOrSpec {
+
+        new (env: Env, description: string, specDefinitions: () => void, parentSuite: Suite): any;
+
+        parentSuite: Suite;
+
+        getFullName(): string;
+        finish(onComplete?: () => void): void;
+        beforeEach(beforeEachFunction: SpecFunction): void;
+        afterEach(afterEachFunction: SpecFunction): void;
+        results(): NestedResults;
+        add(suiteOrSpec: SuiteOrSpec): void;
+        specs(): Spec[];
+        suites(): Suite[];
+        children(): any[];
+        execute(onComplete?: () => void): void;
+    }
+
+    interface XSuite {
+        execute(): void;
+    }
+
+    interface Spy {
+        (...params: any[]): any;
+
+        identity: string;
+        calls: any[];
+        mostRecentCall: { args: any[]; };
+        argsForCall: any[];
+        wasCalled: boolean;
+        callCount: number;
+
+        andReturn(value: any): Spy;
+        andCallThrough(): Spy;
+        andCallFake(fakeFunc: Function): Spy;
+    }
+
+    interface Util {
+        inherit(childClass: Function, parentClass: Function): any;
+        formatException(e: any): any;
+        htmlEscape(str: string): string;
+        argsToArray(args: any): any;
+        extend(destination: any, source: any): any;
+    }
+
+    interface JsApiReporter extends Reporter {
+
+        started: boolean;
+        finished: boolean;
+        result: any;
+        messages: any;
+
+        new (): any;
+
+        suites(): Suite[];
+        summarize_(suiteOrSpec: SuiteOrSpec): any;
+        results(): any;
+        resultsForSpec(specId: any): any;
+        log(str: any): any;
+        resultsForSpecs(specIds: any): any;
+        summarizeResult_(result: any): any;
+    }
+
+    interface Jasmine {
+        Spec: Spec;
+        Clock: Clock;
+        util: Util;
+    }
+
+    export var HtmlReporter: any;
+}

--- a/third_party/DefinitelyTyped/jasmine/jasmine-tests.ts
+++ b/third_party/DefinitelyTyped/jasmine/jasmine-tests.ts
@@ -1,0 +1,700 @@
+/// <reference path="jasmine.d.ts" />
+
+// tests based on http://jasmine.github.io/2.0/introduction.html
+
+describe("A suite", function () {
+    it("contains spec with an expectation", function () {
+        expect(true).toBe(true);
+    });
+});
+
+describe("A suite is just a function", function () {
+    var a: boolean;
+
+    it("and so is a spec", function () {
+        a = true;
+        expect(a).toBe(true);
+    });
+});
+
+describe("The 'toBe' matcher compares with ===", function () {
+
+    it("and has a positive case", function () {
+        expect(true).toBe(true);
+    });
+
+    it("and can have a negative case", function () {
+        expect(false).not.toBe(true);
+    });
+});
+
+describe("Included matchers:", function () {
+
+    it("The 'toBe' matcher compares with ===", function () {
+        var a = 12;
+        var b = a;
+
+        expect(a).toBe(b);
+        expect(a).not.toBe(null);
+    });
+
+    describe("The 'toEqual' matcher", function () {
+
+        it("works for simple literals and variables", function () {
+            var a = 12;
+            expect(a).toEqual(12);
+        });
+
+        it("should work for objects", function () {
+            var foo = {
+                a: 12,
+                b: 34
+            };
+            var bar = {
+                a: 12,
+                b: 34
+            };
+            expect(foo).toEqual(bar);
+        });
+    });
+
+    it("The 'toMatch' matcher is for regular expressions", function () {
+        var message = "foo bar baz";
+
+        expect(message).toMatch(/bar/);
+        expect(message).toMatch("bar");
+        expect(message).not.toMatch(/quux/);
+    });
+
+    it("The 'toBeDefined' matcher compares against `undefined`", function () {
+        var a = {
+            foo: "foo"
+        };
+
+        expect(a.foo).toBeDefined();
+        expect((<any>a).bar).not.toBeDefined();
+    });
+
+    it("The `toBeUndefined` matcher compares against `undefined`", function () {
+        var a = {
+            foo: "foo"
+        };
+
+        expect(a.foo).not.toBeUndefined();
+        expect((<any>a).bar).toBeUndefined();
+    });
+
+    it("The 'toBeNull' matcher compares against null", function () {
+        var a: string = null;
+        var foo = "foo";
+
+        expect(null).toBeNull();
+        expect(a).toBeNull();
+        expect(foo).not.toBeNull();
+    });
+
+    it("The 'toBeTruthy' matcher is for boolean casting testing", function () {
+        var a: string, foo = "foo";
+
+        expect(foo).toBeTruthy();
+        expect(a).not.toBeTruthy();
+    });
+
+    it("The 'toBeFalsy' matcher is for boolean casting testing", function () {
+        var a: string, foo = "foo";
+
+        expect(a).toBeFalsy();
+        expect(foo).not.toBeFalsy();
+    });
+
+    it("The 'toContain' matcher is for finding an item in an Array", function () {
+        var a = ["foo", "bar", "baz"];
+
+        expect(a).toContain("bar");
+        expect(a).not.toContain("quux");
+    });
+
+    it("The 'toBeLessThan' matcher is for mathematical comparisons", function () {
+        var pi = 3.1415926,
+            e = 2.78;
+
+        expect(e).toBeLessThan(pi);
+        expect(pi).not.toBeLessThan(e);
+    });
+
+    it("The 'toBeGreaterThan' is for mathematical comparisons", function () {
+        var pi = 3.1415926,
+            e = 2.78;
+
+        expect(pi).toBeGreaterThan(e);
+        expect(e).not.toBeGreaterThan(pi);
+    });
+
+    it("The 'toBeCloseTo' matcher is for precision math comparison", function () {
+        var pi = 3.1415926,
+            e = 2.78;
+
+        expect(pi).not.toBeCloseTo(e, 2);
+        expect(pi).toBeCloseTo(e, 0);
+    });
+
+    it("The 'toThrow' matcher is for testing if a function throws an exception", function () {
+        var foo = function () {
+            return 1 + 2;
+        };
+        var bar = function () {
+            var a: any = undefined;
+            return a + 1;
+        };
+
+        expect(foo).not.toThrow();
+        expect(bar).toThrow();
+    });
+});
+
+describe("A spec", function () {
+    it("is just a function, so it can contain any code", function () {
+        var foo = 0;
+        foo += 1;
+
+        expect(foo).toEqual(1);
+    });
+
+    it("can have more than one expectation", function () {
+        var foo = 0;
+        foo += 1;
+
+        expect(foo).toEqual(1);
+        expect(true).toEqual(true);
+    });
+});
+
+describe("A spec (with setup and tear-down)", function () {
+    var foo: number;
+
+    beforeEach(function () {
+        foo = 0;
+        foo += 1;
+    });
+
+    afterEach(function () {
+        foo = 0;
+    });
+
+    it("is just a function, so it can contain any code", function () {
+        expect(foo).toEqual(1);
+    });
+
+    it("can have more than one expectation", function () {
+        expect(foo).toEqual(1);
+        expect(true).toEqual(true);
+    });
+});
+
+describe("A spec", function () {
+    var foo: number;
+
+    beforeEach(function () {
+        foo = 0;
+        foo += 1;
+    });
+
+    afterEach(function () {
+        foo = 0;
+    });
+
+    it("is just a function, so it can contain any code", function () {
+        expect(foo).toEqual(1);
+    });
+
+    it("can have more than one expectation", function () {
+        expect(foo).toEqual(1);
+        expect(true).toEqual(true);
+    });
+
+    describe("nested inside a second describe", function () {
+        var bar: number;
+
+        beforeEach(function () {
+            bar = 1;
+        });
+
+        it("can reference both scopes as needed", function () {
+            expect(foo).toEqual(bar);
+        });
+    });
+});
+
+xdescribe("A spec", function () {
+    var foo: number;
+
+    beforeEach(function () {
+        foo = 0;
+        foo += 1;
+    });
+
+    it("is just a function, so it can contain any code", function () {
+        expect(foo).toEqual(1);
+    });
+});
+
+describe("Pending specs", function () {
+
+    xit("can be declared 'xit'", function () {
+        expect(true).toBe(false);
+    });
+
+    it("can be declared with 'it' but without a function");
+
+    it("can be declared by calling 'pending' in the spec body", function () {
+        expect(true).toBe(false);
+        pending();
+    });
+});
+
+describe("A spy", function () {
+    var foo: any, bar: any = null;
+
+    beforeEach(function () {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            }
+        };
+
+        spyOn(foo, 'setBar');
+
+        foo.setBar(123);
+        foo.setBar(456, 'another param');
+    });
+
+    it("tracks that the spy was called", function () {
+        expect(foo.setBar).toHaveBeenCalled();
+    });
+
+    it("tracks all the arguments of its calls", function () {
+        expect(foo.setBar).toHaveBeenCalledWith(123);
+        expect(foo.setBar).toHaveBeenCalledWith(456, 'another param');
+    });
+
+    it("stops all execution on a function", function () {
+        expect(bar).toBeNull();
+    });
+});
+
+describe("A spy, when configured to call through", function () {
+    var foo: any, bar: any, fetchedBar: any;
+
+    beforeEach(function () {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            },
+            getBar: function () {
+                return bar;
+            }
+        };
+
+        spyOn(foo, 'getBar').and.callThrough();
+
+        foo.setBar(123);
+        fetchedBar = foo.getBar();
+    });
+
+    it("tracks that the spy was called", function () {
+        expect(foo.getBar).toHaveBeenCalled();
+    });
+
+    it("should not effect other functions", function () {
+        expect(bar).toEqual(123);
+    });
+
+    it("when called returns the requested value", function () {
+        expect(fetchedBar).toEqual(123);
+    });
+});
+
+describe("A spy, when configured to fake a return value", function () {
+    var foo: any, bar: any, fetchedBar: any;
+
+    beforeEach(function () {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            },
+            getBar: function () {
+                return bar;
+            }
+        };
+
+        spyOn(foo, "getBar").and.returnValue(745);
+
+        foo.setBar(123);
+        fetchedBar = foo.getBar();
+    });
+
+    it("tracks that the spy was called", function () {
+        expect(foo.getBar).toHaveBeenCalled();
+    });
+
+    it("should not effect other functions", function () {
+        expect(bar).toEqual(123);
+    });
+
+    it("when called returns the requested value", function () {
+        expect(fetchedBar).toEqual(745);
+    });
+});
+
+describe("A spy, when configured with an alternate implementation", function () {
+    var foo: any, bar: any, fetchedBar: any;
+
+    beforeEach(function () {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            },
+            getBar: function () {
+                return bar;
+            }
+        };
+
+        spyOn(foo, "getBar").and.callFake(function () {
+            return 1001;
+        });
+
+        foo.setBar(123);
+        fetchedBar = foo.getBar();
+    });
+
+    it("tracks that the spy was called", function () {
+        expect(foo.getBar).toHaveBeenCalled();
+    });
+
+    it("should not effect other functions", function () {
+        expect(bar).toEqual(123);
+    });
+
+    it("when called returns the requested value", function () {
+        expect(fetchedBar).toEqual(1001);
+    });
+});
+
+describe("A spy, when configured to throw a value", function () {
+    var foo: any, bar: any;
+
+    beforeEach(function () {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            }
+        };
+
+        spyOn(foo, "setBar").and.throwError("quux");
+    });
+
+    it("throws the value", function () {
+        expect(function () {
+            foo.setBar(123)
+    }).toThrowError("quux");
+    });
+});
+
+describe("A spy", function () {
+    var foo: any, bar: any = null;
+
+    beforeEach(function () {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            }
+        };
+
+        spyOn(foo, 'setBar').and.callThrough();
+    });
+
+    it("can call through and then stub in the same spec", function () {
+        foo.setBar(123);
+        expect(bar).toEqual(123);
+
+        foo.setBar.and.stub();
+        bar = null;
+
+        foo.setBar(123);
+        expect(bar).toBe(null);
+    });
+});
+
+describe("A spy", function () {
+    var foo: any, bar: any = null;
+
+    beforeEach(function () {
+        foo = {
+            setBar: function (value: any) {
+                bar = value;
+            }
+        };
+
+        spyOn(foo, 'setBar');
+    });
+
+    it("tracks if it was called at all", function () {
+        expect(foo.setBar.calls.any()).toEqual(false);
+
+        foo.setBar();
+
+        expect(foo.setBar.calls.any()).toEqual(true);
+    });
+
+    it("tracks the number of times it was called", function () {
+        expect(foo.setBar.calls.count()).toEqual(0);
+
+        foo.setBar();
+        foo.setBar();
+
+        expect(foo.setBar.calls.count()).toEqual(2);
+    });
+
+    it("tracks the arguments of each call", function () {
+        foo.setBar(123);
+        foo.setBar(456, "baz");
+
+        expect(foo.setBar.calls.argsFor(0)).toEqual([123]);
+        expect(foo.setBar.calls.argsFor(1)).toEqual([456, "baz"]);
+    });
+
+    it("tracks the arguments of all calls", function () {
+        foo.setBar(123);
+        foo.setBar(456, "baz");
+
+        expect(foo.setBar.calls.allArgs()).toEqual([[123], [456, "baz"]]);
+    });
+
+    it("can provide the context and arguments to all calls", function () {
+        foo.setBar(123);
+
+        expect(foo.setBar.calls.all()).toEqual([{ object: foo, args: [123] }]);
+    });
+
+    it("has a shortcut to the most recent call", function () {
+        foo.setBar(123);
+        foo.setBar(456, "baz");
+
+        expect(foo.setBar.calls.mostRecent()).toEqual({ object: foo, args: [456, "baz"] });
+    });
+
+    it("has a shortcut to the first call", function () {
+        foo.setBar(123);
+        foo.setBar(456, "baz");
+
+        expect(foo.setBar.calls.first()).toEqual({ object: foo, args: [123] });
+    });
+
+    it("can be reset", function () {
+        foo.setBar(123);
+        foo.setBar(456, "baz");
+
+        expect(foo.setBar.calls.any()).toBe(true);
+
+        foo.setBar.calls.reset();
+
+        expect(foo.setBar.calls.any()).toBe(false);
+    });
+});
+
+describe("A spy, when created manually", function () {
+    var whatAmI: any;
+
+    beforeEach(function () {
+        whatAmI = jasmine.createSpy('whatAmI');
+
+        whatAmI("I", "am", "a", "spy");
+    });
+
+    it("is named, which helps in error reporting", function () {
+        expect(whatAmI.and.identity()).toEqual('whatAmI');
+    });
+
+    it("tracks that the spy was called", function () {
+        expect(whatAmI).toHaveBeenCalled();
+    });
+
+    it("tracks its number of calls", function () {
+        expect(whatAmI.calls.count()).toEqual(1);
+    });
+
+    it("tracks all the arguments of its calls", function () {
+        expect(whatAmI).toHaveBeenCalledWith("I", "am", "a", "spy");
+    });
+
+    it("allows access to the most recent call", function () {
+        expect(whatAmI.calls.mostRecent().args[0]).toEqual("I");
+    });
+});
+
+describe("Multiple spies, when created manually", function () {
+    var tape: any;
+
+    beforeEach(function () {
+        tape = jasmine.createSpyObj('tape', ['play', 'pause', 'stop', 'rewind']);
+
+        tape.play();
+        tape.pause();
+        tape.rewind(0);
+    });
+
+    it("creates spies for each requested function", function () {
+        expect(tape.play).toBeDefined();
+        expect(tape.pause).toBeDefined();
+        expect(tape.stop).toBeDefined();
+        expect(tape.rewind).toBeDefined();
+    });
+
+    it("tracks that the spies were called", function () {
+        expect(tape.play).toHaveBeenCalled();
+        expect(tape.pause).toHaveBeenCalled();
+        expect(tape.rewind).toHaveBeenCalled();
+        expect(tape.stop).not.toHaveBeenCalled();
+    });
+
+    it("tracks all the arguments of its calls", function () {
+        expect(tape.rewind).toHaveBeenCalledWith(0);
+    });
+});
+
+describe("jasmine.any", function () {
+    it("matches any value", function () {
+        expect({}).toEqual(jasmine.any(Object));
+        expect(12).toEqual(jasmine.any(Number));
+    });
+
+    describe("when used with a spy", function () {
+        it("is useful for comparing arguments", function () {
+            var foo = jasmine.createSpy('foo');
+            foo(12, function () {
+                return true;
+            });
+
+            expect(foo).toHaveBeenCalledWith(jasmine.any(Number), jasmine.any(Function));
+        });
+    });
+});
+
+describe("jasmine.objectContaining", function () {
+    var foo: any;
+
+    beforeEach(function () {
+        foo = {
+            a: 1,
+            b: 2,
+            bar: "baz"
+        };
+    });
+
+    it("matches objects with the expect key/value pairs", function () {
+        expect(foo).toEqual(jasmine.objectContaining({
+            bar: "baz"
+        }));
+        expect(foo).not.toEqual(jasmine.objectContaining({
+            c: 37
+        }));
+    });
+
+    describe("when used with a spy", function () {
+        it("is useful for comparing arguments", function () {
+            var callback = jasmine.createSpy('callback');
+
+            callback({
+                bar: "baz"
+            });
+
+            expect(callback).toHaveBeenCalledWith(jasmine.objectContaining({
+                bar: "baz"
+            }));
+            expect(callback).not.toHaveBeenCalledWith(jasmine.objectContaining({
+                c: 37
+            }));
+        });
+    });
+});
+
+describe("Manually ticking the Jasmine Clock", function () {
+    var timerCallback: any;
+
+    beforeEach(function () {
+        timerCallback = jasmine.createSpy("timerCallback");
+        jasmine.clock().install();
+    });
+
+    afterEach(function () {
+        jasmine.clock().uninstall();
+    });
+
+    it("causes a timeout to be called synchronously", function () {
+        setTimeout(function () {
+            timerCallback();
+        }, 100);
+
+        expect(timerCallback).not.toHaveBeenCalled();
+
+        jasmine.clock().tick(101);
+
+        expect(timerCallback).toHaveBeenCalled();
+    });
+
+    it("causes an interval to be called synchronously", function () {
+        setInterval(function () {
+            timerCallback();
+        }, 100);
+
+        expect(timerCallback).not.toHaveBeenCalled();
+
+        jasmine.clock().tick(101);
+        expect(timerCallback.calls.count()).toEqual(1);
+
+        jasmine.clock().tick(50);
+        expect(timerCallback.calls.count()).toEqual(1);
+
+        jasmine.clock().tick(50);
+        expect(timerCallback.calls.count()).toEqual(2);
+    });
+});
+
+describe("Asynchronous specs", function () {
+    var value: number;
+    beforeEach(function (done) {
+        setTimeout(function () {
+            value = 0;
+            done();
+        }, 1);
+    });
+
+    it("should support async execution of test preparation and expectations", function (done) {
+        value++;
+        expect(value).toBeGreaterThan(0);
+        done();
+    });
+});
+
+(() => {
+    // from boot.js
+    var env = jasmine.getEnv();
+
+    var htmlReporter = new jasmine.HtmlReporter();
+    env.addReporter(htmlReporter);
+
+    var specFilter = new jasmine.HtmlSpecFilter();
+    env.specFilter = function (spec) {
+        return specFilter.matches(spec.getFullName());
+    };
+
+    var currentWindowOnload = window.onload;
+    window.onload = function () {
+        if (currentWindowOnload) {
+            currentWindowOnload(null);
+        }
+        htmlReporter.initialize();
+        env.execute();
+    };
+
+})();

--- a/third_party/DefinitelyTyped/jasmine/jasmine.d.ts
+++ b/third_party/DefinitelyTyped/jasmine/jasmine.d.ts
@@ -1,0 +1,406 @@
+// Type definitions for Jasmine 2.0
+// Project: http://pivotal.github.com/jasmine/
+// Definitions by: Boris Yankov <https://github.com/borisyankov/>, Theodore Brown <https://github.com/theodorejb>
+// DefinitelyTyped: https://github.com/borisyankov/DefinitelyTyped
+
+
+declare function describe(description: string, specDefinitions: () => void): void;
+declare function xdescribe(description: string, specDefinitions: () => void): void;
+
+declare function it(expectation: string, assertion?: () => void): void;
+declare function it(expectation: string, assertion?: (done: () => void) => void): void;
+declare function xit(expectation: string, assertion?: () => void): void;
+declare function xit(expectation: string, assertion?: (done: () => void) => void): void;
+
+/** If you call the function pending anywhere in the spec body, no matter the expectations, the spec will be marked pending. */
+declare function pending(): void;
+
+declare function beforeEach(action: () => void): void;
+declare function beforeEach(action: (done: () => void) => void): void;
+declare function afterEach(action: () => void): void;
+declare function afterEach(action: (done: () => void) => void): void;
+
+declare function expect(spy: Function): jasmine.Matchers;
+declare function expect(actual: any): jasmine.Matchers;
+
+declare function spyOn(object: any, method: string): jasmine.Spy;
+
+declare function runs(asyncMethod: Function): void;
+declare function waitsFor(latchMethod: () => boolean, failureMessage?: string, timeout?: number): void;
+declare function waits(timeout?: number): void;
+
+declare module jasmine {
+
+    var clock: () => Clock;
+
+    function any(aclass: any): Any;
+    function objectContaining(sample: any): ObjectContaining;
+    function createSpy(name: string, originalFn?: Function): Spy;
+    function createSpyObj(baseName: string, methodNames: any[]): any;
+    function createSpyObj<T>(baseName: string, methodNames: any[]): T;
+    function pp(value: any): string;
+    function getEnv(): Env;
+
+    interface Any {
+
+        new (expectedClass: any): any;
+
+        jasmineMatches(other: any): boolean;
+        jasmineToString(): string;
+    }
+
+    interface ObjectContaining {
+        new (sample: any): any;
+
+        jasmineMatches(other: any, mismatchKeys: any[], mismatchValues: any[]): boolean;
+        jasmineToString(): string;
+    }
+
+    interface Block {
+
+        new (env: Env, func: SpecFunction, spec: Spec): any;
+
+        execute(onComplete: () => void): void;
+    }
+
+    interface WaitsBlock extends Block {
+        new (env: Env, timeout: number, spec: Spec): any;
+    }
+
+    interface WaitsForBlock extends Block {
+        new (env: Env, timeout: number, latchFunction: SpecFunction, message: string, spec: Spec): any;
+    }
+
+    interface Clock {
+        install(): void;
+        uninstall(): void;
+        /** Calls to any registered callback are triggered when the clock is ticked forward via the jasmine.clock().tick function, which takes a number of milliseconds. */
+        tick(ms: number): void;
+    }
+
+    interface Env {
+        setTimeout: any;
+        clearTimeout: void;
+        setInterval: any;
+        clearInterval: void;
+        updateInterval: number;
+
+        currentSpec: Spec;
+
+        matchersClass: Matchers;
+
+        version(): any;
+        versionString(): string;
+        nextSpecId(): number;
+        addReporter(reporter: Reporter): void;
+        execute(): void;
+        describe(description: string, specDefinitions: () => void): Suite;
+        beforeEach(beforeEachFunction: () => void): void;
+        currentRunner(): Runner;
+        afterEach(afterEachFunction: () => void): void;
+        xdescribe(desc: string, specDefinitions: () => void): XSuite;
+        it(description: string, func: () => void): Spec;
+        xit(desc: string, func: () => void): XSpec;
+        compareRegExps_(a: RegExp, b: RegExp, mismatchKeys: string[], mismatchValues: string[]): boolean;
+        compareObjects_(a: any, b: any, mismatchKeys: string[], mismatchValues: string[]): boolean;
+        equals_(a: any, b: any, mismatchKeys: string[], mismatchValues: string[]): boolean;
+        contains_(haystack: any, needle: any): boolean;
+        addEqualityTester(equalityTester: (a: any, b: any, env: Env, mismatchKeys: string[], mismatchValues: string[]) => boolean): void;
+        specFilter(spec: Spec): boolean;
+    }
+
+    interface FakeTimer {
+
+        new (): any;
+
+        reset(): void;
+        tick(millis: number): void;
+        runFunctionsWithinRange(oldMillis: number, nowMillis: number): void;
+        scheduleFunction(timeoutKey: any, funcToCall: () => void, millis: number, recurring: boolean): void;
+    }
+
+    interface HtmlReporter {
+        new (): any;
+    }
+
+    interface HtmlSpecFilter {
+        new (): any;
+    }
+
+    interface Result {
+        type: string;
+    }
+
+    interface NestedResults extends Result {
+        description: string;
+
+        totalCount: number;
+        passedCount: number;
+        failedCount: number;
+
+        skipped: boolean;
+
+        rollupCounts(result: NestedResults): void;
+        log(values: any): void;
+        getItems(): Result[];
+        addResult(result: Result): void;
+        passed(): boolean;
+    }
+
+    interface MessageResult extends Result  {
+        values: any;
+        trace: Trace;
+    }
+
+    interface ExpectationResult extends Result  {
+        matcherName: string;
+        passed(): boolean;
+        expected: any;
+        actual: any;
+        message: string;
+        trace: Trace;
+    }
+
+    interface Trace {
+        name: string;
+        message: string;
+        stack: any;
+    }
+
+    interface PrettyPrinter {
+
+        new (): any;
+
+        format(value: any): void;
+        iterateObject(obj: any, fn: (property: string, isGetter: boolean) => void): void;
+        emitScalar(value: any): void;
+        emitString(value: string): void;
+        emitArray(array: any[]): void;
+        emitObject(obj: any): void;
+        append(value: any): void;
+    }
+
+    interface StringPrettyPrinter extends PrettyPrinter {
+    }
+
+    interface Queue {
+
+        new (env: any): any;
+
+        env: Env;
+        ensured: boolean[];
+        blocks: Block[];
+        running: boolean;
+        index: number;
+        offset: number;
+        abort: boolean;
+
+        addBefore(block: Block, ensure?: boolean): void;
+        add(block: any, ensure?: boolean): void;
+        insertNext(block: any, ensure?: boolean): void;
+        start(onComplete?: () => void): void;
+        isRunning(): boolean;
+        next_(): void;
+        results(): NestedResults;
+    }
+
+    interface Matchers {
+
+        new (env: Env, actual: any, spec: Env, isNot?: boolean): any;
+
+        env: Env;
+        actual: any;
+        spec: Env;
+        isNot?: boolean;
+        message(): any;
+
+        toBe(expected: any): boolean;
+        toNotBe(expected: any): boolean;
+        toEqual(expected: any): boolean;
+        toNotEqual(expected: any): boolean;
+        toMatch(expected: any): boolean;
+        toNotMatch(expected: any): boolean;
+        toBeDefined(): boolean;
+        toBeUndefined(): boolean;
+        toBeNull(): boolean;
+        toBeNaN(): boolean;
+        toBeTruthy(): boolean;
+        toBeFalsy(): boolean;
+        toHaveBeenCalled(): boolean;
+        wasNotCalled(): boolean;
+        toHaveBeenCalledWith(...params: any[]): boolean;
+        toContain(expected: any): boolean;
+        toNotContain(expected: any): boolean;
+        toBeLessThan(expected: any): boolean;
+        toBeGreaterThan(expected: any): boolean;
+        toBeCloseTo(expected: any, precision: any): boolean;
+        toContainHtml(expected: string): boolean;
+        toContainText(expected: string): boolean;
+        toThrow(expected?: any): boolean;
+        toThrowError(expected?: any): boolean;
+        not: Matchers;
+
+        Any: Any;
+    }
+
+    interface Reporter {
+        reportRunnerStarting(runner: Runner): void;
+        reportRunnerResults(runner: Runner): void;
+        reportSuiteResults(suite: Suite): void;
+        reportSpecStarting(spec: Spec): void;
+        reportSpecResults(spec: Spec): void;
+        log(str: string): void;
+    }
+
+    interface MultiReporter extends Reporter {
+        addReporter(reporter: Reporter): void;
+    }
+
+    interface Runner {
+
+        new (env: Env): any;
+
+        execute(): void;
+        beforeEach(beforeEachFunction: SpecFunction): void;
+        afterEach(afterEachFunction: SpecFunction): void;
+        finishCallback(): void;
+        addSuite(suite: Suite): void;
+        add(block: Block): void;
+        specs(): Spec[];
+        suites(): Suite[];
+        topLevelSuites(): Suite[];
+        results(): NestedResults;
+    }
+
+    interface SpecFunction {
+        (spec?: Spec): void;
+    }
+
+    interface SuiteOrSpec {
+        id: number;
+        env: Env;
+        description: string;
+        queue: Queue;
+    }
+
+    interface Spec extends SuiteOrSpec {
+
+        new (env: Env, suite: Suite, description: string): any;
+
+        suite: Suite;
+
+        afterCallbacks: SpecFunction[];
+        spies_: Spy[];
+
+        results_: NestedResults;
+        matchersClass: Matchers;
+
+        getFullName(): string;
+        results(): NestedResults;
+        log(arguments: any): any;
+        runs(func: SpecFunction): Spec;
+        addToQueue(block: Block): void;
+        addMatcherResult(result: Result): void;
+        expect(actual: any): any;
+        waits(timeout: number): Spec;
+        waitsFor(latchFunction: SpecFunction, timeoutMessage?: string, timeout?: number): Spec;
+        fail(e?: any): void;
+        getMatchersClass_(): Matchers;
+        addMatchers(matchersPrototype: any): void;
+        finishCallback(): void;
+        finish(onComplete?: () => void): void;
+        after(doAfter: SpecFunction): void;
+        execute(onComplete?: () => void): any;
+        addBeforesAndAftersToQueue(): void;
+        explodes(): void;
+        spyOn(obj: any, methodName: string, ignoreMethodDoesntExist: boolean): Spy;
+        removeAllSpies(): void;
+    }
+
+    interface XSpec {
+        id: number;
+        runs(): void;
+    }
+
+    interface Suite extends SuiteOrSpec {
+
+        new (env: Env, description: string, specDefinitions: () => void, parentSuite: Suite): any;
+
+        parentSuite: Suite;
+
+        getFullName(): string;
+        finish(onComplete?: () => void): void;
+        beforeEach(beforeEachFunction: SpecFunction): void;
+        afterEach(afterEachFunction: SpecFunction): void;
+        results(): NestedResults;
+        add(suiteOrSpec: SuiteOrSpec): void;
+        specs(): Spec[];
+        suites(): Suite[];
+        children(): any[];
+        execute(onComplete?: () => void): void;
+    }
+
+    interface XSuite {
+        execute(): void;
+    }
+
+    interface Spy {
+        (...params: any[]): any;
+
+        identity: string;
+        and: SpyAnd;
+        calls: any[];
+        mostRecentCall: { args: any[]; };
+        argsForCall: any[];
+        wasCalled: boolean;
+        callCount: number;
+    }
+
+    interface SpyAnd {
+        /** By chaining the spy with and.callThrough, the spy will still track all calls to it but in addition it will delegate to the actual implementation. */
+        callThrough(): void;
+        /** By chaining the spy with and.returnValue, all calls to the function will return a specific value. */
+        returnValue(val: any): void;
+        /** By chaining the spy with and.callFake, all calls to the spy will delegate to the supplied function. */
+        callFake(fn: () => any): void;
+        /** By chaining the spy with and.throwError, all calls to the spy will throw the specified value. */
+        throwError(msg: string): void;
+        /** When a calling strategy is used for a spy, the original stubbing behavior can be returned at any time with and.stub. */
+        stub(): void;
+    }
+
+    interface Util {
+        inherit(childClass: Function, parentClass: Function): any;
+        formatException(e: any): any;
+        htmlEscape(str: string): string;
+        argsToArray(args: any): any;
+        extend(destination: any, source: any): any;
+    }
+
+    interface JsApiReporter extends Reporter {
+
+        started: boolean;
+        finished: boolean;
+        result: any;
+        messages: any;
+
+        new (): any;
+
+        suites(): Suite[];
+        summarize_(suiteOrSpec: SuiteOrSpec): any;
+        results(): any;
+        resultsForSpec(specId: any): any;
+        log(str: any): any;
+        resultsForSpecs(specIds: any): any;
+        summarizeResult_(result: any): any;
+    }
+
+    interface Jasmine {
+        Spec: Spec;
+        clock: Clock;
+        util: Util;
+    }
+
+    export var HtmlReporter: HtmlReporter;
+    export var HtmlSpecFilter: HtmlSpecFilter;
+}


### PR DESCRIPTION
This is intended to help provide a template for writing tests in Typescript with Jasmine. 
- added `hexStringToArrayBuffer`
- added typescript definition interface file for `ArrayBuffers`
- added third_party/DefinitelyTyped directory with README
- added typescript DefinitelyTyped jasmine interface files to third_party
- added jasmine tests for `ArrayBuffers` code. 
- updated Gruntfile to run new tests

TESTED: grunt test
