### PR TITLE
move to uproxy-lib 18, with loggingprovider

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "selenium-standalone": "~2.44.0",
     "socks5-http-client": "^0.1.6",
     "typescript": "^1.1.0-1",
-    "uproxy-lib": "~17.0.0",
+    "uproxy-lib": "~18.0.0",
     "utransformers": "~0.2.1",
     "wd": "~0.3.10",
     "wup": "^1.0.0",

--- a/src/churn-pipe/freedom.json
+++ b/src/churn-pipe/freedom.json
@@ -67,7 +67,6 @@
     }
   },
   "permissions": [
-    "core.console",
     "core.udpsocket"
   ]
 }

--- a/src/churn/mocks.js
+++ b/src/churn/mocks.js
@@ -2,9 +2,13 @@
 // We do this in a non-TypeScript file because the ambient module declaration
 // prevents us creating any variable called freedom in TypeScript-land.
 var freedom = {
-  core: jasmine.createSpy().and.returnValue(
-    jasmine.createSpyObj('core', ['getLogger'])),
   churn: jasmine.createSpy().and.returnValue(
     jasmine.createSpyObj('churn', ['providePromises']))
 };
-
+freedom['core'] = function() {
+  return {
+    'getLogger': function() {
+      return jasmine.createSpyObj('logger', ['then']);
+    }
+  };
+};

--- a/src/churn/mocks.js
+++ b/src/churn/mocks.js
@@ -1,9 +1,10 @@
 // Create a mock instance of Freedom.
 // We do this in a non-TypeScript file because the ambient module declaration
 // prevents us creating any variable called freedom in TypeScript-land.
-var freedom = jasmine.createSpyObj('freedom', ['core.log']);
-freedom.churn = jasmine.createSpy().and.returnValue(
-    jasmine.createSpyObj('churn', ['providePromises']));
-freedom['core.console'] = function() {
-  return window.console;
+var freedom = {
+  core: jasmine.createSpy().and.returnValue(
+    jasmine.createSpyObj('core', ['getLogger'])),
+  churn: jasmine.createSpy().and.returnValue(
+    jasmine.createSpyObj('churn', ['providePromises']))
 };
+

--- a/src/echo/freedom-module.json
+++ b/src/echo/freedom-module.json
@@ -11,8 +11,13 @@
       "freedom-module.js"
     ]
   },
+  "dependencies": {
+    "loggingprovider": {
+      "url": "../loggingprovider/loggingprovider.json",
+      "api": "loggingprovider"
+    }
+  },
   "permissions": [
-    "core.tcpsocket",
-    "core.console"
+    "core.tcpsocket"
   ]
 }

--- a/src/echo/freedom-module.ts
+++ b/src/echo/freedom-module.ts
@@ -2,6 +2,8 @@
 /// <reference path='../logging/logging.d.ts' />
 /// <reference path='../freedom/typings/freedom.d.ts' />
 
+freedom['loggingprovider']().setConsoleFilter(['*:D']);
+
 var log :Logging.Log = new Logging.Log('echo-server');
 
 var tcpServer :TcpEchoServer;

--- a/src/integration/socks-echo/integration.json
+++ b/src/integration/socks-echo/integration.json
@@ -39,7 +39,6 @@
     }
   },
   "permissions": [
-    "core.console",
     "core.rtcpeerconnection",
     "core.rtcdatachannel",
     "core.tcpsocket",

--- a/src/integration/tcp/integration.json
+++ b/src/integration/tcp/integration.json
@@ -10,7 +10,6 @@
     ]
   },
   "permissions": [
-    "core.console",
     "core.tcpsocket"
   ]
 }

--- a/src/rtc-to-net/mocks.js
+++ b/src/rtc-to-net/mocks.js
@@ -1,7 +1,7 @@
 // Create a mock instance of Freedom.
 // We do this in a non-TypeScript file because the ambient module declaration
 // prevents us creating any variable called freedom in TypeScript-land.
