### PR TITLE
use churn rather than uproxypeerconnection

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -21,6 +21,7 @@ Path = require('path');
 
 uproxyLibPath = Path.dirname(require.resolve('uproxy-lib/package.json'))
 ipaddrPath = Path.dirname(require.resolve('ipaddr.js/package.json'))
+churnPath = Path.dirname(require.resolve('uproxy-churn/package.json'))
 ccaPath = Path.dirname(require.resolve('cca/package.json'))
 
 #-------------------------------------------------------------------------
@@ -57,6 +58,12 @@ module.exports = (grunt) ->
         cwd: Path.join(uproxyLibPath, 'src'),
         src: ['*'],
         dest: 'build/typescript-src/' } ] }
+      churnTypescriptSrc: { files: [ {
+        expand: true,
+        overwrite: true,
+        cwd: Path.join(churnPath, 'src'),
+        src: ['*'],
+        dest: 'build/typescript-src/' } ] }
 
     #-------------------------------------------------------------------------
     copy: {
@@ -83,6 +90,13 @@ module.exports = (grunt) ->
           expand: true, cwd: ipaddrPath
           src: ['ipaddr.min.js']
           dest: 'build/ipaddr/'
+          onlyIf: 'modified'
+        } ] }
+
+      churnBuild: { files: [ {
+          expand: true, cwd: Path.join(churnPath, 'build')
+          src: ['**', '!**/typescript-src/**']
+          dest: 'build'
           onlyIf: 'modified'
         } ] }
 
@@ -174,11 +188,13 @@ module.exports = (grunt) ->
     # copy modules from uproxyLibBuild to build/
     'copy:uproxyLibBuild'
     'copy:ipAddrJavaScript'
+    'copy:churnBuild'
     # symlink all modules with typescript src to build/typescript-src
     'symlink:uproxyLibTypescriptSrc'
     'symlink:uproxyLibThirdPartyTypescriptSrc'
     'symlink:thirdPartyTypescriptSrc'
     'symlink:typescriptSrc'
