### PR TITLE
Add socks client functions to socks-common and use ipaddr.js.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -216,7 +216,21 @@ module.exports = (grunt) ->
             standalone: 'sha1'
 
     jasmine:
-      socksCommon: Rule.jasmineSpec 'socks-common'
+      socksCommon:
+        src: FILES.jasmine_helpers.concat([
+          'build/ipaddrjs/ipaddr.min.js'
+          'build/socks-common/socks-headers.js'
+        ])
+        options:
+          specs: 'build/socks-common/*.spec.js'
+          template: require('grunt-template-jasmine-istanbul')
+          templateOptions:
+            coverage: 'build/coverage/socks-common/coverage.json'
+            report:
+              type: 'html'
+              options:
+                dir: 'build/coverage/socks-common'
+
       simpleTransformers: Rule.jasmineSpec 'simple-transformers'
       # TODO: turn tests require arraybuffers
       #       https://github.com/uProxy/uproxy/issues/430
@@ -379,6 +393,7 @@ module.exports = (grunt) ->
     'base'
     'ts:socksCommon'
     'ts:socksCommonSpecDecl'
+    'ipaddrjs'
     'copy:socksCommon'
   ]
 

--- a/src/ipaddrjs/ipaddrjs.d.ts
+++ b/src/ipaddrjs/ipaddrjs.d.ts
@@ -64,6 +64,8 @@ declare module ipaddr {
   }
 
   export interface VersionSpecificIpUtils<T> {
+    // Construct an IPv4 or IPv6 object from a raw numeric representation.
+    new(octetsOrParts:number[]) : T;
     isValid(address: string): boolean;
     parse(address: string): T;
   }

--- a/src/socks-common/socks-headers.d.ts
+++ b/src/socks-common/socks-headers.d.ts
@@ -46,11 +46,15 @@ declare module Socks {
     }
     // The interpret functions fail by throwing an error.
     function interpretAuthHandshakeBuffer(buffer :ArrayBuffer) : Auth[];
+    function composeAuthHandshake(auths:Auth[]) : Uint8Array;
     function composeAuthResponse(auth :Auth) : ArrayBuffer;
+    function interpretAuthResponse(byteArray:Uint8Array) : Auth;
     function interpretRequestBuffer(buffer :ArrayBuffer) : Request;
     function interpretRequest(byteArray :Uint8Array) : Request;
+    function composeRequest(request:Request) : Uint8Array;
     function interpretUdpMessage(byteArray :Uint8Array) : UdpMessage;
     function interpretDestination(byteArray :Uint8Array) : Destination;
+    function composeDestination(destination:Destination) : Uint8Array;
     function interpretIpv6Address(uint16View :Uint16Array) : string;
     function composeRequestResponse(endpoint :Net.Endpoint) : ArrayBuffer;
 }

--- a/src/socks-common/socks-headers.d.ts
+++ b/src/socks-common/socks-headers.d.ts
@@ -46,15 +46,15 @@ declare module Socks {
     }
     // The interpret functions fail by throwing an error.
     function interpretAuthHandshakeBuffer(buffer :ArrayBuffer) : Auth[];
-    function composeAuthHandshake(auths:Auth[]) : Uint8Array;
+    function composeAuthHandshakeBuffer(auths:Auth[]) : ArrayBuffer;
     function composeAuthResponse(auth :Auth) : ArrayBuffer;
-    function interpretAuthResponse(byteArray:Uint8Array) : Auth;
+    function interpretAuthResponse(buffer:ArrayBuffer) : Auth;
     function interpretRequestBuffer(buffer :ArrayBuffer) : Request;
     function interpretRequest(byteArray :Uint8Array) : Request;
-    function composeRequest(request:Request) : Uint8Array;
+    function composeRequestBuffer(request:Request) : ArrayBuffer;
     function interpretUdpMessage(byteArray :Uint8Array) : UdpMessage;
     function interpretDestination(byteArray :Uint8Array) : Destination;
     function composeDestination(destination:Destination) : Uint8Array;
-    function interpretIpv6Address(uint16View :Uint16Array) : string;
+    function interpretIpv6Address(byteArray:Uint8Array) : string;
     function composeRequestResponse(endpoint :Net.Endpoint) : ArrayBuffer;
 }

--- a/src/socks-common/socks-headers.d.ts
+++ b/src/socks-common/socks-headers.d.ts
@@ -57,4 +57,5 @@ declare module Socks {
     function composeDestination(destination:Destination) : Uint8Array;
     function interpretIpv6Address(byteArray:Uint8Array) : string;
     function composeRequestResponse(endpoint :Net.Endpoint) : ArrayBuffer;
+    function interpretRequestResponse(buffer:ArrayBuffer) : Net.Endpoint;
 }

--- a/src/socks-common/socks-headers.spec.ts
+++ b/src/socks-common/socks-headers.spec.ts
@@ -34,6 +34,23 @@ describe("socks", function() {
     }).toThrow();
   });
 