-var freedom = jasmine.createSpyObj('freedom', ['core.log']);
-freedom['core.console'] = function() {
-  return window.console;
+var freedom = {
+  core: jasmine.createSpy().and.returnValue(
+    jasmine.createSpyObj('core', ['getLogger'])),
 };

--- a/src/rtc-to-net/mocks.js
+++ b/src/rtc-to-net/mocks.js
@@ -2,6 +2,11 @@
 // We do this in a non-TypeScript file because the ambient module declaration
 // prevents us creating any variable called freedom in TypeScript-land.
 var freedom = {
-  core: jasmine.createSpy().and.returnValue(
-    jasmine.createSpyObj('core', ['getLogger'])),
+  core: function() {
+    return {
+      'getLogger': function() {
+        return jasmine.createSpyObj('logger', ['then']);
+      }
+    };
+  }
 };

--- a/src/samples/copypaste-churn-chat-chromeapp/freedom-module.json
+++ b/src/samples/copypaste-churn-chat-chromeapp/freedom-module.json
@@ -25,7 +25,6 @@
     }
   },
   "permissions": [
-    "core.console",
     "core.udpsocket",
     "core.rtcdatachannel",
     "core.rtcpeerconnection"

--- a/src/samples/copypaste-churn-chat-chromeapp/freedom-module.json
+++ b/src/samples/copypaste-churn-chat-chromeapp/freedom-module.json
@@ -15,6 +15,10 @@
     ]
   },
   "dependencies": {
+    "loggingprovider": {
+      "url": "lib/loggingprovider/loggingprovider.json",
+      "api": "loggingprovider"
+    },
     "churnPipe": {
       "url": "lib/churn-pipe/freedom.json",
       "api": "churnPipe"

--- a/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
@@ -3,7 +3,7 @@
 /// <reference path='../../logging/logging.d.ts' />
 /// <reference path="../../freedom/typings/freedom.d.ts" />
 
-Logging.setConsoleFilter(['*:D']);
+freedom['loggingprovider']().setConsoleFilter(['*:D']);
 
 var log :Logging.Log = new Logging.Log('copypaste churn chat');
 

--- a/src/samples/copypaste-churn-chat-chromeapp/main.ts
+++ b/src/samples/copypaste-churn-chat-chromeapp/main.ts
@@ -6,7 +6,10 @@ var copyTextarea = <HTMLInputElement>document.getElementById("copy");
 var pasteTextarea = <HTMLInputElement>document.getElementById("paste");
 var receiveButton = document.getElementById("receiveButton");
 
-freedom('freedom-module.json', { 'debug': 'log' }).then(function(interface:any) {
+freedom('freedom-module.json', {
+    'logger': 'lib/loggingprovider/loggingprovider.json',
+    'debug': 'log'
+}).then(function(interface:any) {
   var copypasteChurnChat :any = interface();
 
   // Dispatches each line from the paste box as a signalling channel message.

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.json
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.json
@@ -20,13 +20,16 @@
     ]
   },
   "dependencies": {
+    "loggingprovider": {
+      "url": "lib/loggingprovider/loggingprovider.json",
+      "api": "loggingprovider"
+    },
     "churnPipe": {
       "url": "lib/churn-pipe/freedom.json",
       "api": "churnPipe"
     }
   },
   "permissions": [
-    "core.console",
     "core.tcpsocket",
     "core.udpsocket",
     "core.rtcdatachannel",

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -10,7 +10,7 @@
 // you're debugging. Since the proxy outputs quite a lot of messages,
 // show only warnings by default from the rest of the system.
 // Note that the proxy is extremely slow in debug (D) mode.
-Logging.setConsoleFilter([
+freedom['loggingprovider']().setConsoleFilter([
     '*:I',
     'SocksToRtc:I',
     'RtcToNet:I']);

--- a/src/samples/copypaste-socks-chromeapp/popup.ts
+++ b/src/samples/copypaste-socks-chromeapp/popup.ts
@@ -4,9 +4,10 @@
 /// <reference path='../../networking-typings/i18n.d.ts' />
 /// <reference path='../../webrtc/peerconnection.d.ts' />
 
-var copypastePromise :Promise<any> = freedom(
-    'freedom-module.json', { 'debug': 'log' })
-.then((interface:any) => {
+var copypastePromise :Promise<any> = freedom('freedom-module.json', {
+    'logger': 'lib/loggingprovider/loggingprovider.json',
+    'debug': 'log'
+}).then((interface:any) => {
   return interface();
 }, (e:Error) => {
   console.error('could not load freedom: ' + e.message);

--- a/src/samples/echo-server-chromeapp/background.ts
+++ b/src/samples/echo-server-chromeapp/background.ts
@@ -5,7 +5,10 @@ script.src = 'lib/freedom/freedom-for-chrome.js';
 document.head.appendChild(script);
 
 script.onload = () => {
-  freedom('lib/echo/freedom-module.json', { 'debug': 'log' }).then(function(interface:any) {
+  freedom('lib/echo/freedom-module.json', {
+      'logger': 'lib/loggingprovider/loggingprovider.json',
+      'debug': 'log'
+  }).then(function(interface:any) {
     var echo :any = interface();
     echo.emit('start', { address: '127.0.0.1', port: 9998 });
   }, (e:Error) => {

--- a/src/samples/echo-server-firefoxapp/lib/main.js
+++ b/src/samples/echo-server-firefoxapp/lib/main.js
@@ -5,7 +5,11 @@ var {setTimeout} = require("sdk/timers");
 Cu.import(self.data.url("lib/freedom/freedom-for-firefox.jsm"));
 
 var manifest = self.data.url("lib/echo/freedom-module.json");
-freedom(manifest, { 'debug': 'log' }).then(function(interface) {
+var loggingProviderManifest = self.data.url("lib/loggingprovider/loggingprovider.json");
+freedom(manifest, {
+  'logger': loggingProviderManifest,
+  'debug': 'log'
+}).then(function(interface) {
   var echo = interface();
   echo.emit('start', { address: '127.0.0.1', port: 9998 });
 }, function() {

--- a/src/samples/simple-churn-chat-chromeapp/freedom-module.json
+++ b/src/samples/simple-churn-chat-chromeapp/freedom-module.json
@@ -15,13 +15,16 @@
     ]
   },
   "dependencies": {
+    "loggingprovider": {
+      "url": "lib/loggingprovider/loggingprovider.json",
+      "api": "loggingprovider"
+    },
     "churnPipe": {
       "url": "lib/churn-pipe/freedom.json",
       "api": "churnPipe"
     }
   },
   "permissions": [
-    "core.console",
     "core.udpsocket",
     "core.rtcdatachannel",
     "core.rtcpeerconnection"

--- a/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
@@ -3,7 +3,7 @@
 /// <reference path="../../freedom/typings/freedom.d.ts" />
 /// <reference path='../../logging/logging.d.ts' />
 
-Logging.setConsoleFilter(['*:D']);
+freedom['loggingprovider']().setConsoleFilter(['*:D']);
 
 var log :Logging.Log = new Logging.Log('simple churn chat');
 

--- a/src/samples/simple-churn-chat-chromeapp/main.ts
+++ b/src/samples/simple-churn-chat-chromeapp/main.ts
@@ -8,7 +8,10 @@ var sendAreaB = <HTMLInputElement>document.getElementById("sendAreaB");
 var receiveAreaA = <HTMLInputElement>document.getElementById("receiveAreaA");
 var receiveAreaB = <HTMLInputElement>document.getElementById("receiveAreaB");
 
-freedom('freedom-module.json', { 'debug': 'log' }).then(function(interface:any) {
+freedom('freedom-module.json', {
+    'logger': 'lib/loggingprovider/loggingprovider.json',
+    'debug': 'debug'
+}).then(function(interface:any) {
   var simpleChurnChat :any = interface();
 
   simpleChurnChat.on('ready', function() {

--- a/src/samples/simple-socks-chromeapp/background.ts
+++ b/src/samples/simple-socks-chromeapp/background.ts
@@ -5,7 +5,10 @@ script.src = 'lib/freedom/freedom-for-chrome.js';
 document.head.appendChild(script);
 
 script.onload = () => {
-  freedom('lib/simple-socks/freedom-module.json', { 'debug': 'log' }).then(function(interface:any) {
+  freedom('lib/simple-socks/freedom-module.json', {
+      'logger': 'lib/loggingprovider/loggingprovider.json',
+      'debug': 'log'
+  }).then(function(interface:any) {
     var simpleSocks :any = interface();
   }, (e:Error) => {
     console.error('could not load freedom: ' + e.message);

--- a/src/samples/simple-socks-firefoxapp/lib/main.js
+++ b/src/samples/simple-socks-firefoxapp/lib/main.js
@@ -5,7 +5,11 @@ var {setTimeout} = require("sdk/timers");
 Cu.import(self.data.url("lib/freedom/freedom-for-firefox.jsm"));
 
 var manifest = self.data.url("lib/simple-socks/freedom-module.json");
-freedom(manifest, { 'debug': 'log' }).then(function(interface) {
+var loggingProviderManifest = self.data.url("lib/loggingprovider/loggingprovider.json");
+freedom(manifest, {
+  'logger': loggingProviderManifest,
+  'debug': 'log'
+}).then(function(interface) {
   var simpleSocks = interface();
 }, function() {
   console.error('could not load freedom');

--- a/src/samples/simple-turn-chromeapp/background.ts
+++ b/src/samples/simple-turn-chromeapp/background.ts
@@ -5,7 +5,10 @@ script.src = 'lib/freedom/freedom-for-chrome.js';
 document.head.appendChild(script);
 
 script.onload = () => {
-  freedom('freedom-module.json', { 'debug': 'log' }).then(function(interface:any) {
+  freedom('freedom-module.json', {
+      'logger': 'lib/loggingprovider/loggingprovider.json',
+      'debug': 'log'
+  }).then(function(interface:any) {
     var simpleTurn :any = interface();
   }, (e:Error) => {
     console.error('could not load freedom: ' + e.message);

--- a/src/samples/simple-turn-chromeapp/freedom-module.json
+++ b/src/samples/simple-turn-chromeapp/freedom-module.json
@@ -10,6 +10,10 @@
     ]
   },
   "dependencies": {
+    "loggingprovider": {
+      "url": "lib/loggingprovider/loggingprovider.json",
+      "api": "loggingprovider"
+    },
     "turnFrontend": {
       "url": "lib/turn-frontend/freedom.json",
       "api": "turnFrontend"

--- a/src/samples/simple-turn-chromeapp/freedom-module.json
+++ b/src/samples/simple-turn-chromeapp/freedom-module.json
@@ -22,8 +22,5 @@
       "url": "lib/turn-backend/freedom.json",
       "api": "turnBackend"
     }
-  },
-  "permissions": [
-    "core.console"
-  ]
+  }
 }

--- a/src/samples/simple-turn-chromeapp/freedom-module.ts
+++ b/src/samples/simple-turn-chromeapp/freedom-module.ts
@@ -3,7 +3,7 @@
 /// <reference path='../../freedom/typings/freedom.d.ts' />
 /// <reference path='../../logging/logging.d.ts' />
 
-Logging.setConsoleFilter(['*:I']);
+freedom['loggingprovider']().setConsoleFilter(['*:I']);
 
 var log :Logging.Log = new Logging.Log('simple TURN');
 

--- a/src/simple-socks/freedom-module.json
+++ b/src/simple-socks/freedom-module.json
@@ -30,7 +30,6 @@
     }
   },
   "permissions": [
-    "core.console",
     "core.tcpsocket",
     "core.udpsocket",
     "core.rtcdatachannel",

--- a/src/simple-socks/freedom-module.json
+++ b/src/simple-socks/freedom-module.json
@@ -20,6 +20,10 @@
     ]
   },
   "dependencies": {
+    "loggingprovider": {
+      "url": "../loggingprovider/loggingprovider.json",
+      "api": "loggingprovider"
+    },
     "churnPipe": {
       "url": "../churn-pipe/freedom.json",
       "api": "churnPipe"

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -10,7 +10,7 @@
 // you're debugging. Since the proxy outputs quite a lot of messages,
 // show only warnings by default from the rest of the system.
 // Note that the proxy is extremely slow in debug (D) mode.
-Logging.setConsoleFilter([
+freedom['loggingprovider']().setConsoleFilter([
     '*:I',
     'SocksToRtc:I',
     'RtcToNet:I']);

--- a/src/socks-to-rtc/freedom.json
+++ b/src/socks-to-rtc/freedom.json
@@ -69,7 +69,6 @@
   },
   "permissions": [
     "churnPipe",
-    "core.console",
     "core.rtcdatachannel",
     "core.rtcpeerconnection",
     "core.tcpsocket"

--- a/src/socks-to-rtc/mocks.js
+++ b/src/socks-to-rtc/mocks.js
@@ -1,7 +1,7 @@
 // Create a mock instance of Freedom.
 // We do this in a non-TypeScript file because the ambient module declaration
 // prevents us creating any variable called freedom in TypeScript-land.
-var freedom = jasmine.createSpyObj('freedom', ['core.log']);
-freedom['core.console'] = function() {
-  return window.console;
+var freedom = {
+  core: jasmine.createSpy().and.returnValue(
+    jasmine.createSpyObj('core', ['getLogger'])),
 };

--- a/src/socks-to-rtc/mocks.js
+++ b/src/socks-to-rtc/mocks.js
@@ -2,6 +2,11 @@
 // We do this in a non-TypeScript file because the ambient module declaration
 // prevents us creating any variable called freedom in TypeScript-land.
 var freedom = {
-  core: jasmine.createSpy().and.returnValue(
-    jasmine.createSpyObj('core', ['getLogger'])),
+  core: function() {
+    return {
+      'getLogger': function() {
+        return jasmine.createSpyObj('logger', ['then']);
+      }
+    };
+  }
 };

--- a/src/turn-backend/freedom.json
+++ b/src/turn-backend/freedom.json
@@ -27,7 +27,6 @@
     }
   },
   "permissions": [
-    "core.console",
     "core.udpsocket"
   ]
 }

--- a/src/turn-frontend/freedom.json
+++ b/src/turn-frontend/freedom.json
@@ -39,7 +39,6 @@
     }
   },
   "permissions": [
-    "core.console",
     "core.udpsocket"
   ]
 }

--- a/src/turn-frontend/mocks.js
+++ b/src/turn-frontend/mocks.js
@@ -1,9 +1,8 @@
 // Create a mock instance of Freedom.
 // We do this in a non-TypeScript file because the ambient module declaration
 // prevents us creating any variable called freedom in TypeScript-land.
-var freedom = jasmine.createSpyObj('spy', ['core.udpsocket', 'core.log']);
+var freedom = jasmine.createSpyObj('spy', ['core.udpsocket']);
+freedom.core = jasmine.createSpy().and.returnValue(
+    jasmine.createSpyObj('core', ['getLogger']));
 freedom.turnFrontend = jasmine.createSpy().and.returnValue(
     jasmine.createSpyObj('turnFrontend', ['providePromises']));
-freedom['core.console'] = function() {
-  return window.console;
-};

--- a/src/turn-frontend/mocks.js
+++ b/src/turn-frontend/mocks.js
@@ -2,7 +2,12 @@
 // We do this in a non-TypeScript file because the ambient module declaration
 // prevents us creating any variable called freedom in TypeScript-land.
 var freedom = jasmine.createSpyObj('spy', ['core.udpsocket']);
-freedom.core = jasmine.createSpy().and.returnValue(
-    jasmine.createSpyObj('core', ['getLogger']));
 freedom.turnFrontend = jasmine.createSpy().and.returnValue(
     jasmine.createSpyObj('turnFrontend', ['providePromises']));
+freedom['core'] = function() {
+  return {
+    'getLogger': function() {
+      return jasmine.createSpyObj('logger', ['then']);
+    }
+  };
+};


### PR DESCRIPTION
OK, so, yeah. This updates the repo to use uproxy-lib 18.

This has the new loggingprovider stuff so it's mostly a matter of updating the sample apps to add loggingprovider as a dependency and updating calls to `setConsoleFilter`.

@willscott: Does this look about right to you? Do you spot any unnecessary stuff in here? It's quite a big diff, would appreciate any suggestions you might have on trimming it.

@iislucas: I know you are working on some improvements to mocking with the move to require but hopefully this is not unacceptable.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/188)

<!-- Reviewable:end -->
