### PR TITLE
Emit signals from rtc-to-net when a client starts/stops proxying.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "socks-rtc",
   "description": "Library for proxying SOCKS5 over WebRTC",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/socks-rtc"

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -123,7 +123,8 @@ module RtcToNet {
         } else if (command.type === Channel.COMMANDS.HELLO) {
           // Hello command is used to establish communication from socks-to-rtc,
           // just ignore it.
-          dbg('received hello.');
+          dbg('received hello from peerId ' + this.peerId);
+          freedom.emit('rtcToNetConnectionEstablished', this.peerId);
         } else {
           // TODO: support SocksDisconnected command
           dbgWarn('unsupported control command: ' + JSON.stringify(command));
@@ -190,7 +191,8 @@ module RtcToNet {
 
     // TODO: it's not clear what to do here
     private closeNetClient_ = () => {
-      dbg('transport closed');
+      dbg('transport closed from peerId ' + this.peerId);
+      freedom.emit('rtcToNetConnectionClosed', this.peerId);
     }
   }  // class RtcToNet.Peer
 


### PR DESCRIPTION
Emit signals from rtc-to-net when a client starts/stops proxying.

Tested manually by including in uProxy, and "grunt test".