+    'symlink:churnTypescriptSrc'
   ]
 
   taskManager.add 'tcp', [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "grunt-typescript": "~0.3.0",
     "tsd": "~0.5.7",
     "uproxy-lib": "^11.0.1",
-    "webdriverjs": "^1.6.1"
+    "webdriverjs": "^1.6.1",
+    "uproxy-churn": "0.0.4"
   },
   "scripts": {
     "test": "grunt test",

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -7,6 +7,7 @@
 /// <reference path='../handler/queue.d.ts' />
 /// <reference path='../ipaddrjs/ipaddrjs.d.ts' />
 /// <reference path='../networking-typings/communications.d.ts' />
+/// <reference path="../churn/churn.d.ts" />
 /// <reference path='../webrtc/datachannel.d.ts' />
 /// <reference path='../webrtc/peerconnection.d.ts' />
 /// <reference path='../tcp/tcp.d.ts' />
@@ -69,7 +70,7 @@ module RtcToNet {
       // SOCKS sessions biject to peerconnection datachannels.
       this.sessions_ = {};
       this.proxyConfig = proxyConfig;
-      this.peerConnection_ = freedom['core.uproxypeerconnection'](pcConfig);
+      this.peerConnection_ = freedom.churn(pcConfig);
       this.peerConnection_.on('dataFromPeer', this.onDataFromPeer_);
       this.peerConnection_.on('peerOpenedChannel', (channelLabel:string) => {
         if(channelLabel === '_control_') {

--- a/src/socks-server/samples/copypaste-socks-chromeapp/freedom-module.json
+++ b/src/socks-server/samples/copypaste-socks-chromeapp/freedom-module.json
@@ -8,18 +8,20 @@
       "lib/ipaddr/ipaddr.min.js",
       "lib/logging/logging.js",
       "lib/tcp/tcp.js",
-      "lib/socks/socks-headers.js",
+      "lib/socks-common/socks-headers.js",
       "lib/socks-to-rtc/socks-to-rtc.js",
       "lib/rtc-to-net/rtc-to-net.js",
       "freedom-module.js"
     ]
   },
   "dependencies": {
+    "churn": {
+      "url": "lib/churn/freedom.json",
+      "api": "churn"
+    }
   },
   "permissions": [
     "core.log",
-    "core.tcpsocket",
-    "core.udpsocket",
-    "core.uproxypeerconnection"
+    "core.tcpsocket"
   ]
 }

--- a/src/socks-server/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/socks-server/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -6,7 +6,7 @@
 /// <reference path='../../../freedom/typings/freedom.d.ts' />
 /// <reference path='../../../networking-typings/communications.d.ts' />
 
-var log :Freedom_UproxyLogging.Log = freedom['core.log']('socks-rtc-net');
+var log :Freedom_UproxyLogging.Log = freedom['core.log']('copypaste-socks');
 
 var rtcNetPcConfig :WebRtc.PeerConnectionConfig = {
   webrtcPcConfig: {

--- a/src/socks-server/samples/simple-socks-chromeapp/freedom-module.json
+++ b/src/socks-server/samples/simple-socks-chromeapp/freedom-module.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-socks",
-  "description": "Single page SOCKS server.",
+  "description": "Single-page SOCKS server.",
   "app": {
     "script": [
       "lib/arraybuffers/arraybuffers.js",

--- a/src/socks-server/samples/simple-socks-chromeapp/freedom-module.json
+++ b/src/socks-server/samples/simple-socks-chromeapp/freedom-module.json
@@ -1,6 +1,6 @@
 {
-  "name": "socks-rtc-net",
-  "description": "Sample socks over rtc to net Freedom manifest",
+  "name": "simple-socks",
+  "description": "Single page SOCKS server.",
   "app": {
     "script": [
       "lib/arraybuffers/arraybuffers.js",
@@ -14,11 +14,13 @@
     ]
   },
   "dependencies": {
+    "churn": {
+      "url": "lib/churn/freedom.json",
+      "api": "churn"
+    }
   },
   "permissions": [
     "core.log",
-    "core.tcpsocket",
-    "core.udpsocket",
-    "core.uproxypeerconnection"
+    "core.tcpsocket"
   ]
 }

--- a/src/socks-server/samples/simple-socks-chromeapp/freedom-module.ts
+++ b/src/socks-server/samples/simple-socks-chromeapp/freedom-module.ts
@@ -6,7 +6,7 @@
 /// <reference path='../../../freedom/typings/freedom.d.ts' />
 /// <reference path='../../../networking-typings/communications.d.ts' />
 
-var log :Freedom_UproxyLogging.Log = freedom['core.log']('socks-rtc-net');
+var log :Freedom_UproxyLogging.Log = freedom['core.log']('simple-socks');
 
 //-----------------------------------------------------------------------------
 var localhostEndpoint:Net.Endpoint = { address: '127.0.0.1', port:9999 };
@@ -46,8 +46,6 @@ var socksRtc = new SocksToRtc.SocksToRtc(localhostEndpoint, socksRtcPcConfig);
 //-----------------------------------------------------------------------------
 socksRtc.signalsForPeer.setSyncHandler(rtcNet.handleSignalFromPeer);
 rtcNet.signalsForPeer.setSyncHandler(socksRtc.handleSignalFromPeer);
-
-log.info('socks-rtc-net started up.');
 
 socksRtc.onceReady
   .then((endpoint:Net.Endpoint) => {

--- a/src/socks-server/samples/simple-socks-chromeapp/manifest.json
+++ b/src/socks-server/samples/simple-socks-chromeapp/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Simple SOCKS",
-  "description": "Sample app for proxying SOCKS5 over WebRTC",
+  "description": "Single-page SOCKS server.",
   "version": "0.0.2",
   "app": {
     "background": {

--- a/src/socks-server/samples/simple-socks-chromeapp/manifest.json
+++ b/src/socks-server/samples/simple-socks-chromeapp/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "SocksRtcNet Sample App",
+  "name": "Simple SOCKS",
   "description": "Sample app for proxying SOCKS5 over WebRTC",
   "version": "0.0.2",
   "app": {
@@ -13,7 +13,15 @@
   },
   "permissions": [],
   "sockets": {
-    "tcp": { "connect" : "" },
-    "tcpServer": { "listen": "" }
+    "tcp": {
+      "connect" : ""
+    },
+    "tcpServer": {
+      "listen": ""
+    },
+    "udp": {
+      "bind": "*",
+      "send": "*"
+    }
   }
 }

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -6,6 +6,7 @@
 /// <reference path='../freedom/typings/freedom.d.ts' />
 /// <reference path='../handler/queue.d.ts' />
 /// <reference path='../networking-typings/communications.d.ts' />
+/// <reference path="../churn/churn.d.ts" />
 /// <reference path='../webrtc/datachannel.d.ts' />
 /// <reference path='../webrtc/peerconnection.d.ts' />
 /// <reference path='../tcp/tcp.d.ts' />
@@ -85,7 +86,7 @@ module SocksToRtc {
     private setupPeerConnection_ = (pcConfig:WebRtc.PeerConnectionConfig)
         : Promise<WebRtc.ConnectionAddresses> => {
       // SOCKS sessions biject to peerconnection datachannels.
-      this.peerConnection_ = freedom['core.uproxypeerconnection'](pcConfig);
+      this.peerConnection_ = freedom.churn(pcConfig);
       this.peerConnection_.on('dataFromPeer', this.onDataFromPeer_);
       this.peerConnection_.on('peerOpenedChannel', (channelLabel:string) => {
         log.error('unexpected peerOpenedChannel event: ' +


### PR DESCRIPTION
This integrates the SOCKS server with churn. Pretty simple, thanks to the identical interfaces. Depends on:
https://github.com/uProxy/uproxy-churn/pull/40

I wish there were a simple way to plug in different peerconnection providers but that seems like something to address at some future point.
