### PR TITLE
make freedom runtime dep into a dev dep so its not our only runtime dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,10 @@
     "grunt-env": "~0.4.1",
     "uproxy-build-tools": "~0.0.4",
     "freedom-for-chrome": "^0.1.4",
-    "freedom-typescript-api": "~0.1.5"
+    "freedom-typescript-api": "~0.1.5",
+    "freedom": "^0.4.4"
   },
   "scripts": {
     "test": "grunt test"
-  },
-  "dependencies": {
-    "freedom": "~0.4.3"
   }
 }


### PR DESCRIPTION
This made sense to me at the time...but now it's our only runtime dependency and there's no reason really why it's any different to any of our other dependencies.
