### PR TITLE
fixes to allow churn work with the socks samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.json
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.json
@@ -9,12 +9,21 @@
       "lib/tcp/tcp.js",
       "lib/webrtc/datachannel.js",
       "lib/webrtc/peerconnection.js",
+      "lib/regex2dfa/regex2dfa.js",
+      "lib/crypto/random.js",
+      "lib/churn/churn.js",
       "lib/ipaddrjs/ipaddr.min.js",
       "lib/socks-common/socks-headers.js",
       "lib/socks-to-rtc/socks-to-rtc.js",
       "lib/rtc-to-net/rtc-to-net.js",
       "freedom-module.js"
     ]
+  },
+  "dependencies": {
+    "churnPipe": {
+      "url": "lib/churn-pipe/freedom.json",
+      "api": "churnPipe"
+    }
   },
   "permissions": [
     "core.console",

--- a/src/simple-socks/freedom-module.json
+++ b/src/simple-socks/freedom-module.json
@@ -9,12 +9,21 @@
       "../tcp/tcp.js",
       "../webrtc/datachannel.js",
       "../webrtc/peerconnection.js",
+      "../regex2dfa/regex2dfa.js",
+      "../crypto/random.js",
+      "../churn/churn.js",
       "../ipaddrjs/ipaddr.min.js",
       "../socks-common/socks-headers.js",
       "../socks-to-rtc/socks-to-rtc.js",
       "../rtc-to-net/rtc-to-net.js",
       "freedom-module.js"
     ]
+  },
+  "dependencies": {
+    "churnPipe": {
+      "url": "../churn-pipe/freedom.json",
+      "api": "churnPipe"
+    }
   },
   "permissions": [
     "core.console",


### PR DESCRIPTION
There were a few bits and pieces missing. This allows churn be used from the samples. Not enabling it by default just yet.
