### PR TITLE
added stop-promise to socks-rtc-net

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -31,38 +31,39 @@ module.exports = (grunt) ->
     pkg: grunt.file.readJSON('package.json')
 
     symlink:
+      options:
+        # We should have overwirte set to true, but there is a bug:
+        # https://github.com/gruntjs/grunt-contrib-symlink/issues/12 This stops
+        # us from being able to sym-link into node_modules and have building
+        # work correctly.
+        overwrite: false
       # Symlink all module directories in `src` into typescript-src
       typescriptSrc: { files: [ {
         expand: true,
-        overwrite: true,
         cwd: 'src',
-        src: ['*'],
+        src: ['**/*.ts'],
         dest: 'build/typescript-src/' } ] }
       # Symlink third_party into typescript-src
       thirdPartyTypescriptSrc: { files: [ {
         expand: true,
-        overwrite: true,
-        cwd: '.',
-        src: ['third_party'],
-        dest: 'build/typescript-src/' } ] }
+        cwd: 'third_party',
+        src: ['**/*.ts'],
+        dest: 'build/typescript-src/third_party/' } ] }
       # Symlink third_party into typescript-src
       uproxyLibThirdPartyTypescriptSrc: { files: [ {
         expand: true,
-        overwrite: true,
-        cwd: uproxyLibPath,
-        src: ['third_party'],
-        dest: 'build/typescript-src/' } ] }
+        cwd: Path.join(uproxyLibPath, 'third_party'),
+        src: ['**/*.ts'],
+        dest: 'build/typescript-src/third_party/' } ] }
       uproxyLibTypescriptSrc: { files: [ {
         expand: true,
-        overwrite: true,
         cwd: Path.join(uproxyLibPath, 'src'),
-        src: ['*'],
+        src: ['**/*.ts'],
         dest: 'build/typescript-src/' } ] }
       churnTypescriptSrc: { files: [ {
         expand: true,
-        overwrite: true,
         cwd: Path.join(churnPath, 'src'),
-        src: ['*'],
+        src: ['**/*.ts'],
         dest: 'build/typescript-src/' } ] }
 
     #-------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tsd": "~0.5.7",
     "uproxy-lib": "^11.0.3",
     "webdriverjs": "^1.6.1",
