### PR TITLE
Emit signal when ping-pong times out on socks-to-rtc side

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "socks-rtc",
   "description": "Library for proxying SOCKS5 over WebRTC",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/socks-rtc"

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -219,7 +219,7 @@ module RtcToNet {
       // PONGs from rtc-to-net will be returned to socks-to-rtc immediately
       // after PINGs are received, so we only need to set an interval to
       // check for PINGs received.
-      var PING_PONG_CHECK_INTERVAL_MS :number = 10000;
+      var PING_PONG_CHECK_INTERVAL_MS :number = 5000;
       this.pingPongCheckIntervalId_ = setInterval(() => {
         var nowDate = new Date();
         if (!this.lastPingPongReceiveDate_ ||


### PR DESCRIPTION
Emit signal when ping-pong times out on socks-to-rtc side

Tested by merging into uProxy and verifying that we get a signal when the server disconnects, also re-ran "grunt test"