+  it('compose ipv4 tcp request', () => {
+    var request : Socks.Request = {
+      version: Socks.VERSION5,
+      command: Socks.Command.TCP_CONNECT,
+      destination: {
+        addressType: Socks.AddressType.IP_V4,
+        endpoint: {
+          address: '192.168.1.1',
+          port: 1200
+        },
+        addressByteLength: 7
+      }
+    };
+    var requestArray = Socks.composeRequest(request);
+    expect(requestArray).toEqual(ipv4RequestArray);
+  });
+
   it('parse ipv4 request', () => {
     var result :Socks.Request =
         Socks.interpretRequest(ipv4RequestArray);
@@ -42,6 +59,42 @@ describe("socks", function() {
     expect(result.destination.addressType).toEqual(Socks.AddressType.IP_V4);
     expect(result.destination.endpoint.address).toEqual('192.168.1.1');
     expect(result.destination.endpoint.port).toEqual(1200);
+  });
+
+  it('roundtrip ipv6 tcp request', () => {
+    var request : Socks.Request = {
+      version: Socks.VERSION5,
+      command: Socks.Command.TCP_CONNECT,
+      destination: {
+        addressType: Socks.AddressType.IP_V6,
+        endpoint: {
+          address: '2620::1003:1003:a84f:9831:df45:5420',
+          port: 1200
+        },
+        addressByteLength: 19
+      }
+    };
+    var requestArray = Socks.composeRequest(request);
+    var requestAgain = Socks.interpretRequest(requestArray);
+    expect(requestAgain).toEqual(request);
+  });
+
+  it('roundtrip DNS tcp request', () => {
+    var request : Socks.Request = {
+      version: Socks.VERSION5,
+      command: Socks.Command.TCP_CONNECT,
+      destination: {
+        addressType: Socks.AddressType.DNS,
+        endpoint: {
+          address: 'www.example.com',
+          port: 1200
+        },
+        addressByteLength: 19
+      }
+    };
+    var requestArray = Socks.composeRequest(request);
+    var requestAgain = Socks.interpretRequest(requestArray);
+    expect(requestAgain).toEqual(request);
   });
 
   it('wrong socks version', () => {

--- a/src/socks-common/socks-headers.spec.ts
+++ b/src/socks-common/socks-headers.spec.ts
@@ -118,6 +118,42 @@ describe("socks", function() {
     expect(requestAgain).toEqual(request);
   });
 
+  it('roundtrip IPv4 request response', () => {
+    var ipv4Endpoint :Net.Endpoint = {
+      address: '255.0.1.77',
+      port: 65535
+    };
+    var responseBuffer = Socks.composeRequestResponse(ipv4Endpoint);
+    var responseArray = new Uint8Array(responseBuffer);
+    expect(responseArray[3]).toEqual(Socks.AddressType.IP_V4);
+    var endpointAgain = Socks.interpretRequestResponse(responseBuffer);
+    expect(endpointAgain).toEqual(ipv4Endpoint);
+  });
+
+  it('roundtrip IPv6 request response', () => {
+    var ipv6Endpoint :Net.Endpoint = {
+      address: '2620::1003:1003:a84f:9831:df45:5420',
+      port: 40000
+    };
+    var responseBuffer = Socks.composeRequestResponse(ipv6Endpoint);
+    var responseArray = new Uint8Array(responseBuffer);
+    expect(responseArray[3]).toEqual(Socks.AddressType.IP_V6);
+    var endpointAgain = Socks.interpretRequestResponse(responseBuffer);
+    expect(endpointAgain).toEqual(ipv6Endpoint);
+  });
+
+  it('roundtrip DNS request response', () => {
+    var dnsEndpoint :Net.Endpoint = {
+      address: 'www.subdomain.example.com',
+      port: 45654
+    };
+    var responseBuffer = Socks.composeRequestResponse(dnsEndpoint);
+    var responseArray = new Uint8Array(responseBuffer);
+    expect(responseArray[3]).toEqual(Socks.AddressType.DNS);
+    var endpointAgain = Socks.interpretRequestResponse(responseBuffer);
+    expect(endpointAgain).toEqual(dnsEndpoint);
+  });
+
   it('wrong socks version', () => {
     ipv4RequestArray[0] = 4;
     expect(function() {

--- a/src/socks-common/socks-headers.spec.ts
+++ b/src/socks-common/socks-headers.spec.ts
@@ -28,6 +28,26 @@ describe("socks", function() {
       12]); // datagram (byte 2/2)
   });
 
+  it('roundtrip auth request', () => {
+    var auths = [
+      Socks.Auth.GSSAPI,
+      Socks.Auth.NOAUTH,
+      Socks.Auth.NONE,
+      Socks.Auth.USERPASS
+    ];
+
+    var buffer = Socks.composeAuthHandshakeBuffer(auths);
+    var authsAgain = Socks.interpretAuthHandshakeBuffer(buffer);
+    expect(authsAgain).toEqual(auths);
+  });
+
+  it('roundtrip auth response', () => {
+    var auth = Socks.Auth.USERPASS;
+    var buffer = Socks.composeAuthResponse(auth);
+    var authAgain = Socks.interpretAuthResponse(buffer);
+    expect(authAgain).toEqual(auth);
+  });
+
   it('reject wrongly sized requests', () => {
     expect(() => {
       Socks.interpretRequestBuffer(new ArrayBuffer(8));
@@ -47,7 +67,8 @@ describe("socks", function() {
         addressByteLength: 7
       }
     };
-    var requestArray = Socks.composeRequest(request);
+    var requestBuffer = Socks.composeRequestBuffer(request);
+    var requestArray = new Uint8Array(requestBuffer);
     expect(requestArray).toEqual(ipv4RequestArray);
   });
 
@@ -74,8 +95,8 @@ describe("socks", function() {
         addressByteLength: 19
       }
     };
-    var requestArray = Socks.composeRequest(request);
-    var requestAgain = Socks.interpretRequest(requestArray);
+    var requestBuffer = Socks.composeRequestBuffer(request);
+    var requestAgain = Socks.interpretRequestBuffer(requestBuffer);
     expect(requestAgain).toEqual(request);
   });
 
@@ -92,8 +113,8 @@ describe("socks", function() {
         addressByteLength: 19
       }
     };
-    var requestArray = Socks.composeRequest(request);
-    var requestAgain = Socks.interpretRequest(requestArray);
+    var requestBuffer = Socks.composeRequestBuffer(request);
+    var requestAgain = Socks.interpretRequestBuffer(requestBuffer);
     expect(requestAgain).toEqual(request);
   });
 

--- a/src/socks-common/socks-headers.ts
+++ b/src/socks-common/socks-headers.ts
@@ -111,12 +111,12 @@ module Socks {
     return authMethods;
   }
 
-  export function composeAuthHandshake(auths:Auth[]) : Uint8Array {
+  export function composeAuthHandshakeBuffer(auths:Auth[]) : ArrayBuffer {
     var handshakeBytes = new Uint8Array(auths.length + 2);
     handshakeBytes[0] = Socks.VERSION5;
     handshakeBytes[1] = auths.length;
     handshakeBytes.set(auths, 2);
-    return handshakeBytes;
+    return handshakeBytes.buffer;
   }
 
   // Server to Client (Step 2)
@@ -132,7 +132,8 @@ module Socks {
     return buffer;
   }
 
-  export function interpretAuthResponse(byteArray:Uint8Array) : Socks.Auth {
+  export function interpretAuthResponse(buffer:ArrayBuffer) : Socks.Auth {
+    var byteArray = new Uint8Array(buffer);
     return byteArray[1];
   }
 
@@ -181,14 +182,14 @@ module Socks {
     };
   }
 
-  export function composeRequest(request:Request) : Uint8Array {
+  export function composeRequestBuffer(request:Request) : ArrayBuffer {
     // The header is 3 bytes
     var byteArray = new Uint8Array(3 + request.destination.addressByteLength);
     byteArray[0] = request.version;
     byteArray[1] = request.command;
     byteArray[2] = 0;  // reserved
     byteArray.set(composeDestination(request.destination), 3);
-    return byteArray;
+    return byteArray.buffer;
   }
 
   // Client to Server (Step 3-B)

--- a/src/socks-common/socks-headers.ts
+++ b/src/socks-common/socks-headers.ts
@@ -112,6 +112,9 @@ module Socks {
   }
 
   export function composeAuthHandshakeBuffer(auths:Auth[]) : ArrayBuffer {
+    if (auths.length == 0) {
+      throw new Error('At least one authentication method must be specified.');
+    }
     var handshakeBytes = new Uint8Array(auths.length + 2);
     handshakeBytes[0] = Socks.VERSION5;
     handshakeBytes[1] = auths.length;
@@ -133,7 +136,16 @@ module Socks {
   }
 
   export function interpretAuthResponse(buffer:ArrayBuffer) : Socks.Auth {
+    if (buffer.byteLength != 2) {
+      throw new Error('Auth response must be exactly 2 bytes long');
+    }
     var byteArray = new Uint8Array(buffer);
+
+    // Only SOCKS Version 5 is supported.
+    var socksVersion = byteArray[0];
+    if (socksVersion != Socks.VERSION5) {
+      throw new Error('unsupported SOCKS version: ' + socksVersion);
+    }
     return byteArray[1];
   }
 
@@ -282,7 +294,10 @@ module Socks {
   // Heler function for parsing an IPv6 address from an Uint8Array portion of
   // a socks address in an arraybuffer.
   export function interpretIpv6Address(byteArray:Uint8Array) : string {
-    // |byteArray| contains big-endian shorts, but Uint16Array will read it
+    if (byteArray.length != 16) {
+      throw new Error('IPv6 addresses must be exactly 16 bytes long');
+    }
+    // |byteArray| contains big-endian shorts, but Uint16Array would read it
     // as little-endian on most platforms, so we have to read it manually.
     var parts :number[] = [];
     for (var i = 0; i < 16; i += 2) {


### PR DESCRIPTION
The socks client functions are useful for both unit testing
(included in this change) and integration testing (coming soon).

The ipaddr.js calls replace homebrew parsing and serialization
functions for IPv4 and IPv6 addresses.

This is related to https://github.com/uProxy/uproxy/issues/756

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/180)

<!-- Reviewable:end -->
