### PR TITLE
Move code around for inclusion in UProxy.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ spec/*
 test/*
 tmp/*
 build/chrome-app/*
+build/firefox-app/*

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -145,6 +145,8 @@ module.exports = (grunt) ->
   # Define the tasks
   taskManager = new TaskManager.Manager();
 
+  # TODO: create separate build commands for just the socks-to-rtc and rtc-to-net
+  # libaries, chrome app, and firefox app.
   taskManager.add 'build', [
     'typescript'
     'copy'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -16,6 +16,10 @@ module.exports = (grunt) ->
         expand: true, cwd: 'node_modules/freedom-for-firefox/'
         src: ['freedom-for-firefox.jsm', 'freedom.map']
         dest: 'build/firefox-app/data' } ] }
+      freedomProvidersBuild: { files: [ {
+        expand: true, cwd: 'node_modules/freedom/providers/transport/webrtc/'
+        src: ['*']
+        dest: 'build/freedom-providers' } ] }
       freedomProvidersChrome: { files: [ {
         expand: true, cwd: 'node_modules/freedom/providers/transport/webrtc/'
         src: ['*']
@@ -24,6 +28,11 @@ module.exports = (grunt) ->
         expand: true, cwd: 'node_modules/freedom/providers/transport/webrtc/'
         src: ['*']
         dest: 'build/firefox-app/data/freedom-providers' } ] }
+      buildUtil: { files: [ {
+          expand: true, cwd: 'node_modules/uproxy-build-tools/build/util',
+          src: ['**/*.js'],
+          dest: 'build/util'
+        } ] }
 
       # User should include the compiled source directly from:
       #   - build/socks-to-rtc
@@ -38,12 +47,12 @@ module.exports = (grunt) ->
         dest: 'build/' } ] }
       echoChrome: { files: [ {
         expand: true, cwd: 'test/'
-        src: ['*.js']
-        dest: 'build/chrome-app/socks-to-rtc/' } ] }
+        src: ['**']
+        dest: 'build/chrome-app/test/' } ] }
       echoFirefox: { files: [ {
         expand: true, cwd: 'test/'
-        src: ['*.js']
-        dest: 'build/firefox-app/data/socks-to-rtc/' } ] }
+        src: ['**']
+        dest: 'build/firefox-app/data/test/' } ] }
       firefoxApp: { files: [ {
           expand: true, cwd: 'src/firefox-app'
           src: ['**/*.json', '**/*.js', '**/*.html', '**/*.css']
@@ -137,19 +146,8 @@ module.exports = (grunt) ->
   taskManager = new TaskManager.Manager();
 
   taskManager.add 'build', [
-    'typescript:socks2rtc'
-    'typescript:rtc2net'
-    'typescript:chromeApp'
-    'copy:freedomChrome'
-    'copy:freedomFirefox'
-    'copy:freedomProvidersChrome'
-    'copy:freedomProvidersFirefox'
-    'copy:socks2rtc'
-    'copy:rtc2net'
-    'copy:echoChrome'
-    'copy:echoFirefox'
-    'copy:chromeApp'
-    'copy:firefoxApp'
+    'typescript'
+    'copy'
   ]
 
   # This is the target run by Travis. Targets in here should run locally

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "socks-rtc",
   "description": "Library for proxying SOCKS5 over WebRTC",
-  "version": "0.1.5",
+  "version": "0.1.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/socks-rtc"

--- a/src/chrome-app/socks_rtc.json
+++ b/src/chrome-app/socks_rtc.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "SocksToRtc": { "url": "socks-to-rtc/socks-to-rtc.json" },
-    "RtcToNet": { "url": "rtc-to-net/rtc-to-net.json" }
+    "RtcToNet": { "url": "rtc-to-net/rtc-to-net.json" },
+    "TcpEchoServer": { "url": "test/tcp_echo_server.json" }
   },
   "permissions": [
     "core.tcpsocket",

--- a/src/chrome-app/socks_to_rtc_to_net.js
+++ b/src/chrome-app/socks_to_rtc_to_net.js
@@ -8,8 +8,10 @@ var SERVER_PEER_ID = 'ATotallyFakePeerID';  // Can be any string.
 
 var socksToRtc = freedom.SocksToRtc();
 var rtcToNet = freedom.RtcToNet();
+var tcpEchoServer = freedom.TcpEchoServer();
 
 rtcToNet.emit('start');
+tcpEchoServer.emit('start');
 
 // Once the socksToRtc peer successfully starts, it fires 'sendSignalToPeer'.
 function proxyClientThroughServer() {
@@ -18,7 +20,6 @@ function proxyClientThroughServer() {
     'port':   DEFAULT_PORT,
     'peerId': SERVER_PEER_ID
   });
-  socksToRtc.emit('test', {});
 }
 
 // Attach freedom handlers to peers.

--- a/src/socks-to-rtc/socks-to-rtc.json
+++ b/src/socks-to-rtc/socks-to-rtc.json
@@ -8,7 +8,6 @@
       "socks-headers.js",
       "socks-to-rtc.js",
       "udprelay.js",
-      "tcp_echo_server.js",
       "../util/arraybuffers.js"
     ]
   },

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -279,8 +279,6 @@ module SocksToRTC {
 
 }  // module SocksToRTC
 
-declare var TcpEchoServer:any;
-
 function initClient() {
 
   // Create local peer and attach freedom message handlers, then emit |ready|.
@@ -288,9 +286,6 @@ function initClient() {
   freedom.on('handleSignalFromPeer', peer.handlePeerSignal);
   freedom.on('start', peer.start);
   freedom.on('stop', peer.reset);
-  freedom.on('test', function() {
-    new TcpEchoServer('127.0.0.1', 9998);
-  });
   freedom.emit('ready', {});
 }
 

--- a/test/tcp_echo_server.js
+++ b/test/tcp_echo_server.js
@@ -3,7 +3,7 @@
 */
 
 TcpEchoServer = function(address, port) {
-  console.log('TcpEchoServer(' + address + ', ' + port + ')');
+  console.log('Starting TcpEchoServer(' + address + ', ' + port + ')');
   this.server = new TCP.Server(address, port);
   this.address = address;
   this.port = port;
@@ -19,5 +19,8 @@ TcpEchoServer = function(address, port) {
     });
   }, {minByteLength: 1});
 }
-
 console.log('TcpEchoServer installed');
+
+freedom.on('start', function() {
+  new TcpEchoServer('127.0.0.1', 9998);
+});

--- a/test/tcp_echo_server.json
+++ b/test/tcp_echo_server.json
@@ -1,0 +1,13 @@
+{
+  "name": "TCP Echo Server",
+  "description": "Listen for incoming requests, and echo them back.",
+  "app": {
+    "script": [
+      "../socks-to-rtc/tcp.js",
+      "tcp_echo_server.js"
+    ]
+  },
+  "permissions": [
+    "core.tcpsocket"
+  ]
+}


### PR DESCRIPTION
Move code around for inclusion in UProxy.
- Moved tcp_echo_server to its own freedom module, so that socks-to-rtc.json doesn't include the echo server (i.e. UProxy shouldn't include the echo server)
- Moved util and freedom-providers into build directory
