### PR TITLE
Emit socksToRtcSuccess or socksToRtcFailure after freedom.transport.setup succeeds or fails.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "socks-rtc",
   "description": "Library for proxying SOCKS5 over WebRTC",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/socks-rtc"

--- a/src/chrome-app/socks_to_rtc_to_net.js
+++ b/src/chrome-app/socks_to_rtc_to_net.js
@@ -32,6 +32,15 @@ socksToRtc.on('sendSignalToPeer', function(signal) {
   // If all goes correctly, the rtcToNet will fire a 'sendSignalToPeer'.
 });
 
+// Listen for socksToRtc success or failure signals, and just print them for now.
+socksToRtc.on('socksToRtcSuccess', function(peerId) {
+  console.log('Received socksToRtcSuccess for peerId ' + JSON.stringify(peerId));
+});
+
+socksToRtc.on('socksToRtcFailure', function(peerId) {
+  console.error('Received socksToRtcFailure for peerId ' + JSON.stringify(peerId));
+});
+
 // Server tells socksToRtc about itself.
 rtcToNet.on('sendSignalToPeer', function(signal) {
   console.log(' * RTC-NET signaling SOCKS-RTC.');  // + JSON.stringify(signal));

--- a/src/interfaces/communications.d.ts
+++ b/src/interfaces/communications.d.ts
@@ -6,7 +6,8 @@ declare module Channel {
     NET_CONNECT_REQUEST = 1,
     NET_CONNECT_RESPONSE = 2,
     NET_DISCONNECTED = 3,
-    SOCKS_DISCONNECTED = 4
+    SOCKS_DISCONNECTED = 4,
+    HELLO = 5
   }
 
   // "Top-level" message for the control channel.

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -38,7 +38,11 @@ module RtcToNet {
       this.transport = freedom['transport']();
       this.transport.on('onData', this.passPeerDataToNet_);
       this.transport.on('onClose', this.closeNetClient_);
-      this.transport.setup('RtcToNet-' + peerId, channel.identifier);
+      this.transport.setup('RtcToNet-' + peerId, channel.identifier).then(
+        // TODO: emit signals when peer-to-peer connections are setup or fail.
+        () => { console.log('RtcToNet transport.setup succeeded'); },
+        () => { console.error('RtcToNet transport.setup failed'); }
+      );
       this.signallingChannel = channel.channel;
       this.signallingChannel.on('message', (msg) => {
         freedom.emit('sendSignalToPeer', {
@@ -116,9 +120,13 @@ module RtcToNet {
                 this.transport.send('control',
                     ArrayBuffers.stringToArrayBuffer(JSON.stringify(out)));
               });
+        } else if (command.type === Channel.COMMANDS.HELLO) {
+          // Hello command is used to establish communication from socks-to-rtc,
+          // just ignore it.
+          dbg('received hello.');
         } else {
           // TODO: support SocksDisconnected command
-          dbgWarn('unsupported control command: ' + command.type);
+          dbgWarn('unsupported control command: ' + JSON.stringify(command));
         }
       } else {
         dbg(message.tag + ' <--- received ' + JSON.stringify(message));

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -40,8 +40,8 @@ module RtcToNet {
       this.transport.on('onClose', this.closeNetClient_);
       this.transport.setup('RtcToNet-' + peerId, channel.identifier).then(
         // TODO: emit signals when peer-to-peer connections are setup or fail.
-        () => { console.log('RtcToNet transport.setup succeeded'); },
-        () => { console.error('RtcToNet transport.setup failed'); }
+        () => { dbg('RtcToNet transport.setup succeeded'); },
+        (e) => { dbgErr('RtcToNet transport.setup failed ' + e); }
       );
       this.signallingChannel = channel.channel;
       this.signallingChannel.on('message', (msg) => {

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -61,12 +61,12 @@ module SocksToRTC {
       fCore.createChannel().then((chan) => {
         this.transport_.setup('SocksToRtc-' + peerId, chan.identifier).then(
           () => {
-            console.log('SocksToRtc transport_.setup succeeded');
+            dbg('SocksToRtc transport_.setup succeeded');
             freedom.emit('socksToRtcSuccess', remotePeer);
           }
         ).catch(
           (e) => {
-            console.error('SocksToRtc transport_.setup failed', e);
+            dbgErr('SocksToRtc transport_.setup failed ' + e);
             freedom.emit('socksToRtcFailure', remotePeer);
           }
         );
@@ -78,7 +78,10 @@ module SocksToRTC {
           });
         });
         dbg('signalling channel to SCTP peer connection ready.');
-        // Send hello command to initiate communication.
+        // Send hello command to initiate communication, which will cause
+        // the promise returned this.transport_.setup to fulfill.
+        // TODO: remove hello command once freedom.transport.setup
+        // is changed to automatically negotiate the connection.
         dbg('sending hello command.');
         var command :Channel.Command = {type: Channel.COMMANDS.HELLO};
         this.transport_.send('control', ArrayBuffers.stringToArrayBuffer(

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -40,6 +40,8 @@ module SocksToRTC {
      * Start the Peer, based on the remote peer's info.
      * This will emit a socksToRtcSuccess signal when the peer connection is esablished,
      * or a socksToRtcFailure signal if there is an error openeing the peer connection.
+     * TODO: update this to return a promise that fulfills/rejects, after freedom v0.5
+     * is ready.
      */
     public start = (remotePeer:PeerInfo) => {
       this.reset();  // Begin with fresh components.


### PR DESCRIPTION
Emit socksToRtcSuccess or socksToRtcFailure after freedom.transport.setup succeeds or fails.

Tested with socks-rtc chrome app to verify that these signals fire.