-    "uproxy-churn": "0.0.4"
+    "uproxy-churn": "^0.0.5"
   },
   "scripts": {
     "test": "grunt test",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "grunt-jasmine-node": "~0.2.1",
     "grunt-typescript": "~0.3.0",
     "tsd": "~0.5.7",
-    "uproxy-lib": "^11.0.1",
+    "uproxy-lib": "^11.0.3",
     "webdriverjs": "^1.6.1",
     "uproxy-churn": "0.0.4"
   },

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -10,30 +10,28 @@ declare module RtcToNet {
     allowNonUnicast: boolean;
   }
   class RtcToNet {
+    constructor(pcConfig: WebRtc.PeerConnectionConfig,
+                proxyConfig: ProxyConfig);
     public proxyConfig: ProxyConfig;
     public signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
     public onceReady: Promise<void>;
     public onceClosed: Promise<void>;
-    constructor(pcConfig: WebRtc.PeerConnectionConfig,
-                proxyConfig: ProxyConfig);
-    private close;
+    public close: () => void;
     public handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
-    private onDataFromPeer_;
-    private handleControlMessage_;
     public toString: () => string;
   }
   class Session {
+    constructor(peerConnection_: freedom_UproxyPeerConnection.Pc,
+                channelLabel_: string,
+                proxyConfig: ProxyConfig);
+    public close: () => void;
     public proxyConfig: ProxyConfig;
     public tcpConnection: Tcp.Connection;
     public onceReady: Promise<void>;
     public onceClosed: Promise<void>;
     public channelLabel: () => string;
     public isClosed: () => boolean;
-    constructor(peerConnection_: freedom_UproxyPeerConnection.Pc,
-                channelLabel_: string,
-                proxyConfig: ProxyConfig);
     public longId: () => string;
-    public close: () => void;
     public handleWebRtcDataFromPeer: (webrtcData: WebRtc.Data) => void;
     public toString: () => string;
   }

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -7,32 +7,33 @@
 
 declare module RtcToNet {
   interface ProxyConfig {
-    allowNonUnicast: boolean;
+    allowNonUnicast :boolean;
   }
   class RtcToNet {
-    constructor(pcConfig: WebRtc.PeerConnectionConfig,
-                proxyConfig: ProxyConfig);
-    public proxyConfig: ProxyConfig;
-    public signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
-    public onceReady: Promise<void>;
-    public onceClosed: Promise<void>;
-    public close: () => void;
-    public handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
-    public toString: () => string;
+    constructor(pcConfig:WebRtc.PeerConnectionConfig,
+                proxyConfig:ProxyConfig,
+                obfuscate?:boolean);
+    public proxyConfig :ProxyConfig;
+    public signalsForPeer :Handler.Queue<WebRtc.SignallingMessage, void>;
+    public onceReady :Promise<void>;
+    public onceClosed :Promise<void>;
+    public close :() => void;
+    public handleSignalFromPeer :(signal:WebRtc.SignallingMessage) => void;
+    public toString :() => string;
   }
   class Session {
-    constructor(peerConnection_: freedom_UproxyPeerConnection.Pc,
-                channelLabel_: string,
-                proxyConfig: ProxyConfig);
-    public close: () => void;
-    public proxyConfig: ProxyConfig;
-    public tcpConnection: Tcp.Connection;
-    public onceReady: Promise<void>;
-    public onceClosed: Promise<void>;
-    public channelLabel: () => string;
-    public isClosed: () => boolean;
-    public longId: () => string;
-    public handleWebRtcDataFromPeer: (webrtcData: WebRtc.Data) => void;
-    public toString: () => string;
+    constructor(peerConnection_:freedom_UproxyPeerConnection.Pc,
+                channelLabel_:string,
+                proxyConfig:ProxyConfig);
+    public close :() => void;
+    public proxyConfig :ProxyConfig;
+    public tcpConnection :Tcp.Connection;
+    public onceReady :Promise<void>;
+    public onceClosed :Promise<void>;
+    public channelLabel :() => string;
+    public isClosed :() => boolean;
+    public longId :() => string;
+    public handleWebRtcDataFromPeer :(webrtcData: WebRtc.Data) => void;
+    public toString :() => string;
   }
 }

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -1,0 +1,40 @@
+/// <reference path="../freedom/coreproviders/uproxypeerconnection.d.ts" />
+/// <reference path="../handler/queue.d.ts" />
+/// <reference path="../webrtc/datachannel.d.ts" />
+/// <reference path="../webrtc/peerconnection.d.ts" />
+/// <reference path="../tcp/tcp.d.ts" />
+/// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
+
+declare module RtcToNet {
+  interface ProxyConfig {
+    allowNonUnicast: boolean;
+  }
+  class RtcToNet {
+    public proxyConfig: ProxyConfig;
+    public signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
+    public onceReady: Promise<void>;
+    public onceClosed: Promise<void>;
+    constructor(pcConfig: WebRtc.PeerConnectionConfig,
+                proxyConfig: ProxyConfig);
+    private close;
+    public handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
+    private onDataFromPeer_;
+    private handleControlMessage_;
+    public toString: () => string;
+  }
+  class Session {
+    public proxyConfig: ProxyConfig;
+    public tcpConnection: Tcp.Connection;
+    public onceReady: Promise<void>;
+    public onceClosed: Promise<void>;
+    public channelLabel: () => string;
+    public isClosed: () => boolean;
+    constructor(peerConnection_: freedom_UproxyPeerConnection.Pc,
+                channelLabel_: string,
+                proxyConfig: ProxyConfig);
+    public longId: () => string;
+    public close: () => void;
+    public handleWebRtcDataFromPeer: (webrtcData: WebRtc.Data) => void;
+    public toString: () => string;
+  }
+}

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -97,7 +97,7 @@ module RtcToNet {
 
     // Close the peer-connection (and hence all data channels) and all
     // associated TCP connections. Note: once closed, cannot be openned again.
-    private close = () => {
+    public close = () => {
       this.peerConnection_.close();
       // CONSIDER: will peerConnection's closing of channels make this un-
       // needed? is it better to include this anyway?

--- a/src/socks-server/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/socks-server/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../socks-to-rtc/socks-to-rtc.ts' />
-/// <reference path='../../../rtc-to-net/rtc-to-net.ts' />
+/// <reference path='../../../socks-to-rtc/socks-to-rtc.d.ts' />
+/// <reference path='../../../rtc-to-net/rtc-to-net.d.ts' />
 
 /// <reference path='../../../webrtc/peerconnection.d.ts' />
 /// <reference path='../../../freedom/coreproviders/uproxylogging.d.ts' />

--- a/src/socks-server/samples/simple-socks-chromeapp/freedom-module.ts
+++ b/src/socks-server/samples/simple-socks-chromeapp/freedom-module.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../socks-to-rtc/socks-to-rtc.ts' />
-/// <reference path='../../../rtc-to-net/rtc-to-net.ts' />
+/// <reference path='../../../socks-to-rtc/socks-to-rtc.d.ts' />
+/// <reference path='../../../rtc-to-net/rtc-to-net.d.ts' />
 
 /// <reference path='../../../webrtc/peerconnection.d.ts' />
 /// <reference path='../../../freedom/coreproviders/uproxylogging.d.ts' />

--- a/src/socks-server/samples/simple-socks-chromeapp/freedom-module.ts
+++ b/src/socks-server/samples/simple-socks-chromeapp/freedom-module.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../../socks-to-rtc/socks-to-rtc.d.ts' />
 /// <reference path='../../../rtc-to-net/rtc-to-net.d.ts' />
+/// <reference path='../../../socks-to-rtc/socks-to-rtc.d.ts' />
 
 /// <reference path='../../../webrtc/peerconnection.d.ts' />
 /// <reference path='../../../freedom/coreproviders/uproxylogging.d.ts' />

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -1,0 +1,31 @@
+/// <reference path="../freedom/coreproviders/uproxypeerconnection.d.ts" />
+/// <reference path="../handler/queue.d.ts" />
+/// <reference path="../networking-typings/communications.d.ts" />
+/// <reference path="../webrtc/datachannel.d.ts" />
+/// <reference path="../webrtc/peerconnection.d.ts" />
+/// <reference path="../tcp/tcp.d.ts" />
+/// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
+declare module SocksToRtc {
+  class SocksToRtc {
+    public onceReady: Promise<Net.Endpoint>;
+    public isStopped: () => boolean;
+    public onceStopped_: Promise<void>;
+    public onceStopped: () => Promise<void>;
+    public signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
+    constructor(endpoint: Net.Endpoint, pcConfig: WebRtc.PeerConnectionConfig);
+    public handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
+    public toString: () => string;
+  }
+  class Session {
+    constructor(tcpConnection: Tcp.Connection,
+                peerConnection_: freedom_UproxyPeerConnection.Pc);
+    public tcpConnection: Tcp.Connection;
+    public onceReady: Promise<Net.Endpoint>;
+    public onceClosed: Promise<void>;
+    public longId: () => string;
+    public close: () => Promise<void>;
+    public handleDataFromPeer(data: WebRtc.Data): void;
+    public channelLabel: () => string;
+    public toString: () => string;
+  }
+}

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -7,12 +7,12 @@
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 declare module SocksToRtc {
   class SocksToRtc {
+    constructor(endpoint: Net.Endpoint, pcConfig: WebRtc.PeerConnectionConfig);
+    public stop: () => Promise<void>;
     public onceReady: Promise<Net.Endpoint>;
     public isStopped: () => boolean;
-    public onceStopped_: Promise<void>;
     public onceStopped: () => Promise<void>;
     public signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
-    constructor(endpoint: Net.Endpoint, pcConfig: WebRtc.PeerConnectionConfig);
     public handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
     public toString: () => string;
   }

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -7,25 +7,27 @@
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 declare module SocksToRtc {
   class SocksToRtc {
-    constructor(endpoint: Net.Endpoint, pcConfig: WebRtc.PeerConnectionConfig);
-    public stop: () => Promise<void>;
-    public onceReady: Promise<Net.Endpoint>;
-    public isStopped: () => boolean;
-    public onceStopped: () => Promise<void>;
-    public signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
-    public handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
-    public toString: () => string;
+    constructor(endpoint:Net.Endpoint,
+                pcConfig:WebRtc.PeerConnectionConfig,
+                obfuscate:boolean);
+    public stop :() => Promise<void>;
+    public onceReady :Promise<Net.Endpoint>;
+    public isStopped :() => boolean;
+    public onceStopped :() => Promise<void>;
+    public signalsForPeer :Handler.Queue<WebRtc.SignallingMessage, void>;
+    public handleSignalFromPeer :(signal: WebRtc.SignallingMessage) => void;
+    public toString :() => string;
   }
   class Session {
-    constructor(tcpConnection: Tcp.Connection,
-                peerConnection_: freedom_UproxyPeerConnection.Pc);
-    public tcpConnection: Tcp.Connection;
-    public onceReady: Promise<Net.Endpoint>;
-    public onceClosed: Promise<void>;
-    public longId: () => string;
-    public close: () => Promise<void>;
-    public handleDataFromPeer(data: WebRtc.Data): void;
-    public channelLabel: () => string;
-    public toString: () => string;
+    constructor(tcpConnection:Tcp.Connection,
+                peerConnection_:freedom_UproxyPeerConnection.Pc);
+    public tcpConnection :Tcp.Connection;
+    public onceReady :Promise<Net.Endpoint>;
+    public onceClosed :Promise<void>;
+    public longId :() => string;
+    public close :() => Promise<void>;
+    public handleDataFromPeer :(data:WebRtc.Data) => void;
+    public channelLabel :() => string;
+    public toString :() => string;
   }
 }

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -261,7 +261,7 @@ module SocksToRtc {
       return this.onceClosed;
     }
 
-    public handleDataFromPeer(data:WebRtc.Data) {
+    public handleDataFromPeer = (data:WebRtc.Data) : void => {
       this.dataFromPeer_.handle(data);
     }
 

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -33,7 +33,8 @@ module SocksToRtc {
 
     private isStopped_ :boolean;
     public isStopped = () : boolean => { return this.isStopped_; }
-    public onceStopped :Promise<void>;
+    public onceStopped_ :Promise<void>;
+    public onceStopped = () : Promise<void> => { return this.onceStopped_; }
 
     // Message handler queues to/from the peer.
     public signalsForPeer :Handler.Queue<WebRtc.SignallingMessage, void>;
@@ -77,7 +78,7 @@ module SocksToRtc {
       // The socks to rtc session is over when the peer connection
       // disconnection is disconnected, at which point we call close to stop
       // the tcpo server too, and do any needed cleanup.
-      this.onceStopped = this.peerConnection_.onceDisconnected()
+      this.onceStopped_ = this.peerConnection_.onceDisconnected()
           .then(this.stop);
 
       // Return promise for then we have the tcp-server endpoint & we have a

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -33,7 +33,7 @@ module SocksToRtc {
 
     private isStopped_ :boolean;
     public isStopped = () : boolean => { return this.isStopped_; }
-    public onceStopped_ :Promise<void>;
+    private onceStopped_ :Promise<void>;
     public onceStopped = () : Promise<void> => { return this.onceStopped_; }
 
     // Message handler queues to/from the peer.
@@ -89,7 +89,7 @@ module SocksToRtc {
 
     // Stop SOCKS server and close peer-connection (and hence all data
     // channels).
-    private stop = () : Promise<void> => {
+    public stop = () : Promise<void> => {
       if (this.isStopped_) {
         return Promise.resolve<void>();
       }

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -163,8 +163,8 @@ module Tcp {
     public stopListening = () : Promise<void> => {
       // Close the server socket.
       return this.serverSocket_.close().then(() => {
-          log.debug('successfully stopped listening for more connections.');
-        });
+        log.debug('successfully stopped listening for more connections.');
+      });
     }
 
     public shutdown = () : Promise<void> => {

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -163,11 +163,13 @@ module Tcp {
     public stopListening = () : Promise<void> => {
       // Close the server socket.
       return this.serverSocket_.close().then(() => {
-        log.debug('successfully stopped listening for more connections.');
-      });
+          log.debug('successfully stopped listening for more connections.');
+        });
     }
 
     public shutdown = () : Promise<void> => {
+      // This order is important: make sure no new connections happen while
+      // we're trying to close all the connections.
       return this.stopListening().then(this.closeAll);
     }
   }  // class Tcp.Server


### PR DESCRIPTION
- Added promise support for when socks-rtc stops (e.g. peer-connection breaks or is closed by remote peer).
- Added declaration files (*.d) for socks-to-rtc and rtc-to-net
- Made typescript sym-links done by file, not directory (improves support for `cd` then `tsc` testing). 
- rtc-to-net now has 'close' as public
- churn is now used by semantic versioning
