### PR TITLE
move to Freedom v0.5-based freedom-for-xxx providers

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -13,7 +13,7 @@ module.exports = (grunt) ->
         src: ['freedom-for-chrome.js']
         dest: 'build/chrome-app/' } ] }
       freedomFirefox: { files: [ {
-        expand: true, cwd: 'node_modules/freedom-for-firefox/'
+        expand: true, cwd: 'node_modules/freedom-for-firefox/build/'
         src: ['freedom-for-firefox.jsm', 'freedom.map']
         dest: 'build/firefox-app/data' } ] }
       freedomProvidersBuild: { files: [ {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
     "webdriverjs": "^1.6.1",
     "grunt-env": "^0.4.1",
     "uproxy-build-tools": "~0.0.5",
-    "freedom-for-chrome": "^0.1.4",
-    "freedom-for-firefox": "~0.3.0",
-    "freedom-typescript-api": "~0.1.5",
-    "freedom": "^0.4.4"
+    "freedom-for-chrome": "~0.2.0",
+    "freedom-for-firefox": "~0.4.0",
+    "freedom-typescript-api": "~0.1.5"
   },
   "scripts": {
     "test": "grunt test"


### PR DESCRIPTION
This moves to Freedom v0.5-based `freedom-for-chrome` and `freedom-for-firefox`. No minor version bump since this doesn't require an API change. My next task is to give `socks-rtc` a custom API; that would obviously be a breaking change and should bump us to v0.2.

Tested with `grunt endtoend` and with curl in both Firefox and Chrome.

Only issue I see are some error messages in Chrome:

```
```

I wasn't able to quickly track down the source of these. Since my next task is to give `socks-rtc` a custom API, I intend to track down the issue then. All seems to work fine; my guess is this error reporting is new in Freedom 0.5.
