### PR TITLE
add integration tests to grunt test

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -563,6 +563,7 @@ module.exports = (grunt) ->
   taskManager.add 'test', [
     'build'
     'jasmine'
+    'integration'
   ]
 
   taskManager.add 'default', [

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -560,10 +560,19 @@ module.exports = (grunt) ->
     'churn'
   ]
 
-  taskManager.add 'test', [
+  taskManager.add 'unit_test', [
     'build'
     'jasmine'
+  ]
+
+  taskManager.add 'integration_test', [
+    'build'
     'integration'
+  ]
+
+  taskManager.add 'test', [
+    'unit_test'
+    'integration_test'
   ]
 
   taskManager.add 'default', [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "freedom": "^0.6.11"
   },
   "scripts": {
-    "test": "grunt test",
+    "test": "grunt build jasmine",
     "prepublish": "grunt test",
     "benchmark": "node bin/run-benchmark.js -n 1024 -v"
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "utransformers": "~0.2.1",
     "wd": "~0.3.10",
     "wup": "^1.0.0",
-    "yargs": "^1.3.1"
+    "yargs": "^1.3.1",
+    "async": "^0.9.0",
+    "glob": "^4.3.2"
   },
   "peerDependencies": {
     "freedom": "^0.6.11"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   },
   "scripts": {
     "test": "grunt build jasmine",
-    "prepublish": "grunt test",
     "benchmark": "node bin/run-benchmark.js -n 1024 -v"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "freedom": "^0.6.11"
   },
   "scripts": {
-    "test": "grunt build jasmine",
+    "test": "grunt unit_test",
     "benchmark": "node bin/run-benchmark.js -n 1024 -v"
   }
 }

--- a/src/tcp/integration.ts
+++ b/src/tcp/integration.ts
@@ -21,17 +21,15 @@ freedom().on('listen', () => {
 
   server.listen().then((endpoint:Net.Endpoint) => {
     var client = new Tcp.Connection({endpoint: endpoint});
-    client.send(ArrayBuffers.stringToArrayBuffer('ping'));
-
     client.dataFromSocketQueue.setSyncNextHandler((buffer:ArrayBuffer) => {
       var s = ArrayBuffers.arrayBufferToString(buffer);
       if (s == 'ping') {
         freedom().emit('listen');
       }
     });
-  }, (e:Error) => {
-    // Because this is flaky...
-    console.error('failed to listen!: ' + e.message);
+    client.onceConnected.then((endpoint:Net.Endpoint) => {
+      client.send(ArrayBuffers.stringToArrayBuffer('ping'));
+    });
   });
 });
 

--- a/tools/docker-entrypoint.sh
+++ b/tools/docker-entrypoint.sh
@@ -3,6 +3,5 @@ set -e
 
 Xvfb :10 -screen 0 1280x1024x24 &
 sleep 3
-cd /uproxy-networking 
-grunt build
-grunt integration 
+cd /uproxy-networking
+grunt test


### PR DESCRIPTION
So, we've had this integration test for the TCP wrapper since around the time we moved to Freedom 0.6. It was a little experiment and wasn't really reviewed (my bad: it got lumped in with some other changes). I'd like to get another pair of eyes on it now, and get it running as part of `grunt test`.

Then we can tackle the end-to-end SOCKS test:
https://github.com/uProxy/uproxy/issues/756

ONE THING: I've noticed this is currently flaky...tracking it down, but this test fails the first time the extension loads. If you reload the extension, it works fine. Just that first time it fails...I think if we could figure out why, it would explain why Simple SOCKS mysteriously fails to start occasionally:
https://github.com/uProxy/uproxy/issues/628

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/178)

<!-- Reviewable:end -->
