### PR TITLE
echo server for firefox

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -102,9 +102,13 @@ module.exports = (grunt) ->
       ipaddrjs: Rule.copyModule 'ipaddrjs'
       rtcToNet: Rule.copyModule 'rtc-to-net'
       benchmark: Rule.copyModule 'benchmark'
+      echo: Rule.copyModule 'echo'
 
       echoServerChromeApp: Rule.copyModule 'samples/echo-server-chromeapp'
       echoServerChromeAppLib: Rule.copySampleFiles 'samples/echo-server-chromeapp'
+
+      echoServerFirefoxApp: Rule.copyModule 'samples/echo-server-firefoxapp'
+      echoServerFirefoxAppLib: Rule.copySampleFiles 'samples/echo-server-firefoxapp/data'
 
       simpleSocksChromeApp: Rule.copyModule 'samples/simple-socks-chromeapp'
       simpleSocksChromeAppLib: Rule.copySampleFiles 'samples/simple-socks-chromeapp'
@@ -154,7 +158,11 @@ module.exports = (grunt) ->
           declaration: true
       }
 
+      echo: Rule.typescriptSrc 'echo'
+
       echoServerChromeApp: Rule.typescriptSrc 'samples/echo-server-chromeapp/'
+      echoServerFirefoxApp: Rule.typescriptSrc 'samples/echo-server-firefoxapp/'
+
       simpleSocksChromeApp: Rule.typescriptSrc 'samples/simple-socks-chromeapp'
       simpleSocksFirefoxApp: Rule.typescriptSrc 'samples/simple-socks-firefoxapp'
       copypasteSocksChromeApp: Rule.typescriptSrc 'samples/copypaste-socks-chromeapp'
@@ -261,7 +269,7 @@ module.exports = (grunt) ->
 
   taskManager.add 'base', [
     'symlink:build'
-    'symlink:thirdParty'    
+    'symlink:thirdParty'
     'symlink:uproxyLibBuild'
     'symlink:uproxyLibThirdParty'
     'symlink:utransformers'
@@ -319,12 +327,31 @@ module.exports = (grunt) ->
     'tcp'
   ]
 
