### PR TITLE
Fixed median calc, updated timeout, and parameterized num timeouts.

### DIFF
--- a/bin/run-benchmark.js
+++ b/bin/run-benchmark.js
@@ -10,6 +10,8 @@ var argv = require('yargs')
     .alias('c', 'concurrency')
     .default('speed', 1)
     .alias('s', 'speed')
+    .default('maxtimeouts', 10)
+    .alias('m', 'maxtimeouts')
     .argv;
 
 var should_sleep = true;
@@ -17,9 +19,12 @@ var num_tests = argv.n;
 var verbosity = argv.verbose;
 var concurrency = argv.concurrency
 var tail_lat = 1000 / argv.speed;
+var max_timeouts = argv.maxtimeouts;
+console.log("Configured arguments: num tests: " + num_tests + ", concurrency: " + concurrency + 
+            ", max timeouts: " + max_timeouts);
 
 // 500ms window for the histogram, broken into 64 buckets.
-runner.configureDefaults(concurrency, 64, tail_lat, verbosity);
+runner.configureDefaults(concurrency, 64, tail_lat, verbosity, max_timeouts);
 runner.runTests(num_tests, function (results) {
     console.log("-------------------------------------------------------");
     console.log("  BENCHMARK COMPLETE");


### PR DESCRIPTION
Small changes to make the benchmark tool better.  Specifically:
- I turned length-checking back on.  I after having diagnosed the length issue in https://github.com/uProxy/uproxy/issues/770
- Upped the timeout for requests to 30 seconds from 2 sec.  There were requests on localhost taking a surprisingly long amount of time, but let's make sure that we know if they eventually come back.
- Fixed median latency calculation. 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/183)

<!-- Reviewable:end -->
