### PR TITLE
Code coverage

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -231,6 +231,13 @@ module.exports = (grunt) ->
         ])
         options:
           specs: 'build/turn-frontend/*.spec.js'
+          template: require('grunt-template-jasmine-istanbul')
+          templateOptions:
+            coverage: 'build/coverage/turn-frontend/coverage.json'
+            report:
+              type: 'html'
+              options:
+                dir: 'build/coverage/turn-frontend'
       # TODO: churn tests require peerconnection
       #       https://github.com/uProxy/uproxy/issues/430
       churn:
@@ -242,6 +249,13 @@ module.exports = (grunt) ->
         ]),
         options:
           specs: 'build/churn/*.spec.js'
+          template: require('grunt-template-jasmine-istanbul')
+          templateOptions:
+            coverage: 'build/coverage/churn/coverage.json'
+            report:
+              type: 'html'
+              options:
+                dir: 'build/coverage/churn'
       # TODO: socksToRtc tests require a bunch of other modules
       #       https://github.com/uProxy/uproxy/issues/430
       socksToRtc:
@@ -254,9 +268,16 @@ module.exports = (grunt) ->
           'build/socks-to-rtc/socks-to-rtc.js'
         ])
         options:
-          outfile: 'build/socks-to-rtc/SpecRunner.html'
-          keepRunner: true
           specs: 'build/socks-to-rtc/*.spec.js'
+          #outfile: 'build/socks-to-rtc/SpecRunner.html'
+          #keepRunner: true
+          template: require('grunt-template-jasmine-istanbul')
+          templateOptions:
+            coverage: 'build/coverage/socksToRtc/coverage.json'
+            report:
+              type: 'html'
+              options:
+                dir: 'build/coverage/socksToRtc'
       # TODO: rtcToNet tests require a bunch of other modules
       #       https://github.com/uProxy/uproxy/issues/430
       rtcToNet:
@@ -268,15 +289,14 @@ module.exports = (grunt) ->
           'build/rtc-to-net/rtc-to-net.js'
         ])
         options:
-          outfile: 'build/rtc-to-net/SpecRunner.html'
-          keepRunner: true
           specs: 'build/rtc-to-net/*.spec.js'
-          # Coverage reporting
+          #outfile: 'build/rtc-to-net/SpecRunner.html'
+          #keepRunner: true
           template: require('grunt-template-jasmine-istanbul')
           templateOptions:
             coverage: 'build/coverage/rtcToNet/coverage.json'
             report:
-              type: 'lcovonly'
+              type: 'html'
               options:
                 dir: 'build/coverage/rtcToNet'
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -271,6 +271,19 @@ module.exports = (grunt) ->
           outfile: 'build/rtc-to-net/SpecRunner.html'
           keepRunner: true
           specs: 'build/rtc-to-net/*.spec.js'
+          # Coverage reporting
+          template: require('grunt-template-jasmine-istanbul')
+          templateOptions:
+            coverage: 'build/coverage/rtcToNet/coverage.json'
+            report:
+              type: 'lcovonly'
+              options:
+                dir: 'build/coverage/rtcToNet'
+
+    # Upload lcov files to coveralls.io
+    coveralls:
+      report:
+        src: 'build/coverage/**/*lcov.info'
 
     integration:
       tcp:
@@ -317,6 +330,7 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-symlink'
   grunt.loadNpmTasks 'grunt-ts'
   grunt.loadNpmTasks 'grunt-browserify'
+  grunt.loadNpmTasks 'grunt-coveralls'
 
   grunt.loadTasks 'node_modules/freedom-for-chrome/tasks'
 
