### PR TITLE
fail on typescript errors and remove base_path option warning

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -57,23 +57,23 @@ module.exports = (grunt) ->
       socks2rtc:
         src: ['src/socks-to-rtc/**/*.ts']
         dest: 'build/'
-        options: { basePath: 'src' }
+        options: { basePath: 'src', ignoreError: false }
       rtc2net:
         src: ['src/rtc-to-net/**/*.ts']
         dest: 'build/'
-        options: { basePath: 'src' }
+        options: { basePath: 'src', ignoreError: false }
       common:
         src: ['src/common/**/*.ts']
         dest: 'build/'
-        options: { basePath: 'src' }
+        options: { basePath: 'src', ignoreError: false }
       chromeProviders:
         src: ['src/chrome-providers/**/*.ts']
         dest: 'build/chrome-app/'
-        options: { basePath: 'src' }
+        options: { basePath: 'src', ignoreError: false }
       chromeApp:
         src: ['src/chrome-app/**/*.ts']
         dest: 'build/'
-        options: { basePath: 'src/' }
+        options: { basePath: 'src/', ignoreError: false }
     }
 
     jasmine: {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-coffee": "~0.7.0",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-typescript": "~0.2.7",
+    "grunt-typescript": "~0.2.10",
     "grunt-jasmine-node": "git://github.com/vojtajina/grunt-jasmine-node.git#fix-grunt-exit-code",
     "webdriverjs": "~1.3.1",
     "grunt-env": "~0.4.1",


### PR DESCRIPTION
This will make the build Grunt task fail if TypeScript finds any type errors (the default is to fail only if TypeScript can't create an output JS file). Also rename base_path -> basePath, to remove annoying compiler warnings.

I'll wait until master is back in good shape to merge this.

Addresses:
https://github.com/uProxy/socks-rtc/issues/63
