### PR TITLE
disable churn in simple-socks for now

### DIFF
--- a/src/socks-server/samples/simple-socks-chromeapp/freedom-module.ts
+++ b/src/socks-server/samples/simple-socks-chromeapp/freedom-module.ts
@@ -30,7 +30,7 @@ var rtcNet = new RtcToNet.RtcToNet(
     {
       allowNonUnicast: true
     },
-    true); // obfuscate
+    false); // obfuscate
 
 //-----------------------------------------------------------------------------
 var socksRtcPcConfig :WebRtc.PeerConnectionConfig = {
@@ -49,7 +49,7 @@ var socksRtcPcConfig :WebRtc.PeerConnectionConfig = {
 var socksRtc = new SocksToRtc.SocksToRtc(
     localhostEndpoint,
     socksRtcPcConfig,
-    true); // obfuscate
+    false); // obfuscate
 
 //-----------------------------------------------------------------------------
 socksRtc.signalsForPeer.setSyncHandler(rtcNet.handleSignalFromPeer);


### PR DESCRIPTION
I can't make >1 request via the proxy with churn. Disabling for now so Lally can continue benchmarking.