@@ -563,6 +577,11 @@ module.exports = (grunt) ->
   taskManager.add 'test', [
     'build'
     'jasmine'
+  ]
+
+  taskManager.add 'ci', [
+    'test',
+    'coveralls'
   ]
 
   taskManager.add 'default', [

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -280,11 +280,6 @@ module.exports = (grunt) ->
               options:
                 dir: 'build/coverage/rtcToNet'
 
-    # Upload lcov files to coveralls.io
-    coveralls:
-      report:
-        src: 'build/coverage/**/*lcov.info'
-
     integration:
       tcp:
         options:
@@ -330,7 +325,6 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-contrib-symlink'
   grunt.loadNpmTasks 'grunt-ts'
   grunt.loadNpmTasks 'grunt-browserify'
-  grunt.loadNpmTasks 'grunt-coveralls'
 
   grunt.loadTasks 'node_modules/freedom-for-chrome/tasks'
 
@@ -578,18 +572,6 @@ module.exports = (grunt) ->
     'build'
     'jasmine'
   ]
-
-  if process.env.TRAVIS_JOB_NUMBER
-    jobParts = process.env.TRAVIS_JOB_NUMBER.split('.')
-    #When run from Travis from jobs *.1
-    if jobParts.length > 1 and jobParts[1] == '1'
-      taskManager.add 'ci', [ 'test', 'coveralls' ]
-    #When run from Travis from jobs *.2, *.3, etc.
-    else
-      taskManager.add 'ci', [ 'test' ]
-  #When run from command-line
-  else
-    taskManager.add 'ci', [ 'test' ]
 
   taskManager.add 'default', [
     'build'

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -579,10 +579,17 @@ module.exports = (grunt) ->
     'jasmine'
   ]
 
-  taskManager.add 'ci', [
-    'test',
-    'coveralls'
-  ]
+  if process.env.TRAVIS_JOB_NUMBER
+    jobParts = process.env.TRAVIS_JOB_NUMBER.split('.')
+    #When run from Travis from jobs *.1
+    if jobParts.length > 1 and jobParts[1] == '1'
+      taskManager.add 'ci', [ 'test', 'coveralls' ]
+    #When run from Travis from jobs *.2, *.3, etc.
+    else
+      taskManager.add 'ci', [ 'test' ]
+  #When run from command-line
+  else
+    taskManager.add 'ci', [ 'test' ]
 
   taskManager.add 'default', [
     'build'

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-jasmine": "~0.7.0",
     "grunt-contrib-symlink": "~0.3.0",
-    "grunt-coveralls": "^1.0.0",
     "grunt-template-jasmine-istanbul": "^0.3.0",
     "grunt-ts": "^1.11",
     "regex2dfa": "~0.1.6",
@@ -52,7 +51,7 @@
     "freedom": "^0.6.11"
   },
   "scripts": {
-    "test": "grunt ci",
+    "test": "grunt test",
     "prepublish": "grunt test",
     "benchmark": "node bin/run-benchmark.js -n 1024 -v"
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-jasmine": "~0.7.0",
     "grunt-contrib-symlink": "~0.3.0",
+    "grunt-coveralls": "^1.0.0",
+    "grunt-template-jasmine-istanbul": "^0.3.0",
     "grunt-ts": "^1.11",
     "regex2dfa": "~0.1.6",
     "request": "^2.44.0",
@@ -50,7 +52,7 @@
     "freedom": "^0.6.11"
   },
   "scripts": {
-    "test": "grunt test",
+    "test": "grunt ci",
     "prepublish": "grunt test",
     "benchmark": "node bin/run-benchmark.js -n 1024 -v"
   }


### PR DESCRIPTION
Adding coverage reporting to turn-frontend, churn, socksToRtc, and rtcToNet

The coverage reports are generated as HTML files into
build/coverage

Currently here are the coverage numbers for these 4 directories
directory; statements, branches, functions, lines
churn/ 39.87%, 38%, 27.03%, 39.87%
turn-frontend/ 76.24%, 67.39%, 62.16%, 76.24%
rtcToNet/ 57.45%, 27.27%, 55.26%, 57.45%
socksToRtc/ 61.96%, 44.44%, 50.91%, 61.96%

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/176)

<!-- Reviewable:end -->
