### PR TITLE
Improve error reporting in rtc-to-net

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -317,7 +317,7 @@ module.exports = (grunt) ->
                 dir: 'build/coverage/rtcToNet'
 
     integration:
-      all:
+      base:
         options:
           template: 'node_modules/freedom-for-chrome/spec/helper/'
           spec: ['build/integration/*/*.integration.spec.js']
@@ -326,6 +326,26 @@ module.exports = (grunt) ->
             # the jasmine tests in the core environment.
             {path: 'build/freedom/freedom-for-chrome.js', include: true}
             {path: 'build/arraybuffers/arraybuffers.js', include: true}
+            {path: 'build/logging/logging.js', include: false}
+            {path: 'build/handler/queue.js', include: false}
+            {path: 'build/ipaddrjs/ipaddr.min.js', include: false}
+            {path: 'build/rtc-to-net/rtc-to-net.js', include: false}
+            {path: 'build/socks-common/socks-headers.js', include: false}
+            {path: 'build/socks-to-rtc/socks-to-rtc.js', include: false}
+            {path: 'build/webrtc/*.js', include: false}
+            {path: 'build/tcp/tcp.js', include: false}
+            {path: 'build/integration/*/integration.*', include: false}
+          ]
+          keepBrowser: false
+      slow:
+        options:
+          template: 'node_modules/freedom-for-chrome/spec/helper/'
+          spec: ['build/integration/*/*.slow_integration.spec.js']
+          helper: [
+            # "include: true" is needed for dependencies that are used by
+            # the jasmine tests in the core environment.
+            {path: 'build/freedom/freedom-for-chrome.js', include: true}
+            {path: 'build/arraybuffers/arraybuffers.js', include: false}
             {path: 'build/logging/logging.js', include: false}
             {path: 'build/handler/queue.js', include: false}
             {path: 'build/ipaddrjs/ipaddr.min.js', include: false}
@@ -620,7 +640,12 @@ module.exports = (grunt) ->
     'build'
     'ts:integrationTests'
     'ts:integrationTestsSpecDecl'
-    'integration'
+    'integration:base'
+  ]
+
+  taskManager.add 'slow_integration_test', [
+    'integration_test'
+    'integration:slow'
   ]
 
   taskManager.add 'test', [

--- a/src/integration/socks-echo/socks-echo.integration.spec.ts
+++ b/src/integration/socks-echo/socks-echo.integration.spec.ts
@@ -170,9 +170,7 @@ describe('proxy integration tests', function() {
     }).then(done);
   });
 
