### PR TITLE
require.resolve to avoid node_module paths, and fix postinstall script

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -232,8 +232,6 @@ module.exports = (grunt) ->
     'copy:echoServerChromeApp'
   ]
 
-  #-------------------------------------------------------------------------
-  # tasks for sample apps
   taskManager.add 'socksRtcNet', [
     'base'
     'tcp'
@@ -246,7 +244,6 @@ module.exports = (grunt) ->
     'typescript:socksRtcNetChromeApp'
     'copy:socksRtcNetChromeApp'
   ]
-
 
   #-------------------------------------------------------------------------
   taskManager.add 'build', [

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -17,10 +17,14 @@ TaskManager = require 'uproxy-lib/tools/taskmanager'
 # build directory.
 Rule = require 'uproxy-lib/tools/common-grunt-rules'
 
+Path = require('path');
+
+uproxyLibPath = Path.dirname(require.resolve('uproxy-lib/package.json'))
+ipaddrPath = Path.dirname(require.resolve('ipaddr.js/package.json'))
+ccaPath = Path.dirname(require.resolve('cca/package.json'))
+
 #-------------------------------------------------------------------------
 module.exports = (grunt) ->
-  path = require('path');
-
   #-------------------------------------------------------------------------
   grunt.initConfig {
     pkg: grunt.file.readJSON('package.json')
@@ -44,13 +48,13 @@ module.exports = (grunt) ->
       uproxyLibThirdPartyTypescriptSrc: { files: [ {
         expand: true,
         overwrite: true,
-        cwd: 'node_modules/uproxy-lib',
+        cwd: uproxyLibPath,
         src: ['third_party'],
         dest: 'build/typescript-src/' } ] }
       uproxyLibTypescriptSrc: { files: [ {
         expand: true,
         overwrite: true,
-        cwd: 'node_modules/uproxy-lib/src/',
+        cwd: Path.join(uproxyLibPath, 'src'),
         src: ['*'],
         dest: 'build/typescript-src/' } ] }
 
@@ -60,7 +64,7 @@ module.exports = (grunt) ->
       #
       # Copy all the built stuff from uproxy-lib
       uproxyLibBuild: { files: [ {
-          expand: true, cwd: 'node_modules/uproxy-lib/build'
+          expand: true, cwd: Path.join(uproxyLibPath, 'build')
           src: ['**', '!**/typescript-src/**']
           dest: 'build'
           onlyIf: 'modified'
@@ -76,7 +80,7 @@ module.exports = (grunt) ->
 
       # Copy the ipaddr.js library into the build directory
       ipAddrJavaScript: { files: [ {
-          expand: true, cwd: 'node_modules/ipaddr.js'
+          expand: true, cwd: ipaddrPath
           src: ['ipaddr.min.js']
           dest: 'build/ipaddr/'
           onlyIf: 'modified'
@@ -135,9 +139,13 @@ module.exports = (grunt) ->
 
     clean: ['build/**']
 
-    ccaPath: 'node_modules/cca/src/cca.js'
+    ccaJsPath: Path.join(ccaPath, 'src/cca.js')
     ccaCwd: 'build/cca-app'
     exec: {
+      postInstallFromDev: {
+        cwd: uproxyLibPath
+        command: 'npm install'
+      }
       adbLog: {
         command: 'adb logcat *:I | grep CONSOLE'
       }
@@ -146,12 +154,12 @@ module.exports = (grunt) ->
         exitCode: [0,1]
       }
       ccaCreate: {
-        command: '<%= ccaPath %> create build/cca-app --link-to=socks-rtc-net/samples/socks-rtc-net-freedom-chromeapp/manifest.json'
+        command: '<%= ccaJsPath %> create build/cca-app --link-to=socks-rtc-net/samples/socks-rtc-net-freedom-chromeapp/manifest.json'
         exitCode: [0,1]
       }
       ccaEmulate: {
-        command: '../../<%= ccaPath %> emulate android'
         cwd: '<%= ccaCwd %>'
+        command: '../../<%= ccaJsPath %> emulate android'
       }
     }
   }  # grunt.initConfig

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   },
   "scripts": {
     "test": "grunt test",
-    "prepublish": "grunt test"
+    "prepublish": "grunt test",
+    "postinstall": "grunt exec:postInstallFromDev",
+    "postupdate": "grunt exec:postInstallFromDev"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "upoxy-networking",
+  "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
   "version": "1.0.1",
   "repository": {


### PR DESCRIPTION
- remove references to node_module paths by using require.resolve
- added a post-npm install script 

TESTED: ran & tested from clean clone:
`npm install`
then open sample app socks-rtc-net app and use it to do some proxying.  
