### PR TITLE
bin/make-data.sh now makes text files.

### DIFF
--- a/bin/make-data.sh
+++ b/bin/make-data.sh
@@ -3,7 +3,10 @@ mkdir data
 pushd data
 for i in 1024 2048 4096 8192 1048576 2097152 16777216
 do
-   dd if=/dev/urandom of=$i bs=$i count=1 status=noxfer
+   dd if=/dev/urandom of=$i.bin bs=$i count=1 status=noxfer
+   od -x $i.bin >$i.txt
+   dd if=$i.txt of=$i bs=$i count=1 status=noxfer
+   rm $i.bin $i.txt
 done
 popd
 


### PR DESCRIPTION
Instead of creating binary files that seem to decode incorrectly in the benchmark (due to mime-type issues, AFAICT), make text files instead.

The script starts with the same binary files, then hex-dumps that, and then pulls the appropriate amount of data out of the hex dump.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/189)

<!-- Reviewable:end -->
