### PR TITLE
improving/filling out the tcp interface, proper closing

### DIFF
--- a/bin/echo-server-stresser.sh
+++ b/bin/echo-server-stresser.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Simple shell script to launch 10000 clients against the server at a rate of
+# 200 new clients/second. Each client will wait up to 5 seconds to connect and,
+# once connected, will keep its connection open for 1 second. This script
+# should complete in ~50 seconds.
+
+for i in `seq 1 10000`; do
+  echo "Sending $i"
+  (echo $i|nc -n 127.0.0.1 9998 -q 5 -w 1) &
+  sleep 0.005
+done

--- a/src/samples/echo-server-chromeapp/freedom-module.ts
+++ b/src/samples/echo-server-chromeapp/freedom-module.ts
@@ -1,5 +1,6 @@
 /// <reference path='../../freedom/typings/freedom.d.ts' />
 /// <reference path='../../freedom/coreproviders/uproxylogging.d.ts' />
+/// <reference path='tcp-echo-server.ts' />
 
 var log :Freedom_UproxyLogging.Log = freedom['core.log']('echo-server');
 

--- a/src/samples/echo-server-chromeapp/tcp-echo-server.ts
+++ b/src/samples/echo-server-chromeapp/tcp-echo-server.ts
@@ -4,6 +4,7 @@
 /// <reference path='../../freedom/coreproviders/uproxylogging.d.ts' />
 /// <reference path='../../networking-typings/communications.d.ts' />
 /// <reference path='../../tcp/tcp.d.ts' />
