### PR TITLE
SOCKS server life-cycle: detailed definitions and unit tests for onceStarted and onceStopped promises

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -8,6 +8,14 @@ ipaddrjsPath = path.dirname(require.resolve('ipaddr.js/package.json'))
 churnPath = path.dirname(require.resolve('uproxy-churn/package.json'))
 ccaPath = path.dirname(require.resolve('cca/package.json'))
 
+FILES =
+  # Help Jasmine's PhantomJS understand promises.
+  jasmine_helpers: [
+    'node_modules/es6-promise/dist/promise-*.js',
+    '!node_modules/es6-promise/dist/promise-*amd.js',
+    '!node_modules/es6-promise/dist/promise-*.min.js'
+  ]
+
 #-------------------------------------------------------------------------
 module.exports = (grunt) ->
   grunt.initConfig {
@@ -94,6 +102,8 @@ module.exports = (grunt) ->
       socksCommonSpecDecl: Rule.typescriptSpecDecl 'socks-common'
 
       socksToRtc: Rule.typescriptSrc 'socks-to-rtc'
+      socksToRtcSpecDecl: Rule.typescriptSpecDecl 'socks-to-rtc'
+
       rtcToNet: Rule.typescriptSrc 'rtc-to-net'
 
       echoServerChromeApp: Rule.typescriptSrc 'samples/echo-server-chromeapp/'
@@ -103,6 +113,17 @@ module.exports = (grunt) ->
 
     jasmine:
       socksCommon: Rule.jasmineSpec 'socks-common'
+
+      # TODO: socksToRtc tests require a bunch of other modules
+      #       https://github.com/uProxy/uproxy/issues/430
+      socksToRtc:
+        src: FILES.jasmine_helpers.concat([
+          'build/handler/queue.js'
+          'build/socks-to-rtc/mocks.js'
+          'build/socks-to-rtc/socks-to-rtc.js'
+        ])
+        options:
+          specs: 'build/socks-to-rtc/*.spec.js'
 
     clean: ['build/', 'dist/', '.tscache/']
 
@@ -166,8 +187,10 @@ module.exports = (grunt) ->
 
   taskManager.add 'socksToRtc', [
     'base'
+    'tcp'
     'socksCommon'
     'ts:socksToRtc'
+    'ts:socksToRtcSpecDecl'
     'copy:socksToRtc'
   ]
 
@@ -179,6 +202,7 @@ module.exports = (grunt) ->
 
   taskManager.add 'rtcToNet', [
     'base'
+    'tcp'
     'socksCommon'
     'ipaddrjs'
     'ts:rtcToNet'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/socks-to-rtc/mocks.js
+++ b/src/socks-to-rtc/mocks.js
@@ -1,0 +1,4 @@
+// Create a mock instance of Freedom.
+// We do this in a non-TypeScript file because the ambient module declaration
+// prevents us creating any variable called freedom in TypeScript-land.
+var freedom = jasmine.createSpyObj('freedom', ['core.log']);

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -11,7 +11,6 @@ declare module SocksToRtc {
                 pcConfig?:WebRtc.PeerConnectionConfig,
                 obfuscate?:boolean);
     public stop :() => Promise<void>;
-    public onceStarted: () => Promise<void>;
     public onceReady :Promise<Net.Endpoint>;
     public isStopped :() => boolean;
     public onceStopped :() => Promise<void>;
@@ -20,11 +19,17 @@ declare module SocksToRtc {
     public bytesSentToPeer :Handler.Queue<number, void>;
     public handleSignalFromPeer :(signal: WebRtc.SignallingMessage) => void;
     public toString :() => string;
-
     public configure :(
         tcpServer:Tcp.Server,
         peerconnection:freedom_UproxyPeerConnection.Pc)
         => void;
+    public getOnceTcpServerStarted :(tcpServer:Tcp.Server) => Promise<void>;
+    public getOnceTcpServerStopped :(tcpServer:Tcp.Server) => Promise<void>;
+    public getOncePeerconnectionStarted :(
+        peerconnection:freedom_UproxyPeerConnection.Pc) => Promise<void>;
+    public getOncePeerconnectionStopped :(
+        peerconnection:freedom_UproxyPeerConnection.Pc) => Promise<void>;
+    public makeTcpToRtcSession :(tcpConnection:Tcp.Connection) => void;
   }
   class Session {
     constructor(tcpConnection:Tcp.Connection,

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -10,51 +10,30 @@
 /// <reference path="../tcp/tcp.d.ts" />
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 declare module SocksToRtc {
-    import WebrtcLib = freedom_UproxyPeerConnection;
     class SocksToRtc {
-        onceReady: Promise<Net.Endpoint>;
-        private onceStarted_;
         onceStarted: () => Promise<void>;
-        private onceStopped_;
+        onceReady: Promise<Net.Endpoint>;
         onceStopped: () => Promise<void>;
         signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
         bytesReceivedFromPeer: Handler.Queue<number, void>;
         bytesSentToPeer: Handler.Queue<number, void>;
-        private tcpServer_;
-        private peerConnection_;
-        private sessions_;
         constructor(endpoint?: Net.Endpoint, pcConfig?: WebRtc.PeerConnectionConfig, obfuscate?: boolean);
-        setResources(tcpServer: Tcp.Server, peerconnection: WebrtcLib.Pc): void;
-        makeDefaultOnceStarted(): void;
-        makeOnceStarted(socketReady: Promise<any>, pcReady: Promise<any>): void;
-        makeDefaultOnceStopped(): void;
-        makeOnceStopped(socketStopped: Promise<any>, pcStopped: Promise<any>): void;
-        stop: () => void;
-        private cleanup_;
-        public makeTcpToRtcSession(tcpConnection:Tcp.Connection): void;
+        configure(tcpServer: Tcp.Server, peerconnection: freedom_UproxyPeerConnection.Pc): void;
+        makeOnceStarted(serverReady: Promise<any>, peerconnectionReady: Promise<any>): void;
+        makeOnceStopped(serverTerminated: Promise<any>, peerconnectionTerminated: Promise<any>): void;
+        stop: () => Promise<void>;
+        makeTcpToRtcSession: (tcpConnection: Tcp.Connection) => void;
         handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
-        private onDataFromPeer_;
         toString: () => string;
     }
     class Session {
-        tcpConnection: Tcp.Connection;
-        private peerConnection_;
-        private bytesReceivedFromPeer;
-        private bytesSentToPeer;
-        private channelLabel_;
         onceReady: Promise<Net.Endpoint>;
         onceClosed: Promise<void>;
-        private dataChannelIsClosed_;
-        private dataFromPeer_;
-        constructor(tcpConnection: Tcp.Connection, peerConnection_: WebrtcLib.Pc, bytesReceivedFromPeer: Handler.Queue<number, void>, bytesSentToPeer: Handler.Queue<number, void>);
+        constructor(tcpConnection: Tcp.Connection, peerConnection_: freedom_UproxyPeerConnection.Pc, bytesReceivedFromPeer: Handler.Queue<number, void>, bytesSentToPeer: Handler.Queue<number, void>);
         longId: () => string;
         close: () => Promise<void>;
         handleDataFromPeer: (data: WebRtc.Data) => void;
         channelLabel: () => string;
         toString: () => string;
-        private doAuthHandshake_;
-        private receiveEndpointFromPeer_;
-        private doRequestHandshake_;
-        private linkTcpAndPeerConnectionData_;
     }
 }

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -1,39 +1,36 @@
-/// <reference path="../socks-common/socks-headers.d.ts" />
-/// <reference path="../freedom/coreproviders/uproxylogging.d.ts" />
 /// <reference path="../freedom/coreproviders/uproxypeerconnection.d.ts" />
-/// <reference path="../freedom/typings/freedom.d.ts" />
 /// <reference path="../handler/queue.d.ts" />
 /// <reference path="../networking-typings/communications.d.ts" />
-/// <reference path="../churn/churn.d.ts" />
 /// <reference path="../webrtc/datachannel.d.ts" />
 /// <reference path="../webrtc/peerconnection.d.ts" />
 /// <reference path="../tcp/tcp.d.ts" />
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 declare module SocksToRtc {
-    class SocksToRtc {
-        onceStarted: () => Promise<void>;
-        onceReady: Promise<Net.Endpoint>;
-        onceStopped: () => Promise<void>;
-        signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
-        bytesReceivedFromPeer: Handler.Queue<number, void>;
-        bytesSentToPeer: Handler.Queue<number, void>;
-        constructor(endpoint?: Net.Endpoint, pcConfig?: WebRtc.PeerConnectionConfig, obfuscate?: boolean);
-        configure(tcpServer: Tcp.Server, peerconnection: freedom_UproxyPeerConnection.Pc): void;
-        makeOnceStarted(serverReady: Promise<any>, peerconnectionReady: Promise<any>): void;
-        makeOnceStopped(serverTerminated: Promise<any>, peerconnectionTerminated: Promise<any>): void;
-        stop: () => Promise<void>;
-        makeTcpToRtcSession: (tcpConnection: Tcp.Connection) => void;
-        handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
-        toString: () => string;
-    }
-    class Session {
-        onceReady: Promise<Net.Endpoint>;
-        onceClosed: Promise<void>;
-        constructor(tcpConnection: Tcp.Connection, peerConnection_: freedom_UproxyPeerConnection.Pc, bytesReceivedFromPeer: Handler.Queue<number, void>, bytesSentToPeer: Handler.Queue<number, void>);
-        longId: () => string;
-        close: () => Promise<void>;
-        handleDataFromPeer: (data: WebRtc.Data) => void;
-        channelLabel: () => string;
-        toString: () => string;
-    }
+  class SocksToRtc {
+    constructor(endpoint:Net.Endpoint,
+                pcConfig:WebRtc.PeerConnectionConfig,
+                obfuscate:boolean);
+    public stop :() => Promise<void>;
+    public onceStarted: () => Promise<void>;
+    public onceReady :Promise<Net.Endpoint>;
+    public isStopped :() => boolean;
+    public onceStopped :() => Promise<void>;
+    public signalsForPeer :Handler.Queue<WebRtc.SignallingMessage, void>;
+    public bytesReceivedFromPeer :Handler.Queue<number, void>;
+    public bytesSentToPeer :Handler.Queue<number, void>;
+    public handleSignalFromPeer :(signal: WebRtc.SignallingMessage) => void;
+    public toString :() => string;
+  }
+  class Session {
+    constructor(tcpConnection:Tcp.Connection,
+                peerConnection_:freedom_UproxyPeerConnection.Pc);
+    public tcpConnection :Tcp.Connection;
+    public onceReady :Promise<Net.Endpoint>;
+    public onceClosed :Promise<void>;
+    public longId :() => string;
+    public close :() => Promise<void>;
+    public handleDataFromPeer :(data:WebRtc.Data) => void;
+    public channelLabel :() => string;
+    public toString :() => string;
+  }
 }

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -23,12 +23,6 @@ declare module SocksToRtc {
         tcpServer:Tcp.Server,
         peerconnection:freedom_UproxyPeerConnection.Pc)
         => Promise<Net.Endpoint>;
-    public getOnceTcpServerStarted :(tcpServer:Tcp.Server) => Promise<void>;
-    public getOnceTcpServerStopped :(tcpServer:Tcp.Server) => Promise<void>;
-    public getOncePeerconnectionStarted :(
-        peerconnection:freedom_UproxyPeerConnection.Pc) => Promise<void>;
-    public getOncePeerconnectionStopped :(
-        peerconnection:freedom_UproxyPeerConnection.Pc) => Promise<void>;
     public makeTcpToRtcSession :(tcpConnection:Tcp.Connection) => void;
   }
   class Session {

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -20,18 +20,10 @@ declare module SocksToRtc {
     public bytesSentToPeer :Handler.Queue<number, void>;
     public handleSignalFromPeer :(signal: WebRtc.SignallingMessage) => void;
     public toString :() => string;
-    public setResources :(
+
+    public configure :(
         tcpServer:Tcp.Server,
         peerconnection:freedom_UproxyPeerConnection.Pc)
-        => void;
-    public configure :() => void;
-    public makeOnceStarted :(
-        serverReady:Promise<any>,
-        peerconnectionReady:Promise<any>)
-        => void;
-    public makeOnceStopped :(
-        serverTerminated:Promise<any>,
-        peerconnectionTerminated:Promise<any>)
         => void;
   }
   class Session {

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -7,9 +7,9 @@
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 declare module SocksToRtc {
   class SocksToRtc {
-    constructor(endpoint:Net.Endpoint,
-                pcConfig:WebRtc.PeerConnectionConfig,
-                obfuscate:boolean);
+    constructor(endpoint?:Net.Endpoint,
+                pcConfig?:WebRtc.PeerConnectionConfig,
+                obfuscate?:boolean);
     public stop :() => Promise<void>;
     public onceStarted: () => Promise<void>;
     public onceReady :Promise<Net.Endpoint>;
@@ -20,6 +20,19 @@ declare module SocksToRtc {
     public bytesSentToPeer :Handler.Queue<number, void>;
     public handleSignalFromPeer :(signal: WebRtc.SignallingMessage) => void;
     public toString :() => string;
+    public setResources :(
+        tcpServer:Tcp.Server,
+        peerconnection:freedom_UproxyPeerConnection.Pc)
+        => void;
+    public configure :() => void;
+    public makeOnceStarted :(
+        serverReady:Promise<any>,
+        peerconnectionReady:Promise<any>)
+        => void;
+    public makeOnceStopped :(
+        serverTerminated:Promise<any>,
+        peerconnectionTerminated:Promise<any>)
+        => void;
   }
   class Session {
     constructor(tcpConnection:Tcp.Connection,

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -19,10 +19,10 @@ declare module SocksToRtc {
     public bytesSentToPeer :Handler.Queue<number, void>;
     public handleSignalFromPeer :(signal: WebRtc.SignallingMessage) => void;
     public toString :() => string;
-    public configure :(
+    public start :(
         tcpServer:Tcp.Server,
         peerconnection:freedom_UproxyPeerConnection.Pc)
-        => void;
+        => Promise<Net.Endpoint>;
     public getOnceTcpServerStarted :(tcpServer:Tcp.Server) => Promise<void>;
     public getOnceTcpServerStopped :(tcpServer:Tcp.Server) => Promise<void>;
     public getOncePeerconnectionStarted :(

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -1,35 +1,60 @@
+/// <reference path="../socks-common/socks-headers.d.ts" />
+/// <reference path="../freedom/coreproviders/uproxylogging.d.ts" />
 /// <reference path="../freedom/coreproviders/uproxypeerconnection.d.ts" />
+/// <reference path="../freedom/typings/freedom.d.ts" />
 /// <reference path="../handler/queue.d.ts" />
 /// <reference path="../networking-typings/communications.d.ts" />
+/// <reference path="../churn/churn.d.ts" />
 /// <reference path="../webrtc/datachannel.d.ts" />
 /// <reference path="../webrtc/peerconnection.d.ts" />
 /// <reference path="../tcp/tcp.d.ts" />
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 declare module SocksToRtc {
-  class SocksToRtc {
-    constructor(endpoint:Net.Endpoint,
-                pcConfig:WebRtc.PeerConnectionConfig,
-                obfuscate:boolean);
-    public stop :() => Promise<void>;
-    public onceReady :Promise<Net.Endpoint>;
-    public isStopped :() => boolean;
-    public onceStopped :() => Promise<void>;
-    public signalsForPeer :Handler.Queue<WebRtc.SignallingMessage, void>;
-    public bytesReceivedFromPeer :Handler.Queue<number, void>;
-    public bytesSentToPeer :Handler.Queue<number, void>;
-    public handleSignalFromPeer :(signal: WebRtc.SignallingMessage) => void;
-    public toString :() => string;
-  }
-  class Session {
-    constructor(tcpConnection:Tcp.Connection,
-                peerConnection_:freedom_UproxyPeerConnection.Pc);
-    public tcpConnection :Tcp.Connection;
-    public onceReady :Promise<Net.Endpoint>;
-    public onceClosed :Promise<void>;
-    public longId :() => string;
-    public close :() => Promise<void>;
-    public handleDataFromPeer :(data:WebRtc.Data) => void;
-    public channelLabel :() => string;
-    public toString :() => string;
-  }
+    import WebrtcLib = freedom_UproxyPeerConnection;
+    class SocksToRtc {
+        onceReady: Promise<Net.Endpoint>;
+        private onceStarted_;
+        onceStarted: () => Promise<void>;
+        private onceStopped_;
+        onceStopped: () => Promise<void>;
+        signalsForPeer: Handler.Queue<WebRtc.SignallingMessage, void>;
+        bytesReceivedFromPeer: Handler.Queue<number, void>;
+        bytesSentToPeer: Handler.Queue<number, void>;
+        private tcpServer_;
+        private peerConnection_;
+        private sessions_;
+        constructor(endpoint?: Net.Endpoint, pcConfig?: WebRtc.PeerConnectionConfig, obfuscate?: boolean);
+        setResources(tcpServer: Tcp.Server, peerconnection: WebrtcLib.Pc): void;
+        makeDefaultOnceStarted(): void;
+        makeOnceStarted(socketReady: Promise<any>, pcReady: Promise<any>): void;
+        makeDefaultOnceStopped(): void;
+        makeOnceStopped(socketStopped: Promise<any>, pcStopped: Promise<any>): void;
+        stop: () => void;
+        private cleanup_;
+        public makeTcpToRtcSession(tcpConnection:Tcp.Connection): void;
+        handleSignalFromPeer: (signal: WebRtc.SignallingMessage) => void;
+        private onDataFromPeer_;
+        toString: () => string;
+    }
+    class Session {
+        tcpConnection: Tcp.Connection;
+        private peerConnection_;
+        private bytesReceivedFromPeer;
+        private bytesSentToPeer;
+        private channelLabel_;
+        onceReady: Promise<Net.Endpoint>;
+        onceClosed: Promise<void>;
+        private dataChannelIsClosed_;
+        private dataFromPeer_;
+        constructor(tcpConnection: Tcp.Connection, peerConnection_: WebrtcLib.Pc, bytesReceivedFromPeer: Handler.Queue<number, void>, bytesSentToPeer: Handler.Queue<number, void>);
+        longId: () => string;
+        close: () => Promise<void>;
+        handleDataFromPeer: (data: WebRtc.Data) => void;
+        channelLabel: () => string;
+        toString: () => string;
+        private doAuthHandshake_;
+        private receiveEndpointFromPeer_;
+        private doRequestHandshake_;
+        private linkTcpAndPeerConnectionData_;
+    }
 }

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -25,6 +25,7 @@ describe("socksToRtc", function() {
         'listen',
         'shutdown'
       ]);
+    mockTcpServer.endpoint = mockEndpoint;
     mockPeerconnection = jasmine.createSpyObj('peerconnection', [
         'on',
         'negotiateConnection',

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -1,0 +1,80 @@
+/// <reference path='socks-to-rtc.d.ts' />
+/// <reference path='../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../third_party/typings/jasmine/jasmine.d.ts' />
+
+describe("socksToRtc", function() {
+  var server :SocksToRtc.SocksToRtc;
+  var stop :jasmine.Spy;
+
+  beforeEach(function() {
+    server = new SocksToRtc.SocksToRtc();
+    stop = spyOn(server, 'stop');
+  });
+
+  it('onceStarted fulfills on socket and peerconnection success and does not clean up', (done) => {
+    server.makeOnceStarted(
+        Promise.resolve(),  // socket setup
+        Promise.resolve()); // peerconnection setup
+    server.onceStarted()
+      .then(() => {
+        expect(stop).not.toHaveBeenCalled();
+      })
+      .then(done);
+  });
+
+  it('onceStarted rejects and cleans up on socket setup failure', (done) => {
+    server.makeOnceStarted(
+        Promise.reject(new Error('failed to listen')), // socket
+        new Promise((F, R) => {}));                    // peerconnection
+    server.onceStarted()
+      .catch((e:Error) => {
+        expect(stop).toHaveBeenCalled();
+      })
+      .then(done);
+  });
+
+  it('onceStarted rejects and cleans up on peerconnection setup failure', (done) => {
+    server.makeOnceStarted(
+        new Promise((F, R) => {}),                         // socket
+        Promise.reject(new Error('failed to negotiate'))); // peerconnection
+    server.onceStarted()
+      .catch((e:Error) => {
+        expect(stop).toHaveBeenCalled();
+      })
+      .then(done);
+  });
+
+  it('onceStopped fulfills and cleans up on socket termination fulfillment', (done) => {
+    server.makeOnceStopped(
+        Promise.resolve(),          // socket
+        new Promise((F, R) => {})); // peerconnection
+    server.onceStopped()
+      .then(() => {
+        expect(stop).toHaveBeenCalled();
+      })
+      .then(done);
+  });
+
+  it('onceStopped fulfills and cleans up on peerconnection fulfillment', (done) => {
+    server.makeOnceStopped(
+        new Promise((F, R) => {}), // socket
+        Promise.resolve());        // peerconnection
+    server.onceStopped()
+      .then(() => {
+        expect(stop).toHaveBeenCalled();
+      })
+      .then(done);
+  });
+
+  it('onceStopped rejects if stop fails', (done) => {
+    stop.and.returnValue(Promise.reject('shutdown failed'));
+    server.makeOnceStopped(
+        Promise.resolve(),  // socket
+        Promise.resolve()); // peerconnection
+    server.onceStopped()
+      .catch((e:Error) => {
+        expect(stop).toHaveBeenCalled();
+      })
+      .then(done);
+  });
+});

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -45,14 +45,15 @@ describe("socksToRtc", function() {
   });
 
   it('stop sufficient to fulfill onceStopped', (done) => {
-    // Both TCP server and peerconnection start terminate successfully.
+    // Both TCP server and peerconnection start successfully
+    // and neither terminates "naturally".
     spyOn(server, 'getOnceTcpServerStarted').and.returnValue(Promise.resolve());
     spyOn(server, 'getOncePeerconnectionStarted').and.returnValue(Promise.resolve());
     spyOn(server, 'getOnceTcpServerStopped').and.returnValue(new Promise<void>((F, R) => {}));
     spyOn(server, 'getOncePeerconnectionStopped').and.returnValue(new Promise<void>((F, R) => {}));
-    server.start(mockTcpServer, mockPeerconnection);
-    server.stop();
-    server.onceStopped().then(done);
+
+    server.start(mockTcpServer, mockPeerconnection).then(
+          server.stop).then(server.onceStopped).then(done);
   });
 
   it('socket setup failure sufficient to fulfill onceStopped', (done) => {

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -32,9 +32,7 @@ describe("socksToRtc", function() {
     spyOn(server, 'getOncePeerconnectionStarted').and.returnValue(Promise.resolve());
     spyOn(server, 'getOnceTcpServerStopped').and.returnValue(new Promise<void>((F, R) => {}));
     spyOn(server, 'getOncePeerconnectionStopped').and.returnValue(new Promise<void>((F, R) => {}));
-    server.configure(mockTcpServer, mockPeerconnection);
-
-    server.onceReady.then(done);
+    server.start(mockTcpServer, mockPeerconnection).then(done);
   });
 
   it('onceReady and onceStopped fulfill on socket and peerconnection setup and termination success', (done) => {
@@ -43,9 +41,7 @@ describe("socksToRtc", function() {
     spyOn(server, 'getOnceTcpServerStopped').and.returnValue(Promise.resolve());
     spyOn(server, 'getOncePeerconnectionStarted').and.returnValue(Promise.resolve());
     spyOn(server, 'getOncePeerconnectionStopped').and.returnValue(Promise.resolve());
-    server.configure(mockTcpServer, mockPeerconnection);
-
-    server.onceReady.then(server.onceStopped).then(done);
+    server.start(mockTcpServer, mockPeerconnection).then(done);
   });
 
   it('stop sufficient to fulfill onceStopped', (done) => {
@@ -54,8 +50,7 @@ describe("socksToRtc", function() {
     spyOn(server, 'getOncePeerconnectionStarted').and.returnValue(Promise.resolve());
     spyOn(server, 'getOnceTcpServerStopped').and.returnValue(new Promise<void>((F, R) => {}));
     spyOn(server, 'getOncePeerconnectionStopped').and.returnValue(new Promise<void>((F, R) => {}));
-    server.configure(mockTcpServer, mockPeerconnection);
-
+    server.start(mockTcpServer, mockPeerconnection);
     server.stop();
     server.onceStopped().then(done);
   });
@@ -66,8 +61,6 @@ describe("socksToRtc", function() {
     spyOn(server, 'getOncePeerconnectionStarted').and.returnValue(Promise.resolve());
     spyOn(server, 'getOnceTcpServerStopped').and.returnValue(new Promise<void>((F, R) => {}));
     spyOn(server, 'getOncePeerconnectionStopped').and.returnValue(new Promise<void>((F, R) => {}));
-    server.configure(mockTcpServer, mockPeerconnection);
-
-    server.onceReady.catch(server.onceStopped).then(done);
+    server.start(mockTcpServer, mockPeerconnection).catch(server.onceStopped).then(done);
   });
 });

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -85,7 +85,7 @@ module SocksToRtc {
         pcConfig?:WebRtc.PeerConnectionConfig,
         obfuscate?:boolean) {
       if (endpoint) {
-        this.configure(
+        this.start(
             new Tcp.Server(endpoint, this.makeTcpToRtcSession),
             obfuscate ?
               freedom.churn(pcConfig) :
@@ -93,12 +93,12 @@ module SocksToRtc {
       }
     }
 
-    // Sets the TCP server and peerconnection to be used by this SOCKS server.
-    // onceReady can be used to listen for startup success or failure.
-    public configure(
+    // Starts the SOCKS server with the supplied TCP server and peerconnection.
+    // Returns this.onceReady.
+    public start(
         tcpServer:Tcp.Server,
         peerconnection:freedom_UproxyPeerConnection.Pc)
-        : void {
+        : Promise<Net.Endpoint> {
       if (this.tcpServer_) {
         throw new Error('already configured');
       }
@@ -131,6 +131,8 @@ module SocksToRtc {
           this.getOncePeerconnectionStopped(this.peerConnection_)])
         .then(this.stop);
       this.onceStopped_ = onceStopping.then(this.doStop_);
+
+      return this.onceReady;
     }
 
     // Returns a promise which fulfills once the server is ready to accept

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -128,7 +128,6 @@ module SocksToRtc {
       if (this.tcpServer_ === undefined) {
         throw new Error('must set resources before configuring');
       }
-      this.setResources(this.tcpServer_, this.peerConnection_);
 
       this.peerConnection_.on('dataFromPeer', this.onDataFromPeer_);
       this.peerConnection_.on('signalForPeer', this.signalsForPeer.handle);

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -15,8 +15,6 @@
 console.log('WEBWORKER - SocksToRtc: ' + self.location.href);
 
 module SocksToRtc {
-  import WebrtcLib = freedom_UproxyPeerConnection;
-
   var log :Freedom_UproxyLogging.Log = freedom['core.log']('SocksToRtc');
 
   var tagNumber_ = 0;
@@ -28,12 +26,26 @@ module SocksToRtc {
   // remotely through WebRTC peer connections.
   // TODO: rename this 'Server'.
   export class SocksToRtc {
-    // Holds the IP/port that the localhost socks server is listeneing to.
-    public onceReady : Promise<Net.Endpoint>;
 
-    private isStopped_ :boolean;
-    public isStopped = () : boolean => { return this.isStopped_; }
+    // Fulfills once the TCP socket is listening for connections and a
+    // peerconnection has been successfully established. Rejects if either
+    // socket or peerconnection setup fails. On rejection, both TCP socket
+    // and peerconnection will be closed.
+    private onceStarted_ :Promise<void>;
+    public onceStarted = () : Promise<void> => { return this.onceStarted_; }
 
+    // As onceStarted(), but reports the address on which the server
+    // is listening for connections.
+    // TODO: Remove this public field in favour of onceStarted() and a
+    //       getEndpoint()-type method
+    public onceReady :Promise<Net.Endpoint>;
+
+    // Fulfills once the TCP socket has closed or the peerconnection
+    // has terminated *and* there is subsequently no error closing the
+    // socket or the peerconnection (if an error is encountered at this
+    // stage, this rejects).
+    // Behaviour is undefined if onceStarted() has rejected so do not
+    // rely on this promise unless startup has succeeded.
     private onceStopped_ :Promise<void>;
     public onceStopped = () : Promise<void> => { return this.onceStopped_; }
 
@@ -63,7 +75,7 @@ module SocksToRtc {
 
     // The connection to the peer that is acting as the endpoint for the proxy
     // connection.
-    private peerConnection_  :WebrtcLib.Pc = null;
+    private peerConnection_  :freedom_UproxyPeerConnection.Pc = null;
 
     // From WebRTC data-channel labels to their TCP connections. Most of the
     // wiring to manage this relationship happens via promises of the
@@ -75,85 +87,125 @@ module SocksToRtc {
     // removed.
     private sessions_ :{ [channelLabel:string] : Session } = {};
 
-    // SocsToRtc server is given a localhost transport address (endpoint) to
-    // start a socks server listening to, and a config for setting up a peer-
-    // connection. The constructor will immidiately start negotiating the
-    // connection. TODO: If the given port is zero, platform chooses a port and
-    // this listening port is returned by the |onceReady| promise.
+    // Creates a new SOCKS server running on the specified address.
+    // A TCP server and peerconnection, configured with the supplied endpoint
+    // and config, are constructed.
+    // If the endpoint is undefined, the caller must manually configure the
+    // server; this is only intended for unit tests.
+    // TODO: Replace this with a static constructor.
     constructor(
-        endpoint:Net.Endpoint,
-        pcConfig:WebRtc.PeerConnectionConfig,
+        endpoint?:Net.Endpoint,
+        pcConfig?:WebRtc.PeerConnectionConfig,
         obfuscate?:boolean) {
-      // The |onceTcpServerReady| promise holds the address and port that the
-      // tcp-server is listening on.
-      var onceTcpServerReady :Promise<Net.Endpoint>;
-      // The |oncePeerConnectionReady| holds the IP/PORT of the peer once a
-      // connection to them has been established.
-      var oncePeerConnectionReady :Promise<WebRtc.ConnectionAddresses>;
-
-      // Create SOCKS server and start listening.
-      this.tcpServer_ = new Tcp.Server(endpoint, this.makeTcpToRtcSession_);
-      onceTcpServerReady = this.tcpServer_.listen();
-      oncePeerConnectionReady = this.setupPeerConnection_(pcConfig, obfuscate);
-
-      // The socks to rtc session is over when the peer connection
-      // disconnection is disconnected, at which point we call close to stop
-      // the tcpo server too, and do any needed cleanup.
-      this.onceStopped_ = this.peerConnection_.onceDisconnected()
-          .then(this.stop);
-
-      // Return promise for then we have the tcp-server endpoint & we have a
-      // peer connection.
-      this.onceReady = oncePeerConnectionReady
-        .then(() => { return onceTcpServerReady; });
-    }
-
-    // Stop SOCKS server and close peer-connection (and hence all data
-    // channels).
-    public stop = () : Promise<void> => {
-      if (this.isStopped_) {
-        return Promise.resolve<void>();
+      if (endpoint) {
+        this.configure(
+            new Tcp.Server(endpoint, this.makeTcpToRtcSession),
+            obfuscate ?
+              freedom.churn(pcConfig) :
+              freedom['core.uproxypeerconnection'](pcConfig));
       }
-      this.isStopped_ = true;
-      this.signalsForPeer.clear();
-      this.bytesReceivedFromPeer.clear();
-      this.bytesSentToPeer.clear();
-      this.peerConnection_.close();
-      this.sessions_ = {};
-      return this.tcpServer_.shutdown();
     }
 
-    private setupPeerConnection_ = (
-        pcConfig:WebRtc.PeerConnectionConfig,
-        obfuscate?:boolean)
-        : Promise<WebRtc.ConnectionAddresses> => {
-      // SOCKS sessions biject to peerconnection datachannels.
-      this.peerConnection_ = obfuscate ?
-          freedom.churn(pcConfig) :
-          freedom['core.uproxypeerconnection'](pcConfig);
-      this.peerConnection_.on('dataFromPeer', this.onDataFromPeer_);
-      this.peerConnection_.on('peerOpenedChannel', (channelLabel:string) => {
-        log.error('unexpected peerOpenedChannel event: ' +
-            JSON.stringify(channelLabel));
-      });
-      this.peerConnection_.on('signalForPeer',
-          this.signalsForPeer.handle);
+    // Same as the constructor, except creation of TCP server
+    // and peerconnection objects is delegated to the caller.
+    // This method is intended for use by unit tests.
+    public configure(
+        tcpServer:Tcp.Server,
+        peerconnection:freedom_UproxyPeerConnection.Pc)
+        : void {
+      if (this.tcpServer_) {
+        throw new Error('resources already set');
+      }
+      this.tcpServer_ = tcpServer;
+      this.peerConnection_ = peerconnection;
 
-      var onceConnected = this.peerConnection_.onceConnected()
-      this.peerConnection_.negotiateConnection();
-      // Give back onceConnected endpoint, but only after a control channel has
-      // been setupp.
-      return onceConnected.then(() => {
-          return this.peerConnection_.openDataChannel('_control_')
-        })
-        .then(() => {
-          this.peerConnection_.send('_control_', { str: 'hello?' });
-          return onceConnected;
+      this.peerConnection_.on('dataFromPeer', this.onDataFromPeer_);
+      this.peerConnection_.on('signalForPeer', this.signalsForPeer.handle);
+
+      // TODO: Integration tests for these objects' startup behaviours.
+      this.makeOnceStarted(
+          this.tcpServer_.listen(),
+          this.peerConnection_.negotiateConnection());
+
+      // TODO: Integration tests for these objects' termination behaviours.
+      this.makeOnceStopped(
+          // TCP server has no onceDisconnected()-type method!
+          // So, supply a dummy promise that neither resolves nor rejects.
+          new Promise((F, R) => {}),
+          this.peerConnection_.onceDisconnected());
+
+      this.onceReady = this.onceStarted_.then(() => {
+        return {
+          address: this.tcpServer_.endpoint.address,
+          port: this.tcpServer_.endpoint.port
+        };
+      });
+    }
+
+    // Configures onceStarted_, given two other promises:
+    //  - serverReady must fulfill once the server is ready to accept
+    //    connections and must reject if it fails to start listening
+    //  - peerconnectionReady must fulfill once it has successfully connected
+    //    with the remote peer and must reject if a connection cannot be
+    //    established
+    //
+    // Public for unit tests, so that startup failures can be easily simulated.
+    public makeOnceStarted(
+        serverReady:Promise<any>,
+        peerconnectionReady:Promise<any>)
+        : void {
+      if (this.onceStarted_) {
+        throw new Error('onceStarted_ already set');
+      }
+      this.onceStarted_ = Promise.all([
+          serverReady,
+          peerconnectionReady])
+        .then((answers:any[]) => {
+          return Promise.resolve<void>();
+        });
+      this.onceStarted_.catch(this.stop);
+    }
+
+    // Configures onceStopped_, given two other promises:
+    //  - serverTerminated must fulfill if the server dies for any
+    //    reason, its socket's network interface disappears
+    //  - peerconnectionTerminated must fulfill if the peerconnection
+    //    is terminated for any reason
+    //
+    // Public for unit tests, so that termination failures can be easily
+    // simulated.
+    public makeOnceStopped(
+        serverTerminated:Promise<any>,
+        peerconnectionTerminated:Promise<any>)
+        : void {
+      if (this.onceStopped_) {
+        throw new Error('onceStopped_ already set');
+      }
+      this.onceStopped_ = Promise.race([
+          serverTerminated,
+          peerconnectionTerminated])
+        .then(this.stop);
+    }
+
+    // Stops accepting TCP connections and closes the peerconnection.
+    // Fulfills if both TCP server and peerconnection terminate normally,
+    // otherwise rejects.
+    // The SOCKS server cannot be used once this method has been invoked.
+    public stop = () : Promise<void> => {
+      // TODO: Integration tests for these objects' stop()-like methods.
+      return Promise.all([
+          this.tcpServer_.shutdown(),
+          this.peerConnection_.close()])
+        .then((answers:any[]) => {
+          return Promise.resolve();
+        }, (e:Error) => {
+          return Promise.reject(e);
         });
     }
 
-    // Setup a SOCKS5 TCP-to-rtc session from a tcp connection.
-    private makeTcpToRtcSession_ = (tcpConnection:Tcp.Connection) : void => {
+    // Invoked when a SOCKS client establishes a connection with our
+    // server socket.
+    public makeTcpToRtcSession = (tcpConnection:Tcp.Connection) : void => {
       var session = new Session(tcpConnection, this.peerConnection_,
         this.bytesReceivedFromPeer, this.bytesSentToPeer);
       this.sessions_[session.channelLabel()] = session;
@@ -169,7 +221,8 @@ module SocksToRtc {
 
     // Data from the remote peer over WebRtc gets sent to the
     // socket that corresponds to the channel label.
-    private onDataFromPeer_ = (rtcData:WebrtcLib.LabelledDataChannelMessage)
+    private onDataFromPeer_ = (
+        rtcData:freedom_UproxyPeerConnection.LabelledDataChannelMessage)
         : void => {
       log.debug('onDataFromPeer_: ' + JSON.stringify(rtcData));
 
@@ -227,7 +280,7 @@ module SocksToRtc {
     private dataFromPeer_ :Handler.Queue<WebRtc.Data,void>;
 
     constructor(public tcpConnection:Tcp.Connection,
-                private peerConnection_:WebrtcLib.Pc,
+                private peerConnection_:freedom_UproxyPeerConnection.Pc,
                 private bytesReceivedFromPeer:Handler.Queue<number,void>,
                 private bytesSentToPeer:Handler.Queue<number,void>) {
       this.channelLabel_ = obtainTag();

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -114,8 +114,8 @@ module SocksToRtc {
       this.peerConnection_.on('dataFromPeer', this.onDataFromPeer_);
       this.peerConnection_.on('signalForPeer', this.signalsForPeer.handle);
 
-      // Start the peerconnection. TCP server doesn't have a start/onceReady
-      // separation so we let getOnceTcpServerStarted start the TCP server.
+      // Start the peerconnection (getOnceTcpServerStarted starts
+      // the TCP server).
       peerconnection.negotiateConnection();
 
       // Startup notifications.

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -115,13 +115,14 @@ module SocksToRtc {
       this.peerConnection_.on('signalForPeer', this.signalsForPeer.handle);
 
       // Start and listen for notifications.
+      // TODO: Use tcpServer.onceConnected once it's available.
       peerconnection.negotiateConnection();
       this.onceReady = Promise.all<any>([
           tcpServer.listen(),
           peerconnection.onceConnected()
         ])
         .then((answers:any[]) => {
-          return answers[0];
+          return tcpServer.endpoint;
         });
 
       // Shutdown if startup fails, or peerconnection terminates.


### PR DESCRIPTION
The general idea here is that the SOCKS server depends on two things to function:
- TCP server
- peerconnection

Once both have successfully started, the SOCKS server is running (`onceStarted`); conversely, once _either_ dies, the SOCKS server has died (`onceStopped`).

This defines `onceStarted` and `onceStopped` reasonably concretely and adds unit tests for how they should behave. Those tests are obviously pretty abstract so this pull request has a number of TODOs marking where integration tests are required, e.g. verify peerconnection's `onceDisconnected` actually fires and that its `stop` method is idempodent.

Tested with the sample apps.

Clearly, a followup pull request would implement a similar lifecycle for SOCKS sessions which depend on both a TCP connection and data channel to function.
