### PR TITLE
Specify a minimum Chrome version for the sample apps.

### DIFF
--- a/src/samples/copypaste-churn-chat-chromeapp/manifest.json
+++ b/src/samples/copypaste-churn-chat-chromeapp/manifest.json
@@ -3,6 +3,7 @@
   "name": "copypaste churn chat",
   "description": "Copy paste-based obfuscating peerconnection chat demo.",
   "version": "0.1",
+  "minimum_chrome_version": "41.0.2267.0",
   "app": {
     "background": {
       "scripts": [

--- a/src/samples/copypaste-socks-chromeapp/manifest.json
+++ b/src/samples/copypaste-socks-chromeapp/manifest.json
@@ -3,6 +3,7 @@
   "name": "copypaste SOCKS",
   "description": "SOCKS with copy/paste-based signalling channel",
   "version": "0.1",
+  "minimum_chrome_version": "41.0.2267.0",
   "app": {
     "background": {
       "scripts": [

--- a/src/samples/simple-churn-chat-chromeapp/manifest.json
+++ b/src/samples/simple-churn-chat-chromeapp/manifest.json
@@ -3,6 +3,7 @@
   "name": "churn chat",
   "description": "Single-page obfuscated chat.",
   "version": "0.1",
+  "minimum_chrome_version": "41.0.2267.0",
   "app": {
     "background": {
       "scripts": [

--- a/src/samples/simple-socks-chromeapp/manifest.json
+++ b/src/samples/simple-socks-chromeapp/manifest.json
@@ -3,6 +3,7 @@
   "name": "Simple SOCKS",
   "description": "Single-page SOCKS server.",
   "version": "0.1",
+  "minimum_chrome_version": "41.0.2267.0",
   "app": {
     "background": {
       "scripts": [


### PR DESCRIPTION
The selected version is 41.0.2267.0, which is the first dev-channel
Chrome that has the fix for https://crbug.com/438699
(https://codereview.chromium.org/773243002), which caused
https://github.com/uProxy/uproxy/issues/615.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/174)

<!-- Reviewable:end -->
