### PR TITLE
sample apps: remove remaining references to DtlsSrtpKeyAgreement and only specify two STUN servers

### DIFF
--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -21,10 +21,7 @@ var log :Logging.Log = new Logging.Log('copypaste-socks');
 var rtcNetPcConfig :WebRtc.PeerConnectionConfig = {
   webrtcPcConfig: {
     iceServers: [{urls: ['stun:stun.l.google.com:19302']},
-                 {urls: ['stun:stun1.l.google.com:19302']},
-                 {urls: ['stun:stun2.l.google.com:19302']},
-                 {urls: ['stun:stun3.l.google.com:19302']},
-                 {urls: ['stun:stun4.l.google.com:19302']}]
+                 {urls: ['stun:stun1.l.google.com:19302']}]
   },
   peerName: 'rtcNet'
 };
@@ -32,10 +29,7 @@ var rtcNetPcConfig :WebRtc.PeerConnectionConfig = {
 var socksRtcPcConfig :WebRtc.PeerConnectionConfig = {
   webrtcPcConfig: {
     iceServers: [{urls: ['stun:stun.l.google.com:19302']},
-                 {urls: ['stun:stun1.l.google.com:19302']},
-                 {urls: ['stun:stun2.l.google.com:19302']},
-                 {urls: ['stun:stun3.l.google.com:19302']},
-                 {urls: ['stun:stun4.l.google.com:19302']}]
+                 {urls: ['stun:stun1.l.google.com:19302']}]
   },
   peerName: 'socksRtc'
 };

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -26,9 +26,6 @@ var rtcNetPcConfig :WebRtc.PeerConnectionConfig = {
                  {urls: ['stun:stun3.l.google.com:19302']},
                  {urls: ['stun:stun4.l.google.com:19302']}]
   },
-  webrtcMediaConstraints: {
-    optional: [{DtlsSrtpKeyAgreement: true}]
-  },
   peerName: 'rtcNet'
 };
 
@@ -39,9 +36,6 @@ var socksRtcPcConfig :WebRtc.PeerConnectionConfig = {
                  {urls: ['stun:stun2.l.google.com:19302']},
                  {urls: ['stun:stun3.l.google.com:19302']},
                  {urls: ['stun:stun4.l.google.com:19302']}]
-  },
-  webrtcMediaConstraints: {
-    optional: [{DtlsSrtpKeyAgreement: true}]
   },
   peerName: 'socksRtc'
 };

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -24,10 +24,7 @@ var localhostEndpoint:Net.Endpoint = { address: '127.0.0.1', port:9999 };
 var rtcNetPcConfig :WebRtc.PeerConnectionConfig = {
     webrtcPcConfig: {
       iceServers: [{urls: ['stun:stun.l.google.com:19302']},
-                   {urls: ['stun:stun1.l.google.com:19302']},
-                   {urls: ['stun:stun2.l.google.com:19302']},
-                   {urls: ['stun:stun3.l.google.com:19302']},
-                   {urls: ['stun:stun4.l.google.com:19302']}]
+                   {urls: ['stun:stun1.l.google.com:19302']}]
     },
     peerName: 'rtcNet'
   };
@@ -42,10 +39,7 @@ var rtcNet = new RtcToNet.RtcToNet(
 var socksRtcPcConfig :WebRtc.PeerConnectionConfig = {
     webrtcPcConfig: {
       iceServers: [{urls: ['stun:stun.l.google.com:19302']},
-                   {urls: ['stun:stun1.l.google.com:19302']},
-                   {urls: ['stun:stun2.l.google.com:19302']},
-                   {urls: ['stun:stun3.l.google.com:19302']},
-                   {urls: ['stun:stun4.l.google.com:19302']}]
+                   {urls: ['stun:stun1.l.google.com:19302']}]
     },
     peerName: 'socksRtc'
   };


### PR DESCRIPTION
@bemasc I saw you did this for some of the sample apps and both seem like a good idea throughout.
