### PR TITLE
implement similar lifecycle for socks sessions as for socks server

### DIFF
--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -26,8 +26,14 @@ declare module SocksToRtc {
     public makeTcpToRtcSession :(tcpConnection:Tcp.Connection) => void;
   }
   class Session {
-    constructor(tcpConnection:Tcp.Connection,
-                peerConnection_:freedom_UproxyPeerConnection.Pc);
+    constructor();
+    public start :(
+        channelLabel:string,
+        tcpConnection:Tcp.Connection,
+        peerConnection_:freedom_UproxyPeerConnection.Pc,
+        bytesSentToPeer:Handler.Queue<number,void>)
+        => Promise<Net.Endpoint>;
+    public stop :() => Promise<void>;
     public tcpConnection :Tcp.Connection;
     public onceReady :Promise<Net.Endpoint>;
     public onceClosed :Promise<void>;

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -36,7 +36,7 @@ declare module SocksToRtc {
     public stop :() => Promise<void>;
     public tcpConnection :Tcp.Connection;
     public onceReady :Promise<Net.Endpoint>;
-    public onceClosed :Promise<void>;
+    public onceStopped :Promise<void>;
     public longId :() => string;
     public close :() => Promise<void>;
     public handleDataFromPeer :(data:WebRtc.Data) => void;

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -38,7 +38,6 @@ declare module SocksToRtc {
     public onceReady :Promise<Net.Endpoint>;
     public onceStopped :Promise<void>;
     public longId :() => string;
-    public close :() => Promise<void>;
     public handleDataFromPeer :(data:WebRtc.Data) => void;
     public channelLabel :() => string;
     public toString :() => string;

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -99,9 +99,6 @@ describe("SOCKS session", function() {
   });
 
   it('onceReady fulfills with listening endpoint on successful negotiation', (done) => {
-    mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
-    (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
-
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
 

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -6,12 +6,12 @@
 /// <reference path='../webrtc/datachannel.d.ts' />
 /// <reference path='../webrtc/peerconnection.d.ts' />
 
-describe("socksToRtc", function() {
-  var mockEndpoint :Net.Endpoint = {
-    address: '127.0.0.1',
-    port: 1234
-  };
+var mockEndpoint :Net.Endpoint = {
+  address: '127.0.0.1',
+  port: 1234
+};
 
+describe('SOCKS server', function() {
   var server :SocksToRtc.SocksToRtc;
 
   var mockTcpServer :Tcp.Server;
@@ -81,5 +81,86 @@ describe("socksToRtc", function() {
 
     server.start(mockTcpServer, mockPeerconnection).then(
         server.stop).then(server.onceStopped).catch(done);
+  });
+});
+
+describe("SOCKS session", function() {
+  var session :SocksToRtc.Session;
+
+  var mockTcpConnection :Tcp.Connection;
+  var mockPeerconnection :freedom_UproxyPeerConnection.Pc;
+  var mockBytesSent :Handler.Queue<number,void>;
+
+  beforeEach(function() {
+    session = new SocksToRtc.Session();
+
+    mockTcpConnection = jasmine.createSpyObj('tcp connection', [
+        'onceClosed',
+        'close'
+      ]);
+    mockPeerconnection = jasmine.createSpyObj('peerconnection', [
+        'onceDataChannelClosed',
+        'closeDataChannel'
+      ]);
+    mockBytesSent = jasmine.createSpyObj('bytes sent handler', [
+        'handle'
+      ]);
+  });
+
+  it('onceReady fulfills with listening endpoint on successful negotiation', (done) => {
+    mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
+    (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
+
+    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
+    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+
+    session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
+      .then((result:Net.Endpoint) => {
+        expect(result.address).toEqual(mockEndpoint.address);
+        expect(result.port).toEqual(mockEndpoint.port);
+      })
+      .then(done);
+  });
+
+  it('onceReady rejects and onceClosed fulfills on unsuccessful negotiation', (done) => {
+    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
+    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.reject('unknown hostname'));
+
+    session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
+      .catch((e:Error) => { return session.onceClosed; }).then(done);
+  });
+
+  it('onceClosed fulfills on TCP connection termination', (done) => {
+    (<any>mockTcpConnection.onceClosed).and.returnValue(Promise.resolve());
+    (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
+
+    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
+    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+
+    session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
+      .then(() => { return session.onceClosed; }).then(done);
+  });
+
+  it('onceClosed fulfills on call to stop', (done) => {
+    (<any>mockTcpConnection.onceClosed).and.returnValue(new Promise<void>((F, R) => {}));
+    (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
+
+    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
+    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+
+    session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
+      .then(session.stop).then(() => { return session.onceClosed; }).then(done);
+  });
+
+  it('onceClosed rejects on tcp connection shutdown failure', (done) => {
+    (<any>mockTcpConnection.onceClosed).and.returnValue(new Promise<void>((F, R) => {}));
+    (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
+    (<any>mockTcpConnection.close).and.returnValue(Promise.reject('client vanished'));
+
+    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
+    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+
+    session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
+      .then(session.stop).then(() => { return session.onceClosed; }).catch(done);
   });
 });

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -72,16 +72,6 @@ describe('SOCKS server', function() {
     server.start(mockTcpServer, mockPeerconnection).then(
         server.stop).then(server.onceStopped).then(done);
   });
-
-  it('onceStopped rejects on peerconnection shutdown failure', (done) => {
-    (<any>mockTcpServer.listen).and.returnValue(Promise.resolve(mockEndpoint));
-    (<any>mockPeerconnection.onceConnected).and.returnValue(Promise.resolve());
-    (<any>mockPeerconnection.onceDisconnected).and.returnValue(new Promise<void>((F, R) => {}));
-    (<any>mockPeerconnection.close).and.returnValue(Promise.reject('could not cleanly shutdown'));
-
-    server.start(mockTcpServer, mockPeerconnection).then(
-        server.stop).then(server.onceStopped).catch(done);
-  });
 });
 
 describe("SOCKS session", function() {
@@ -150,17 +140,5 @@ describe("SOCKS session", function() {
 
     session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
       .then(session.stop).then(() => { return session.onceStopped; }).then(done);
-  });
-
-  it('onceStopped rejects on tcp connection shutdown failure', (done) => {
-    (<any>mockTcpConnection.onceClosed).and.returnValue(new Promise<void>((F, R) => {}));
-    (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
-    (<any>mockTcpConnection.close).and.returnValue(Promise.reject('client vanished'));
-
-    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
-
-    session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
-      .then(session.stop).then(() => { return session.onceStopped; }).catch(done);
   });
 });

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -28,7 +28,8 @@ describe('SOCKS server', function() {
         'on',
         'onceListening',
         'shutdown',
-        'onceShutdown'
+        'onceShutdown',
+        'isShutdown'
       ]);
     // TODO: make a real mock of listen; this one is frgaile to implementation
     // changes and tests that might call onceListening before listen.

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -86,7 +86,8 @@ describe("SOCKS session", function() {
 
     mockTcpConnection = jasmine.createSpyObj('tcp connection', [
         'onceClosed',
-        'close'
+        'close',
+        'isClosed'
       ]);
     mockPeerconnection = jasmine.createSpyObj('peerconnection', [
         'onceDataChannelClosed',
@@ -115,6 +116,7 @@ describe("SOCKS session", function() {
   it('onceReady rejects and onceStopped fulfills on unsuccessful negotiation', (done) => {
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.reject('unknown hostname'));
+    (<any>mockTcpConnection.isClosed).and.returnValue(false);
 
     session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
       .catch((e:Error) => { return session.onceStopped; }).then(done);
@@ -123,6 +125,7 @@ describe("SOCKS session", function() {
   it('onceStopped fulfills on TCP connection termination', (done) => {
     (<any>mockTcpConnection.onceClosed).and.returnValue(Promise.resolve());
     (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
+    (<any>mockTcpConnection.isClosed).and.returnValue(false);
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
@@ -134,6 +137,7 @@ describe("SOCKS session", function() {
   it('onceStopped fulfills on call to stop', (done) => {
     (<any>mockTcpConnection.onceClosed).and.returnValue(new Promise<void>((F, R) => {}));
     (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
+    (<any>mockTcpConnection.isClosed).and.returnValue(false);
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -122,15 +122,15 @@ describe("SOCKS session", function() {
       .then(done);
   });
 
-  it('onceReady rejects and onceClosed fulfills on unsuccessful negotiation', (done) => {
+  it('onceReady rejects and onceStopped fulfills on unsuccessful negotiation', (done) => {
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.reject('unknown hostname'));
 
     session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
-      .catch((e:Error) => { return session.onceClosed; }).then(done);
+      .catch((e:Error) => { return session.onceStopped; }).then(done);
   });
 
-  it('onceClosed fulfills on TCP connection termination', (done) => {
+  it('onceStopped fulfills on TCP connection termination', (done) => {
     (<any>mockTcpConnection.onceClosed).and.returnValue(Promise.resolve());
     (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
 
@@ -138,10 +138,10 @@ describe("SOCKS session", function() {
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
 
     session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
-      .then(() => { return session.onceClosed; }).then(done);
+      .then(() => { return session.onceStopped; }).then(done);
   });
 
-  it('onceClosed fulfills on call to stop', (done) => {
+  it('onceStopped fulfills on call to stop', (done) => {
     (<any>mockTcpConnection.onceClosed).and.returnValue(new Promise<void>((F, R) => {}));
     (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
 
@@ -149,10 +149,10 @@ describe("SOCKS session", function() {
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
 
     session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
-      .then(session.stop).then(() => { return session.onceClosed; }).then(done);
+      .then(session.stop).then(() => { return session.onceStopped; }).then(done);
   });
 
-  it('onceClosed rejects on tcp connection shutdown failure', (done) => {
+  it('onceStopped rejects on tcp connection shutdown failure', (done) => {
     (<any>mockTcpConnection.onceClosed).and.returnValue(new Promise<void>((F, R) => {}));
     (<any>mockPeerconnection.onceDataChannelClosed).and.returnValue(new Promise<void>((F, R) => {}));
     (<any>mockTcpConnection.close).and.returnValue(Promise.reject('client vanished'));
@@ -161,6 +161,6 @@ describe("SOCKS session", function() {
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
 
     session.start('buzz', mockTcpConnection, mockPeerconnection, mockBytesSent)
-      .then(session.stop).then(() => { return session.onceClosed; }).catch(done);
+      .then(session.stop).then(() => { return session.onceStopped; }).catch(done);
   });
 });

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -43,8 +43,7 @@ module SocksToRtc {
     //  - startup failure
     //  - TCP server or peerconnection failure
     //  - manual invocation of stop()
-    // Rejects if there was any error shutting down the TCP server or
-    // peerconnection.
+    // Should never reject.
     private onceStopped_ :Promise<void>;
     public onceStopped = () : Promise<void> => { return this.onceStopped_; }
 
@@ -143,8 +142,9 @@ module SocksToRtc {
       return this.onceStopped_;
     }
 
-    // Closes the TCP server and peerconnection.
-    // Fulfills if both close with out error, otherwise rejects.
+    // Shuts down the TCP server and peerconnection, fulfilling once both
+    // have terminated. Since neither objects' close() methods should ever
+    // reject, this should never reject.
     private stopResources_ = () : Promise<void> => {
       return Promise.all([
           this.tcpServer_.shutdown(),
@@ -258,8 +258,7 @@ module SocksToRtc {
     //  - startup (negotiation) failure
     //  - TCP connection or datachannel termination
     //  - manual invocation of stop()
-    // Rejects if there's an error shutting down the TCP connection or
-    // datachannel.
+    // Should never reject.
     public onceStopped :Promise<void>;
 
     // We push data from the peer into this queue so that we can write the
@@ -312,8 +311,9 @@ module SocksToRtc {
       return this.onceStopped;
     }
 
-    // Closes the TCP connection and datachannel.
-    // Fulfills if both close with out error, otherwise rejects.
+    // Closes the TCP connection and datachannel, fulfilling once both
+    // have closed. Since neither objects' close() methods should ever
+    // reject, this should never reject.
     private stopResources_ = () : Promise<void> => {
       return Promise.all<any>([
           this.tcpConnection_.close(),

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -355,6 +355,7 @@ module SocksToRtc {
     // Assumes: no packet fragmentation.
     // TODO: handle packet fragmentation:
     //   https://github.com/uProxy/uproxy/issues/323
+    // TODO: Needs unit tests badly since it's mocked by several other tests.
     private doAuthHandshake_ = ()
         : Promise<void> => {
       return this.tcpConnection_.receiveNext()
@@ -367,6 +368,7 @@ module SocksToRtc {
 
     // Sets the next data hanlder to get next data from peer, assuming it's
     // stringified version of the destination.
+    // TODO: Needs unit tests badly since it's mocked by several other tests.
     private receiveEndpointFromPeer_ = () : Promise<Net.Endpoint> => {
       return new Promise((F,R) => {
         this.dataFromPeer_.setSyncNextHandler((data:WebRtc.Data) => {


### PR DESCRIPTION
Similar ideas to:
https://github.com/uProxy/uproxy-networking/pull/137

A SOCKS session lives as long as its TCP connection and datachannel.
