### PR TITLE
bump minor version for new close method call and typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"


### PR DESCRIPTION
For the new API calls introduced in:
https://github.com/uProxy/uproxy-networking/pull/119