+/// <reference path='freedom-module.ts' />
 
 class TcpEchoServer {
   public server :Tcp.Server;
@@ -14,8 +15,9 @@ class TcpEchoServer {
 
   constructor(public endpoint:Net.Endpoint) {
     log.info('Starting TcpEchoServer(' + JSON.stringify(endpoint) + ')...');
-    this.server = new Tcp.Server(endpoint, this.onConnection_);
+    this.server = new Tcp.Server(endpoint);
 
+    // Start listening to connections.
     this.server.listen().then((listeningEndpoint) => {
       log.info('TCP echo server listening on ' +
           JSON.stringify(listeningEndpoint));
@@ -25,19 +27,22 @@ class TcpEchoServer {
           e.toString);
       this.server.shutdown();
     });
+
+    // Handle any new connections using |this.onConnection_|.
+    this.server.connectionsQueue.setSyncHandler(this.onConnection_);
   }
 
   private onConnection_ = (conn:Tcp.Connection) : void => {
-    log.info('New TCP Connection: ' + conn.toString());
+    log.info(conn.toString() + ': New TCP Connection: ');
     // The onceConnected is fulfilled by onConnection (in practice, but not
     // specified by the freedom TCP interface)
     conn.onceConnected.then((endpoint) => {
-      log.info(' Connection resolved to: ' + JSON.stringify(endpoint));
+      log.info(conn.toString() + ': Connection resolved to: ' + JSON.stringify(endpoint));
     });
     // This use of |receiveNext| here is to shows you can how to use it to get
     // the first ArrayBuffer of data and treat handling it differently.
     conn.receiveNext().then((data :ArrayBuffer) => {
-      log.info('Received first data!');
+      log.info(conn.toString() + ': Received first data!');
       this.onData_(conn, data);
       // Now handle further data as we get it using |this.onData_|.
       conn.dataFromSocketQueue.setSyncHandler(this.onData_.bind(this, conn));
@@ -45,10 +50,10 @@ class TcpEchoServer {
   }
 
   private onData_ = (conn:Tcp.Connection, data :ArrayBuffer) : void => {
-    log.info('Received: ' + data.byteLength + " bytes.");
+    log.info(conn.toString() + ': Received: ' + data.byteLength + " bytes.");
 
     var hexStrOfData = ArrayBuffers.arrayBufferToHexString(data);
-    log.info('Received data as hex-string: ' + hexStrOfData);
+    log.info(conn.toString() + ': Received data as hex-string: ' + hexStrOfData);
 
     // This shows how you handle some data and close the connection.
     if(hexStrOfData === TcpEchoServer.CTRL_D_HEX_STR_CODE) {

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -3,6 +3,7 @@
 /// <reference path='../third_party/typings/jasmine/jasmine.d.ts' />
 
 /// <reference path='../tcp/tcp.d.ts' />
+/// <reference path='../handler/queue.d.ts' />
 /// <reference path='../webrtc/datachannel.d.ts' />
 /// <reference path='../webrtc/peerconnection.d.ts' />
 
@@ -20,12 +21,21 @@ describe("socksToRtc", function() {
   beforeEach(function() {
     server = new SocksToRtc.SocksToRtc();
 
+    // TODO: create named more fleshed out TcpServer and PeerConnection mock
+    // classes for testing. e.g. failing to listen mock, listen & gets
+    // connection, listen and connection drops, etc.
     mockTcpServer = jasmine.createSpyObj('tcp server', [
         'on',
-        'listen',
-        'shutdown'
+        'onceListening',
+        'shutdown',
+        'onceShutdown'
       ]);
-    mockTcpServer.endpoint = mockEndpoint;
+    // TODO: make a real mock of listen; this one is frgaile to implementation
+    // changes and tests that might call onceListening before listen.
+    mockTcpServer.listen = () => { return mockTcpServer.onceListening(); }
+    mockTcpServer.connectionsQueue = new Handler.Queue<Tcp.Connection, void>();
+    mockTcpServer.shutdown = () => { return mockTcpServer.onceShutdown(); }
+
     mockPeerconnection = jasmine.createSpyObj('peerconnection', [
         'on',
         'negotiateConnection',
@@ -36,9 +46,12 @@ describe("socksToRtc", function() {
   });
 
   it('onceReady fulfills with server endpoint on server and peerconnection success', (done) => {
-    (<any>mockTcpServer.listen).and.returnValue(Promise.resolve(mockEndpoint));
+    (<any>mockTcpServer.onceListening).and.returnValue(Promise.resolve(mockEndpoint));
+    (<any>mockTcpServer.onceShutdown)
+        .and.returnValue(new Promise((F,R) => {}));
     (<any>mockPeerconnection.onceConnected).and.returnValue(Promise.resolve());
-    (<any>mockPeerconnection.onceDisconnected).and.returnValue(new Promise<void>((F, R) => {}));
+    (<any>mockPeerconnection.onceDisconnected)
+        .and.returnValue(new Promise<void>((F, R) => {}));
 
     server.start(mockTcpServer, mockPeerconnection)
       .then((result:Net.Endpoint) => {
@@ -49,23 +62,30 @@ describe("socksToRtc", function() {
   });
 
   it('onceReady rejects and onceStopped fulfills on socket setup failure', (done) => {
-    (<any>mockTcpServer.listen).and.returnValue(Promise.reject(new Error('could not allocate port')));
-    (<any>mockPeerconnection.onceConnected).and.returnValue(new Promise<void>((F, R) => {}));
-    (<any>mockPeerconnection.onceDisconnected).and.returnValue(new Promise<void>((F, R) => {}));
+    (<any>mockTcpServer.onceListening)
+        .and.returnValue(Promise.reject(new Error('could not allocate port')));
+    (<any>mockTcpServer.onceShutdown).and.returnValue(Promise.resolve());
+    (<any>mockPeerconnection.onceConnected)
+        .and.returnValue(new Promise<void>((F, R) => {}));
+    (<any>mockPeerconnection.onceDisconnected)
+        .and.returnValue(new Promise<void>((F, R) => {}));
 
     server.start(mockTcpServer, mockPeerconnection).catch(server.onceStopped).then(done);
   });
 
   it('onceStopped fulfills on peerconnection termination', (done) => {
-    (<any>mockTcpServer.listen).and.returnValue(Promise.resolve(mockEndpoint));
+    (<any>mockTcpServer.onceListening).and.returnValue(Promise.resolve(mockEndpoint));
+    (<any>mockTcpServer.onceShutdown).and.returnValue(Promise.resolve());
     (<any>mockPeerconnection.onceConnected).and.returnValue(Promise.resolve());
-    (<any>mockPeerconnection.onceDisconnected).and.returnValue(Promise.resolve());
+    (<any>mockPeerconnection.onceDisconnected)
+        .and.returnValue(Promise.resolve());
 
     server.start(mockTcpServer, mockPeerconnection).then(server.onceStopped).then(done);
   });
 
   it('onceStopped fulfills on call to stop', (done) => {
-    (<any>mockTcpServer.listen).and.returnValue(Promise.resolve(mockEndpoint));
+    (<any>mockTcpServer.onceListening).and.returnValue(Promise.resolve(mockEndpoint));
+    (<any>mockTcpServer.onceShutdown).and.returnValue(Promise.resolve());
     (<any>mockPeerconnection.onceConnected).and.returnValue(Promise.resolve());
     (<any>mockPeerconnection.onceDisconnected).and.returnValue(new Promise<void>((F, R) => {}));
 
@@ -74,7 +94,8 @@ describe("socksToRtc", function() {
   });
 
   it('onceStopped rejects on peerconnection shutdown failure', (done) => {
-    (<any>mockTcpServer.listen).and.returnValue(Promise.resolve(mockEndpoint));
+    (<any>mockTcpServer.onceListening).and.returnValue(Promise.resolve(mockEndpoint));
+    (<any>mockTcpServer.onceShutdown).and.returnValue(Promise.resolve());
     (<any>mockPeerconnection.onceConnected).and.returnValue(Promise.resolve());
     (<any>mockPeerconnection.onceDisconnected).and.returnValue(new Promise<void>((F, R) => {}));
     (<any>mockPeerconnection.close).and.returnValue(Promise.reject('could not cleanly shutdown'));

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -89,7 +89,9 @@ module SocksToRtc {
       var oncePeerConnectionReady :Promise<WebRtc.ConnectionAddresses>;
 
       // Create SOCKS server and start listening.
-      this.tcpServer_ = new Tcp.Server(endpoint, this.makeTcpToRtcSession_);
+      this.tcpServer_ = new Tcp.Server(endpoint);
+      this.tcpServer_.connectionsQueue.setSyncHandler(
+          this.makeTcpToRtcSession_);
       onceTcpServerReady = this.tcpServer_.listen();
       oncePeerConnectionReady = this.setupPeerConnection_(pcConfig, obfuscate);
 

--- a/src/tcp/tcp.d.ts
+++ b/src/tcp/tcp.d.ts
@@ -8,29 +8,47 @@
 declare module Tcp {
   class Server {
     constructor(endpoint        :Net.Endpoint,
-                onConnection    :(c:Connection) => void,
                 maxConnections  ?:number);
 
-    public  endpoint        :Net.Endpoint;
+    // The max allowed number of connections. More than this many connections
+    // will result in new connections being closed as soon as they connect.
+    public maxConnections  :number;
 
-    public connections :() => Connection[];
-    public connectionsCount :() => number;  // equivalent to connections().length
-    public closeAll :() => Promise<void>;  // calls close on all connections.
+    // The endpoint this server is listening on.
+    public connectionsQueue :Handler.Queue<Connection, void>;
 
-    // start accepting new connections; returns the actual endpoint it ends up
+    // Gets all the current connections to this server.
+    public currentConnections :() => Connection[];
+    // Equivalent to connections().length
+    public connectionsCount :() => number;
+
+    // Start accepting new connections; returns the actual endpoint it ends up
     // listening on (e.g. when port 0 is specifed, a dynamic port number is
     // chosen).
     public listen :() => Promise<Net.Endpoint>;
-    // stop accepting new connections.
+    // Getter for the once listening promise. Use to write prettier code.
+    public onceListening :() => Promise<Net.Endpoint>;
+    // The |isListening| variable is
+    public isListening :() => boolean;
+    // Stop accepting new connections.
     public stopListening :() => Promise<void>;
 
-    public shutdown :() => Promise<void>; // stop listening and then close-all
+    // Calls close on all connections. Doesn't stop listening.
+    public closeAll :() => Promise<void>;
+
+    // Stop listening and then close-all
+    public shutdown :() => Promise<void>;
+    // The |onceShutdown| promise can be fulfilled by either a call to
+    // shutdown, or by something going wrong in the OS.
+    public onceShutdown :() => Promise<void>
+    // Synchronous access to is |onceShutdown| fulfilled.
+    public isShutdown :() => boolean
 
     // Mostly useful for debugging
     public toString :() => string;
   }
 
-  // Code for how a Tcp Connection is closed.
+  // Describes how a Tcp Connection got to the closed state.
   enum SocketCloseKind {
     WE_CLOSED_IT,
     REMOTELY_CLOSED,
@@ -38,11 +56,7 @@ declare module Tcp {
     UNKOWN
   }
 
-  /**
-  * Tcp.Connection - Wraps up a single TCP connection to a client
-  *
-  * @param {number} socketId The ID of the server<->client socket.
-  */
+  // Wraps up a single TCP connection to a client
   class Connection {
     constructor(connectionKind :Connection.Kind);
 
@@ -69,6 +83,7 @@ declare module Tcp {
     public connectionId: string;
     public getState :() => Connection.State;
     public isClosed :() => boolean;
+
     public toString :() => string;
   }
 

--- a/src/tcp/tcp.d.ts
+++ b/src/tcp/tcp.d.ts
@@ -14,7 +14,8 @@ declare module Tcp {
     // will result in new connections being closed as soon as they connect.
     public maxConnections  :number;
 
-    // The endpoint this server is listening on.
+    // The handler queue of connections made to this server. By default no
+    // handler is set; the consumer of the server is expected to set one.
     public connectionsQueue :Handler.Queue<Connection, void>;
 
     // Gets all the current connections to this server.
@@ -24,11 +25,12 @@ declare module Tcp {
 
     // Start accepting new connections; returns the actual endpoint it ends up
     // listening on (e.g. when port 0 is specifed, a dynamic port number is
-    // chosen).
+    // chosen). Returns the same promise as calling `onceListening`.
     public listen :() => Promise<Net.Endpoint>;
     // Getter for the once listening promise. Use to write prettier code.
     public onceListening :() => Promise<Net.Endpoint>;
-    // The |isListening| variable is
+    // The |isListening| variable is true after |onceListening| and before
+    // |onceShutdown|
     public isListening :() => boolean;
     // Stop accepting new connections.
     public stopListening :() => Promise<void>;
@@ -36,7 +38,8 @@ declare module Tcp {
     // Calls close on all connections. Doesn't stop listening.
     public closeAll :() => Promise<void>;
 
-    // Stop listening and then close-all
+    // Stops accepting new connection (like |stopListening|) and then closes
+    // all connections (like |closeAll|).
     public shutdown :() => Promise<void>;
     // The |onceShutdown| promise can be fulfilled by either a call to
     // shutdown, or by something going wrong in the OS.

--- a/src/tcp/tcp.d.ts
+++ b/src/tcp/tcp.d.ts
@@ -28,6 +28,8 @@ declare module Tcp {
     // chosen). Returns the same promise as calling `onceListening`.
     public listen :() => Promise<Net.Endpoint>;
     // Getter for the once listening promise. Use to write prettier code.
+    // Fulfills once the server has server has successfully bound to a port
+    // and is accepting connections. Rejects if there is any error.
     public onceListening :() => Promise<Net.Endpoint>;
     // The |isListening| variable is true after |onceListening| and before
     // |onceShutdown|

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -24,7 +24,6 @@ module Tcp {
   // new ones.
   var DEFAULT_MAX_CONNECTIONS = 1048576;
 
-  // Helper function.
   function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
       : Net.Endpoint {
      return { address: info.peerAddress, port: info.peerPort }

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -34,9 +34,14 @@ module Tcp {
   // appropriately deallocate it's interface object.
   function destroyFreedomSocket_(socket:freedom_TcpSocket.Socket,
       idInfoString?:string) : Promise<void> {
-    return socket.close().then(() => {
-      freedom['core.tcpsocket'].close(socket);
-    });
+    // Note that :
+    // freedom['core.tcpsocket'].close =/= freedom['core.tcpsocket']().close
+    // The former destroys the freedom interface & communication channels.
+    // The latter is a method on the constructed interface object that is on
+    // the instance of the freedom tcp-socket's API.
+    return socket.close().then(
+      () => { freedom['core.tcpsocket'].close(socket); },
+      (e) => { freedom['core.tcpsocket'].close(socket); return e; });
   }
 
   // Tcp.Server: a TCP Server. This listens for connections when listen is

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -32,8 +32,8 @@ module Tcp {
 
   // A static helper function to close a freedom socket object and then
   // appropriately deallocate it's interface object.
-  function destroyFreedomSocket_(socket:freedom_TcpSocket.Socket,
-      idInfoString?:string) : Promise<void> {
+  function destroyFreedomSocket_(socket:freedom_TcpSocket.Socket)
+      : Promise<void> {
     // Note that :
     // freedom['core.tcpsocket'].close =/= freedom['core.tcpsocket']().close
     // The former destroys the freedom interface & communication channels.
@@ -149,8 +149,7 @@ module Tcp {
         // Stop too many connections.  We create a new socket here from the
         // incoming Id and immediately close it, because we don't yet have a
         // reference to the incomming socket.
-        destroyFreedomSocket_(freedom['core.tcpsocket'](socketId),
-            'L:' + socketId);
+        destroyFreedomSocket_(freedom['core.tcpsocket'](socketId));
         //log.error('Too many connections: ' + connectionsCount);
         return;
       }
@@ -209,7 +208,7 @@ module Tcp {
       // Close the server socket. Note: freedom doesn't give a socket Id for a
       // listening socket, so we just pass 0 back here: it's only for
       // debugging/console logging, so it doesn't matter.
-      return destroyFreedomSocket_(this.serverSocket_, 'listening').then(() => {
+      return destroyFreedomSocket_(this.serverSocket_).then(() => {
         this.isListening_ = false;
       })
       //.then(() => {
@@ -345,8 +344,7 @@ module Tcp {
       this.state_ = Connection.State.CLOSED;
 
       this.dataToSocketQueue.stopHandling();
-      destroyFreedomSocket_(this.connectionSocket_, this.connectionId).then(
-          () => {
+      destroyFreedomSocket_(this.connectionSocket_).then(() => {
         if (info.errcode === 'SUCCESS') {
           this.fulfillClosed_(SocketCloseKind.WE_CLOSED_IT);
         } else if (info.errcode === 'CONNECTION_CLOSED') {

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -10,8 +10,7 @@
 /// <reference path="../third_party/typings/es6-promise/es6-promise.d.ts" />
 
 module Tcp {
-  import TcpLib = freedom_TcpSocket;
-  var log :Freedom_UproxyLogging.Log = freedom['core.log']('Tcp');
+  //var log :Freedom_UproxyLogging.Log = freedom['core.log']('Tcp');
 
   // Code for how a Tcp Connection is closed.
   export enum SocketCloseKind {
@@ -21,14 +20,25 @@ module Tcp {
     UNKOWN
   }
 
-  // Helper function.
-  function endpointOfSocketInfo(info:TcpLib.SocketInfo) : Net.Endpoint {
-     return { address: info.peerAddress, port: info.peerPort }
-  }
-
   // A limit on the max number of TCP connections before we start rejecting
   // new ones.
   var DEFAULT_MAX_CONNECTIONS = 1048576;
+
+  // Helper function.
+  function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
+      : Net.Endpoint {
+     return { address: info.peerAddress, port: info.peerPort }
+  }
+
+  // A static helper function to close a freedom socket object and then
+  // appropriately deallocate it's interface object.
+  function closeFreedomSocket_(socket:freedom_TcpSocket.Socket,
+      idInfoString?:string) : Promise<void> {
+    return socket.close().then(() => {
+      console.log('closing: ' + idInfoString);
+      freedom['core.tcpsocket'].close(socket);
+    });
+  }
 
   // TODO: support starting listening again after stopping
   // TODO: support changing the connection handler.
@@ -41,9 +51,35 @@ module Tcp {
   // called, and handles the new connection as specified by the onConnection
   // argument to the constructor.
   export class Server {
-    private serverSocket_ :TcpLib.Socket;
+    private serverSocket_ :freedom_TcpSocket.Socket;
     // TODO: index by connectionId not socketID. More stable & string based.
     private conns:{[socketId:number] : Connection} = {};
+
+    public connectionsQueue :Handler.Queue<Connection, void>;
+
+    // The address and port that the tcp server is told to listening on. The
+    // initial assignment may set the port to 0, which indicates that the port
+    // is being dynamically allocated. When the port is actually assigned
+    // (right before the listen promise fulfills), the endpoint is set to the
+    // port that is actually being listened on.
+    private endpoint_ :Net.Endpoint;
+
+    // The |onceShutdown| promise is fulfilled when the server is shutdown and
+    // no longer listening.
+    private onceShutdown_ :Promise<void>;
+    public onceShutdown = () : Promise<void> => { return this.onceShutdown_; }
+    // isShutdown can become true, but never false again. It gives synchronous
+    // access to test if |onceShutdown_| fulfilled.
+    private isShutdown_ :boolean = false;
+    public isShutdown = () : boolean => { return this.isShutdown_; }
+
+    private onceListening_ :Promise<Net.Endpoint>;
+    public onceListening = () : Promise<Net.Endpoint> => {
+      return this.onceListening_;
+    }
+    private fulfillListening_ :(endpoint:Net.Endpoint) => void;
+    private isListening_ :boolean = false;
+    public isListening = () : boolean => { return this.isListening_; };
 
     // Create TCP server.
     // `endpoint` = Address and port to be listening on. Port 0 is used for
@@ -52,14 +88,24 @@ module Tcp {
     // `onConnection` = the handler for new TCP Connections.
     // `maxConnections` = the number of connections after which all new ones
     // will be closed as soon as they connect.
-    constructor(public endpoint       :Net.Endpoint,
-                private onConnection   :(c:Connection) => void,
+    constructor(endpoint :Net.Endpoint,
                 public maxConnections ?:number) {
+      this.endpoint_ = endpoint;
       this.maxConnections = maxConnections || DEFAULT_MAX_CONNECTIONS;
       this.serverSocket_ = freedom['core.tcpsocket']();
       // When `serverSocket_` gets new connections, handle them. This only
       // happens after the server's listen function is called.
       this.serverSocket_.on('onConnection', this.onConnectionHandler_);
+      this.connectionsQueue = new Handler.Queue<Connection, void>();
+      this.onceShutdown_ = new Promise<void>((F,R) => {
+        this.serverSocket_.on('onDisconnect', () => {
+          F();
+          this.isShutdown_ = true;
+        });
+      });
+      this.onceListening_ = new Promise<Net.Endpoint>((F,R) => {
+        this.fulfillListening_ = F;
+      });
     }
 
     // CONSIDER: use a generic util class for better object management, e.g.
@@ -74,22 +120,30 @@ module Tcp {
       return Object.keys(this.conns).length;
     }
 
+
     // Listens on the serverSocket_ to `address:port` for new TCP connections.
     // Returns a Promise that this server is now listening with the endpoint it
     // is listening on. If 0 was passed as the port, a dynamic port is chosen.
     public listen = () : Promise<Net.Endpoint> => {
-      return this.serverSocket_.listen(this.endpoint.address,
-                                       this.endpoint.port)
+      if (this.isShutdown_) {
+        return Promise.reject(new Error('Cannot listen on a shutdown server.'));
+      }
+      return this.serverSocket_.listen(this.endpoint_.address,
+                                       this.endpoint_.port)
           .then(this.serverSocket_.getInfo)
           .then((info : freedom_TcpSocket.SocketInfo) => {
-            return { address: info.localAddress, port: info.localPort };
+            this.endpoint_ = { address: info.localAddress,
+                               port: info.localPort };
+            this.fulfillListening_(this.endpoint_);
+            this.isListening_ = true;
+            return this.endpoint_;
           });
     }
 
     // onConnectionHandler_ is more or less TCP Accept: it is called when a new
     // TCP connection is established.
     private onConnectionHandler_ =
-        (acceptValue:TcpLib.ConnectInfo) : void => {
+        (acceptValue:freedom_TcpSocket.ConnectInfo) : void => {
       var socketId = acceptValue.socket;
 
       // Check that we haven't reach the maximum number of connections
@@ -98,45 +152,39 @@ module Tcp {
         // Stop too many connections.  We create a new socket here from the
         // incoming Id and immediately close it, because we don't yet have a
         // reference to the incomming socket.
-        freedom['core.tcpsocket'](socketId).close();
-        log.error('Too many connections: ' + connectionsCount);
-        return;
-      }
-
-      // if we don't know how to handle the connection, so close it.
-      if (!this.onConnection) {
-        freedom['core.tcpsocket'](socketId).close();
-        log.error('No connection handler is defined!');
+        closeFreedomSocket_(freedom['core.tcpsocket'](socketId),
+            'L:' + socketId);
+        //log.error('Too many connections: ' + connectionsCount);
         return;
       }
 
       // Create new connection.
-      log.debug('Tcp.Server accepted connection on socket id ' + socketId);
+      //log.debug('Tcp.Server accepted connection on socket id ' + socketId);
       var conn = new Connection({existingSocketId:socketId});
       // When the connection is disconnected correctly, or by error, remove
       // from the server's list of connections.
       conn.onceClosed.then(
         () => {
           delete this.conns[socketId];
-          log.debug('Tcp.Server(' + JSON.stringify(this.endpoint) +
-              ') : connection closed (' + socketId + '). Conn Count: ' +
-              Object.keys(this.conns).length + ']');
+          //log.debug('Tcp.Server(' + JSON.stringify(this.endpoint) +
+          //    ') : connection closed (' + socketId + '). Conn Count: ' +
+          //    Object.keys(this.conns).length + ']');
         },
         (e) => {
           delete this.conns[socketId];
-          log.warn('Tcp.Server(' + JSON.stringify(this.endpoint) +
-              ') : connection closed by error (' + socketId + '): ' +
-              e.toString() + ' . Conn Count: ' +
-              Object.keys(this.conns).length + ']');
+          //log.warn('Tcp.Server(' + JSON.stringify(this.endpoint) +
+          //    ') : connection closed by error (' + socketId + '): ' +
+          //    e.toString() + ' . Conn Count: ' +
+          //    Object.keys(this.conns).length + ']');
         })
       this.conns[socketId] = conn;
-      log.debug(this.toString());
-      this.onConnection(conn);
+      //log.debug(this.toString());
+      this.connectionsQueue.handle(conn);
     }
 
     // Mostly useful fro debugging
     public toString = () : string => {
-      var s = 'Tcp.Server(' + JSON.stringify(this.endpoint) +
+      var s = 'Tcp.Server(' + JSON.stringify(this.endpoint_) +
           ') connections: ' + Object.keys(this.conns).length + '\n{';
       for(var socketId in this.conns) {
         s += '  ' + this.conns[socketId].toString() + '\n';
@@ -156,15 +204,20 @@ module Tcp {
 
       // Wait for all promises to complete.
       return Promise.all(allPromises).then(() => {
-        log.debug('successfully closed all Tcp Connections.');
+        //log.debug('successfully closed all Tcp Connections.');
       });
     }
 
     public stopListening = () : Promise<void> => {
-      // Close the server socket.
-      return this.serverSocket_.close().then(() => {
-        log.debug('successfully stopped listening for more connections.');
-      });
+      // Close the server socket. Note: freedom doesn't give a socket Id for a
+      // listening socket, so we just pass 0 back here: it's only for
+      // debugging/console logging, so it doesn't matter.
+      return closeFreedomSocket_(this.serverSocket_, 'listening').then(() => {
+        this.isListening_ = false;
+      })
+      //.then(() => {
+        //log.debug('successfully stopped listening for more connections.');
+      //});
     }
 
     public shutdown = () : Promise<void> => {
@@ -185,7 +238,7 @@ module Tcp {
     // Queue of data to be handled, and the capacity to set a handler and
     // handle the data.
     public dataFromSocketQueue :Handler.Queue<ArrayBuffer,void>;
-    public dataToSocketQueue :Handler.Queue<ArrayBuffer, TcpLib.WriteInfo>;
+    public dataToSocketQueue :Handler.Queue<ArrayBuffer, freedom_TcpSocket.WriteInfo>;
 
     // Public unique connectionId.
     public connectionId :string;
@@ -195,7 +248,7 @@ module Tcp {
     // fulfill/reject the onceDisconnectd once.
     private state_ :Connection.State;
     // The underlying Freedom TCP socket.
-    private connectionSocket_ :TcpLib.Socket;
+    private connectionSocket_ :freedom_TcpSocket.Socket;
     // A private function called to invoke fullfil onceClosed.
     private fulfillClosed_ :(reason:SocketCloseKind)=>void;
 
@@ -205,11 +258,11 @@ module Tcp {
 
       this.dataFromSocketQueue = new Handler.Queue<ArrayBuffer,void>();
       this.dataToSocketQueue =
-          new Handler.Queue<ArrayBuffer,TcpLib.WriteInfo>();
+          new Handler.Queue<ArrayBuffer,freedom_TcpSocket.WriteInfo>();
 
       if(Object.keys(connectionKind).length !== 1) {
-        log.error(this.connectionId + ': Bad New Tcp Connection Kind:' +
-               JSON.stringify(connectionKind));
+        //log.error(this.connectionId + ': Bad New Tcp Connection Kind:' +
+        //       JSON.stringify(connectionKind));
         this.state_ = Connection.State.ERROR;
         this.onceConnected =
             Promise.reject(new Error(
@@ -256,7 +309,7 @@ module Tcp {
 
       // Use the dataFromSocketQueue handler for data from the socket.
       this.connectionSocket_.on('onData',
-          (readInfo:TcpLib.ReadInfo) : void => {
+          (readInfo:freedom_TcpSocket.ReadInfo) : void => {
         this.dataFromSocketQueue.handle(readInfo.data);
       });
 
@@ -284,37 +337,56 @@ module Tcp {
     // because  of an error. When closed by the other end, onceDisconnected is
     // fullfilled.  If there's an error, onceDisconnected is rejected with the
     // error.
-    private onDisconnectHandler_ = (info:TcpLib.DisconnectInfo) : void => {
-      log.debug(this.connectionId + ': onDisconnectHandler_');
+    private onDisconnectHandler_ = (info:freedom_TcpSocket.DisconnectInfo) : void => {
+      //log.debug(this.connectionId + ': onDisconnectHandler_');
+      console.log(this.connectionId + ': onDisconnectHandler_');
 
       if(this.state_ === Connection.State.CLOSED) {
-        log.warn(this.connectionId + ': Got onDisconnect in closed state' +
-            '(errcode=' + info.errcode + '; msg=' + info.message + ')');
+        //log.warn(this.connectionId + ': Got onDisconnect in closed state' +
+        //    '(errcode=' + info.errcode + '; msg=' + info.message + ')');
         return;
       }
+
       this.state_ = Connection.State.CLOSED;
 
-      if (info.errcode === 'SUCCESS') {
-        this.fulfillClosed_(SocketCloseKind.WE_CLOSED_IT);
-      } else if (info.errcode === 'CONNECTION_CLOSED') {
-        this.fulfillClosed_(SocketCloseKind.REMOTELY_CLOSED);
-      } else {
-        log.warn(this.connectionId + ': Disconnected with errcode '
-          + info.errcode + ': ' + info.message);
-        this.fulfillClosed_(SocketCloseKind.UNKOWN);
-      }
+      // Needed to cleanup freedom channel memory. Ideally freedom would
+      // separate closing the socket from memory cleanup. Also: ideally we'd
+      // actually fulfill the this.onceClosed promise when freedom's socket
+      // provider close promise fulfills. Both these problems are tracker here:
+      // TODO: https://github.com/freedomjs/freedom/issues/121
+      this.dataToSocketQueue.stopHandling();
+      closeFreedomSocket_(this.connectionSocket_, this.connectionId).then(
+          () => {
+        if (info.errcode === 'SUCCESS') {
+          this.fulfillClosed_(SocketCloseKind.WE_CLOSED_IT);
+        } else if (info.errcode === 'CONNECTION_CLOSED') {
+          this.fulfillClosed_(SocketCloseKind.REMOTELY_CLOSED);
+        } else {
+          //log.warn(this.connectionId + ': Disconnected with errcode '
+          //  + info.errcode + ': ' + info.message);
+          this.fulfillClosed_(SocketCloseKind.UNKOWN);
+        }
+      });
     }
 
     // This is called to close the underlying socket. This fulfills the
     // disconnect Promise `onceDisconnected`.
     public close = () : Promise<SocketCloseKind> => {
-      log.debug(this.connectionId + ': close');
+      console.log(this.connectionId + ': close');
+      //log.debug(this.connectionId + ': close');
       if (this.state_ === Connection.State.CLOSED) {
-        log.warn(this.connectionId + ': close: called when already closed');
+        //log.warn(this.connectionId + ': close: called when already closed');
         return;
       }
       this.dataToSocketQueue.stopHandling();
       this.connectionSocket_.close();
+      // Note: calling close on the freedom socket will cause
+      // `onDisconnectHandler_` to be fired, but we need to fulfill the promise
+      // set closed here and fulfill here because on the onDisconnect Handler
+      // needs to also call this.connectionSocket_.close() to do freedom memory
+      // cleanup.
+      this.state_ = Connection.State.CLOSED;
+      this.fulfillClosed_(SocketCloseKind.WE_CLOSED_IT);
       return this.onceClosed;
     }
 
@@ -329,7 +401,7 @@ module Tcp {
     /**
      * Sends a message that is pre-formatted as an arrayBuffer.
      */
-    public send = (msg :ArrayBuffer) : Promise<TcpLib.WriteInfo> => {
+    public send = (msg :ArrayBuffer) : Promise<freedom_TcpSocket.WriteInfo> => {
       return this.dataToSocketQueue.handle(msg);
     }
 


### PR DESCRIPTION
- Added echo-server stresser bash script to the repository
- Moved to using a handler queue for connections to the tcp server
  Instead of 

```
    tcpServer_ = new Tcp.Server(endpoint, function);
```

  You now write: 

```
    tcpServer_ = new Tcp.Server(endpoint);
      tcpServer_.connectionsQueue.setSyncHandler(
          makeTcpToRtcSession_);
```

  And of course you can do whatever you want with the handler queue, as usual. 
- Added `onceListening` and `onceShutdown` promises. 
- Added isListening an isShutdown synchronous checking functions. 
- Improved comments
- Fixed closing of freedom's tcpsocket interfaces
- Commented out logging statements (which cause bad slowdown with so many)

Fixed: https://github.com/uProxy/uproxy/issues/489
Fixed: https://github.com/uProxy/uproxy/issues/485 

TESTED: 
grunt test
Manually ran the `socks-chrome-app`