-  // This test is disabled because it times out instead of returning an error.
-  // TODO: Re-enable when fixing https://github.com/uProxy/uproxy/issues/800
-  xit('run a localhost-resolving DNS name echo test while localhost is blocked.', (done) => {
+  it('run a localhost-resolving DNS name echo test while localhost is blocked.', (done) => {
     // Get a test module with one that doesn't allow localhost access.
     getTestModule(true).then((testModule:any) => {
       return testModule.startEchoServer().then((port:number) => {
@@ -187,16 +185,15 @@ describe('proxy integration tests', function() {
       // corporate DNS can drop responses that resolve to local network
       // addresses.  Accordingly, the error code may either indicate
       // a generic failure (if resolution fails) or NOT_ALLOWED if name
-      // resolution succeeds.
-      var expectedReplies = [Socks.Reply.NOT_ALLOWED, Socks.Reply.FAILURE];
-      expect(expectedReplies).toContain(e.reply);
+      // resolution succeeds.  However, to avoid portscanning leaks
+      // (https://github.com/uProxy/uproxy/issues/809) both will be reported
+      // as FAILURE
+      expect(e.reply).toEqual(Socks.Reply.FAILURE);
     }).then(done);
   });
 
-  // Disabled because CONNECTION_REFUSED is not yet implemented in RtcToNet.
-  // Tracked by https://github.com/uProxy/uproxy/issues/800
-  xit('attempt to connect to a nonexistent echo daemon', (done) => {
-    getTestModule(true).then((testModule:any) => {
+  it('attempt to connect to a nonexistent echo daemon', (done) => {
+    getTestModule().then((testModule:any) => {
       return testModule.connect(1023);  // 1023 is a reserved port.
     }).then((connectionId:string) => {
       // This code should not run, because there is no server on this port.
@@ -206,25 +203,91 @@ describe('proxy integration tests', function() {
     }).then(done);
   });
 
-  // Disabled because HOST_UNREACHABLE is not yet implemented in RtcToNet.
+  it('attempt to connect to a nonexistent echo daemon while localhost is blocked', (done) => {
+    getTestModule(true).then((testModule:any) => {
+      return testModule.connect(1023);  // 1023 is a reserved port.
+    }).then((connectionId:string) => {
+      // This code should not run, because localhost is blocked.
+      expect(connectionId).toBeUndefined();
+    }).catch((e:any) => {
+      expect(e.reply).toEqual(Socks.Reply.NOT_ALLOWED);
+    }).then(done);
+  });
+
+  it('attempt to connect to a nonexistent local echo daemon while localhost is blocked as 0.0.0.0', (done) => {
+    getTestModule(true).then((testModule:any) => {
+      return testModule.connect(1023, '0.0.0.0');  // 1023 is a reserved port.
+    }).then((connectionId:string) => {
+      // This code should not run because the destination is invalid.
+      expect(connectionId).toBeUndefined();
+    }).catch((e:any) => {
+      // TODO: Make this just NOT_ALLOWED once this bug in ipadddr.js is fixed:
+      // https://github.com/whitequark/ipaddr.js/issues/9
+      expect([Socks.Reply.NOT_ALLOWED, Socks.Reply.FAILURE]).toContain(e.reply);
+    }).then(done);
+  });
+
+  it('attempt to connect to a nonexistent local echo daemon while localhost is blocked as IPv6', (done) => {
+    getTestModule(true).then((testModule:any) => {
+      return testModule.connect(1023, '::1');  // 1023 is a reserved port.
+    }).then((connectionId:string) => {
+      // This code should not run, because localhost is blocked.
+      expect(connectionId).toBeUndefined();
+    }).catch((e:any) => {
+      expect(e.reply).toEqual(Socks.Reply.NOT_ALLOWED);
+    }).then(done);
+  });
+
+  it('attempt to connect to a local network IP address while it is blocked', (done) => {
+    getTestModule(true).then((testModule:any) => {
+      return testModule.connect(1023, '10.5.5.5');  // 1023 is a reserved port.
+    }).then((connectionId:string) => {
+      // This code should not run, because local network access is blocked.
+      expect(connectionId).toBeUndefined();
+    }).catch((e:any) => {
+      expect(e.reply).toEqual(Socks.Reply.NOT_ALLOWED);
+    }).then(done);
+  });
+
+  it('connection refused from DNS name', (done) => {
+    getTestModule().then((testModule:any) => {
+      // Many sites (such as uproxy.org) seem to simply ignore SYN packets on
+      // unmonitored ports, but openbsd.org actually refuses the connection as
+      // expected.
+      return testModule.connect(1023, 'openbsd.org');
+    }).then((connectionId:string) => {
+      // This code should not run, because there is no server on this port.
+      expect(connectionId).toBeUndefined();
+    }).catch((e:any) => {
+      expect(e.reply).toEqual(Socks.Reply.CONNECTION_REFUSED);
+    }).then(done);
+  });
+
+  it('connection refused from DNS name while localhost is blocked', (done) => {
+    getTestModule(true).then((testModule:any) => {
+      // Many sites (such as uproxy.org) seem to simply ignore SYN packets on
+      // unmonitored ports, but openbsd.org actually refuses the connection as
+      // expected.
+      return testModule.connect(1023, 'openbsd.org');
+    }).then((connectionId:string) => {
+      // This code should not run, because there is no server on this port.
+      expect(connectionId).toBeUndefined();
+    }).catch((e:any) => {
+      // This should be CONNECTION_REFUSED, but since we can't be sure that the
+      // domain isn't on the local network, and we're concerned about port
+      // scanning, we return the generic FAILURE code instead.
+      // See https://github.com/uProxy/uproxy/issues/809.
+      expect(e.reply).toEqual(Socks.Reply.FAILURE);
+    }).then(done);
+  });
+
+  // Disabled because HOST_UNREACHABLE is not yet exposed in freedom-for-chrome's
+  // implementation of the core.tcpsocket API.
   xit('attempt to connect to a nonexistent DNS name', (done) => {
     getTestModule(true).then((testModule:any) => {
       return testModule.connect(80, 'www.nonexistentdomain.gov');
     }).then((connectionId:string) => {
       // This code should not run, because there is no such DNS name.
-      expect(connectionId).toBeUndefined();
-    }).catch((e:any) => {
-      expect(e.reply).toEqual(Socks.Reply.HOST_UNREACHABLE);
-    }).then(done);
-  });
-
-  // Disabled because HOST_UNREACHABLE is not yet implemented in RtcToNet.
-  xit('attempt to connect to a nonexistent IP address', (done) => {
-    getTestModule(true).then((testModule:any) => {
-      // 192.0.2.0/24 is a reserved IP address range.
-      return testModule.connect(80, '192.0.2.111');
-    }).then((connectionId:string) => {
-      // This code should not run, because this is a reserved IP address.
       expect(connectionId).toBeUndefined();
     }).catch((e:any) => {
       expect(e.reply).toEqual(Socks.Reply.HOST_UNREACHABLE);

--- a/src/integration/socks-echo/socks-echo.slow_integration.spec.ts
+++ b/src/integration/socks-echo/socks-echo.slow_integration.spec.ts
@@ -1,0 +1,32 @@
+/// <reference path='../../freedom/typings/freedom.d.ts' />
+/// <reference path='../../third_party/typings/jasmine/jasmine.d.ts' />
+/// <reference path="../../socks-common/socks-headers.d.ts" />
+
+// Integration test for the whole proxying system.
+// The real work is done in the Freedom module which performs each test.
+describe('proxy integration tests', function() {
+  var getTestModule = function(denyLocalhost?:boolean) : any {
+    return freedom('scripts/build/integration/socks-echo/integration.json',
+            { 'debug': 'log' })
+        .then((interface:any) => {
+          return interface(denyLocalhost);
+        });
+  };
+
+  // The default TCP SYN timeout is two minutes, so to be safe we
+  // set a test timeout of four minutes.
+  (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = 240000;
+
+  it('attempt to connect to a nonexistent IP address', (done) => {
+    getTestModule().then((testModule:any) => {
+      // 192.0.2.0/24 is a reserved IP address range.
+      return testModule.connect(80, '192.0.2.111');
+    }).then((connectionId:string) => {
+      // This code should not run, because this is a reserved IP address.
+      expect(connectionId).toBeUndefined();
+    }).catch((e:any) => {
+      // The socket should time out after two minutes.
+      expect(e.reply).toEqual(Socks.Reply.TTL_EXPIRED);
+    }).then(done);
+  });
+});

--- a/src/socks-common/socks-headers.d.ts
+++ b/src/socks-common/socks-headers.d.ts
@@ -41,7 +41,7 @@ declare module Socks {
     function isValidRequest(r:any) : boolean;
     interface Response {
         reply: Reply;
-        endpoint: Net.Endpoint;
+        endpoint?: Net.Endpoint;
     }
     function isValidResponse(r:any) : boolean;
     interface UdpMessage {

--- a/src/socks-common/socks-headers.ts
+++ b/src/socks-common/socks-headers.ts
@@ -101,7 +101,7 @@ module Socks {
 
   export interface Response {
     reply: Reply;
-    endpoint: Net.Endpoint;
+    endpoint?: Net.Endpoint;
   }
 
   export function isValidResponse(r:any) : boolean {
@@ -112,7 +112,10 @@ module Socks {
         typeof Reply[r.reply] != 'string') {
       return false;
     }
-    if (!isValidEndpoint(r.endpoint)) {
+    if (r.reply == Reply.SUCCEEDED && !r.endpoint) {
+      return false;
+    }
+    if (r.endpoint && !isValidEndpoint(r.endpoint)) {
       return false;
     }
     if (Object.keys(r).length > 2) {
@@ -438,7 +441,12 @@ module Socks {
   //
   // Given a destination reached, compose a response.
   export function composeResponseBuffer(response:Response) : ArrayBuffer {
-    var destination = makeDestinationFromEndpoint(response.endpoint);
+    var fakeEndpoint :Net.Endpoint = {
+      address: '0.0.0.0',
+      port: 0
+    };
+    var endpoint :Net.Endpoint = response.endpoint || fakeEndpoint;
+    var destination = makeDestinationFromEndpoint(endpoint);
     var destinationArray = composeDestination(destination);
 
     var bytes :Uint8Array = new Uint8Array(destinationArray.length + 3);


### PR DESCRIPTION
This change attempts to improve the level of detail of error reporting without
revealing information that would allow a port scan of a private network.

Care is taken relative to https://github.com/uProxy/uproxy/issues/809

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/187)

<!-- Reviewable:end -->
