### PR TITLE
Handle error in tcp socket connection. 

### DIFF
--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -300,7 +300,9 @@ module Tcp {
               log.error('Failed to connect to %1, err=%2',
                         [JSON.stringify(connectionKind.endpoint),
                          JSON.stringify(err)]);
-              this.close();
+              this.dataToSocketQueue.stopHandling();
+              this.state_ = Connection.State.CLOSED;
+              this.fulfillClosed_(SocketCloseKind.NEVER_CONNECTED);
             });
       } else {
         throw(new Error(this.connectionId +

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -285,7 +285,7 @@ module Tcp {
                 .connect(connectionKind.endpoint.address,
                          connectionKind.endpoint.port)
                 .then(this.connectionSocket_.getInfo)
-                .then(endpointOfSocketInfo)
+                .then(endpointOfSocketInfo);
         this.state_ = Connection.State.CONNECTING;
         this.onceConnected
             .then(() => {
@@ -295,6 +295,12 @@ module Tcp {
               if(this.state_ !== Connection.State.CLOSED) {
                 this.state_ = Connection.State.CONNECTED;
               }
+            })
+            .catch((err) => {
+              log.error('Failed to connect to %1, err=%2',
+                        [JSON.stringify(connectionKind.endpoint),
+                         JSON.stringify(err)]);
+              this.close();
             });
       } else {
         throw(new Error(this.connectionId +


### PR DESCRIPTION
Handle error in tcp socket connection. When it happens, close the tcp connection so that
other code waiting on the pipe can take actions.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/172)

<!-- Reviewable:end -->