-  taskManager.add 'echoServerChromeApp', [
+  taskManager.add 'echo', [
     'base'
     'tcp'
+    'ts:echo'
+    'copy:echo'
+  ]
+  taskManager.add 'echoServerChromeApp', [
+    'base'
+    'echo'
     'ts:echoServerChromeApp'
     'copy:echoServerChromeApp'
     'copy:echoServerChromeAppLib'
+  ]
+
+  taskManager.add 'echoServerFirefoxApp', [
+    'base'
+    'echo'
+    'ts:echoServerFirefoxApp'
+    'copy:echoServerFirefoxApp'
+    'copy:echoServerFirefoxAppLib'
+  ]
+
+  taskManager.add 'echoServer', [
+    'echoServerChromeApp'
+    'echoServerFirefoxApp'
   ]
 
   taskManager.add 'simpleSocksChromeApp', [
@@ -438,7 +465,7 @@ module.exports = (grunt) ->
   ]
 
   taskManager.add 'samples', [
-    'echoServerChromeApp'
+    'echoServer'
     'simpleSocksChromeApp'
     'simpleSocksFirefoxApp'
     'copypasteSocksChromeApp'

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ transform and restore the data being sent over the network.
 
 A variety of sample apps are included.
 
-They are packaged as Chrome apps:
+To run Chrome apps:
 
  - open `chrome://extensions`, ensure developer mode is enabled, and load unpacked extension from the relevant directory inside `dist/samples/`, e.g. `dist/samples/simple-socks-chromeapp/`.
 
-Firefox apps are on their way!
+To run Firefox add-ons:
+
+- download the [Add-on SDK](https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/Installation), and run the extension with `cfx run` from the relevant directory inside `dist/samples/`, e.g. `dist/samples/echo-server-firefoxapp/`.
 
 ### echo server
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/echo/freedom-module.json
+++ b/src/echo/freedom-module.json
@@ -3,9 +3,9 @@
   "description": "Listen for incoming requests, and echo them back.",
   "app": {
     "script": [
-      "lib/arraybuffers/arraybuffers.js",
-      "lib/handler/queue.js",
-      "lib/tcp/tcp.js",
+      "../arraybuffers/arraybuffers.js",
+      "../handler/queue.js",
+      "../tcp/tcp.js",
       "tcp-echo-server.js",
       "freedom-module.js"
     ]

--- a/src/echo/freedom-module.ts
+++ b/src/echo/freedom-module.ts
@@ -1,5 +1,5 @@
-/// <reference path='../../freedom/typings/freedom.d.ts' />
-/// <reference path='../../freedom/coreproviders/uproxylogging.d.ts' />
+/// <reference path='../freedom/typings/freedom.d.ts' />
+/// <reference path='../freedom/coreproviders/uproxylogging.d.ts' />
 /// <reference path='tcp-echo-server.ts' />
 
 var log :Freedom_UproxyLogging.Log = freedom['core.log']('echo-server');

--- a/src/echo/tcp-echo-server.ts
+++ b/src/echo/tcp-echo-server.ts
@@ -1,9 +1,9 @@
 // For testing just the TCP server portion (see src/client/tcp.ts)
 
-/// <reference path='../../arraybuffers/arraybuffers.d.ts' />
-/// <reference path='../../freedom/coreproviders/uproxylogging.d.ts' />
-/// <reference path='../../networking-typings/communications.d.ts' />
-/// <reference path='../../tcp/tcp.d.ts' />
+/// <reference path='../arraybuffers/arraybuffers.d.ts' />
+/// <reference path='../freedom/coreproviders/uproxylogging.d.ts' />
+/// <reference path='../networking-typings/communications.d.ts' />
+/// <reference path='../tcp/tcp.d.ts' />
 /// <reference path='freedom-module.ts' />
 
 class TcpEchoServer {

--- a/src/samples/echo-server-chromeapp/background.ts
+++ b/src/samples/echo-server-chromeapp/background.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../freedom/typings/freedom.d.ts' />
 
 var script = document.createElement('script');
-script.setAttribute('data-manifest', 'freedom-module.json');
+script.setAttribute('data-manifest', 'lib/echo/freedom-module.json');
 script.textContent = '{ "debug": "warn" }';
 script.src = 'lib/freedom/freedom-for-chrome-for-uproxy.js';
 document.head.appendChild(script);

--- a/src/samples/echo-server-firefoxapp/lib/main.js
+++ b/src/samples/echo-server-firefoxapp/lib/main.js
@@ -1,0 +1,11 @@
+const {Cu} = require("chrome");
+var self = require("sdk/self");
+var {setTimeout} = require("sdk/timers");
+
+Cu.import(self.data.url("lib/freedom/freedom-for-firefox-for-uproxy.jsm"));
+
+var manifest = self.data.url("lib/echo/freedom-module.json");
+console.log('manifest location: ' + manifest);
+var freedom = setupFreedom(manifest, { 'debug': 'log' });
+
+freedom.emit('start', { address: '127.0.0.1', port: 9998 });

--- a/src/samples/echo-server-firefoxapp/package.json
+++ b/src/samples/echo-server-firefoxapp/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "echo",
+  "title": "echo",
+  "id": "jid1-jBoSL7j4ljmKZw",
+  "description": "Echo server.",
+  "author": "",
+  "license": "",
+  "version": "0.1"
+}


### PR DESCRIPTION
All our samples should run on Firefox:
https://github.com/uProxy/uproxy/issues/419

Summary:
- create `src/samples/echo-server-firefoxapp`, with `package.json` and `lib/main.js`
- because the "echo server Freedom module" is common to both Chrome and Firefox, factor it out into its own build component, `echo`

As for all other components, `echo` gets copied into the Chrome and Firefox apps' `lib/` folder from where it can be bootstrapped for each environment.

Tested in Chrome and Firefox.

Thoughts? I don't necessarily love the idea of having the echo server module exist outside of the samples folder but it _is_ common code.
