### PR TITLE
some cleanup of SocksToRtc logging

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -250,6 +250,7 @@ module.exports = (grunt) ->
           'build/handler/queue.js'
           'build/logging/logging.js'
           'build/webrtc/*.js'
+          'build/tcp/tcp.js'
           'build/socks-to-rtc/socks-to-rtc.js'
         ])
         options:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -12,8 +12,6 @@
 /// <reference path='../tcp/tcp.d.ts' />
 /// <reference path='../third_party/typings/es6-promise/es6-promise.d.ts' />
 
-console.log('WEBWORKER - RtcToNet: ' + self.location.href);
-
 module RtcToNet {
 
   var log :Logging.Log = new Logging.Log('RtcToNet');

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -11,8 +11,7 @@
 // show only warnings by default from the rest of the system.
 // Note that the proxy is extremely slow in debug (D) mode.
 Logging.setConsoleFilter([
-    '*:W',
-    'copypaste-socks:I',
+    '*:I',
     'SocksToRtc:I',
     'RtcToNet:I']);
 

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -90,14 +90,16 @@ rtcNet.bytesSentToPeer.setSyncHandler((numBytes:number) => {
 
 socksRtc.onceReady
   .then((endpoint:Net.Endpoint) => {
-    log.info('socksRtc ready. listening to SOCKS5 on: ' + JSON.stringify(endpoint));
-    log.info('` curl -x socks5h://localhost:9999 www.google.com `')
-  })
-  .catch((e) => {
-    console.error('socksRtc Error: ' + e +
-        '; ' + this.socksRtc.toString());
+    log.info('SocksToRtc listening on: ' + JSON.stringify(endpoint));
+    log.info('curl -x socks5h://' + endpoint.address + ':' + endpoint.port +
+        ' www.example.com')
+  }, (e:Error) => {
+    log.error('failed to start SocksToRtc: ' + e.message);
   });
 
-rtcNet.onceReady.then(() => {
-  log.info('rtcNet ready.');
-});
+rtcNet.onceReady
+  .then(() => {
+    log.info('RtcToNet ready');
+  }, (e:Error) => {
+    log.error('failed to start RtcToNet: ' + e.message);
+  });

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -107,7 +107,7 @@ describe("SOCKS session", function() {
   var mockDataChannel :WebRtc.DataChannel;
   var mockBytesSent :Handler.Queue<number,void>;
   var mockBytesReceived :Handler.Queue<number,void>;
-  
+
   beforeEach(function() {
     session = new SocksToRtc.Session();
 
@@ -117,6 +117,8 @@ describe("SOCKS session", function() {
         'isClosed'
       ]);
     (<any>mockTcpConnection.close).and.returnValue(Promise.resolve(-1));
+    mockTcpConnection.onceClosed = Promise.resolve(
+        Tcp.SocketCloseKind.REMOTELY_CLOSED);
     mockDataChannel = <any>{
       getLabel: jasmine.createSpy('getLabel').and.returnValue('mock label'),
       onceOpened: noopPromise,
@@ -154,7 +156,7 @@ describe("SOCKS session", function() {
   });
 
   it('onceStopped fulfills on TCP connection termination', (done) => {
-    (<any>mockTcpConnection.onceClosed).and.returnValue(Promise.resolve());
+    mockTcpConnection.onceClosed = Promise.resolve();
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
@@ -165,7 +167,7 @@ describe("SOCKS session", function() {
 
   it('onceStopped fulfills on call to stop', (done) => {
     // Neither TCP connection nor datachannel close "naturally".
-    (<any>mockTcpConnection.onceClosed).and.returnValue(noopPromise);
+    mockTcpConnection.onceClosed = noopPromise;
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
     spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -11,8 +11,6 @@
 /// <reference path='../tcp/tcp.d.ts' />
 /// <reference path='../third_party/typings/es6-promise/es6-promise.d.ts' />
 
-console.log('WEBWORKER - SocksToRtc: ' + self.location.href);
-
 module SocksToRtc {
   var log :Logging.Log = new Logging.Log('SocksToRtc');
 


### PR DESCRIPTION
Because logging is important...:
- performance improvement: rather than constructing the entire message string, use placeholders with an array
- INFO level shows just session creation and destruction
- many more DEBUG messages, e.g. show which events caused the server or session to close

Example for fetching www.example.com in DEBUG:

```
SocksToRtc I [10/20 19:53:10.770] created new session c0
SocksToRtc D [10/20 19:53:10.779] opened datachannel for session c0
SocksToRtc D [10/20 19:53:10.805] session c0 connected to remote endpoint {"address":"2606:2800:220:6d:26bf:1447:1097:aa7","port":80}
SocksToRtc D [10/20 19:53:10.808] session c0 (TCP open): client socket received 79 bytes
SocksToRtc D [10/20 19:53:10.816] session c0 (TCP open): datachannel received 1591 bytes
SocksToRtc D [10/20 19:53:10.822] session c0 (TCP closed): client socket closed (REMOTELY_CLOSED)
SocksToRtc D [10/20 19:53:10.823] session c0 (TCP closed): freeing resources
SocksToRtc I [10/20 19:53:10.824] discarded session c0 (0 remaining)
SocksToRtc D [10/20 19:53:10.828] session c0 (TCP closed): datachannel closed
```

Do you agree it's an improvement?

Next pull request would be RtcToNet.
