### PR TITLE
Don't emit invalid Net.Endpoints in Tcp.ConnectionInfo on a closed connection

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -192,6 +192,7 @@ module.exports = (grunt) ->
     ts:
       # SOCKS.
       tcp: Rule.typescriptSrc 'tcp'
+      tcpSpecDecl: Rule.typescriptSpecDecl 'tcp'
 
       udp: Rule.typescriptSrc 'udp'
 
@@ -351,6 +352,23 @@ module.exports = (grunt) ->
               type: 'html'
               options:
                 dir: 'build/coverage/rtcToNet'
+      tcp:
+        src: FILES.jasmine_helpers.concat([
+          'build/tcp/mocks.js'
+          'build/logging/logging.js'
+          'build/tcp/tcp.js'
+        ])
+        options:
+          specs: 'build/tcp/*.spec.js'
+          #outfile: 'build/rtc-to-net/SpecRunner.html'
+          #keepRunner: true
+          template: require('grunt-template-jasmine-istanbul')
+          templateOptions:
+            coverage: 'build/coverage/tcp/coverage.json'
+            report:
+              type: 'html'
+              options:
+                dir: 'build/coverage/tcp'
 
     jasmine_chromeapp:
       base:
@@ -432,6 +450,7 @@ module.exports = (grunt) ->
   taskManager.add 'tcp', [
     'base'
     'ts:tcp'
+    'ts:tcpSpecDecl'
     'copy:tcp'
   ]
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "request": "^2.44.0",
     "socks5-http-client": "^0.1.6",
     "typescript": "^1.1.0-1",
-    "uproxy-lib": "~19.0.0",
+    "uproxy-lib": "~19.1.0",
     "utransformers": "~0.2.1",
     "wup": "^1.0.0",
     "yargs": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/tcp/mocks.js
+++ b/src/tcp/mocks.js
@@ -1,0 +1,12 @@
+// Create a mock instance of Freedom.
+// We do this in a non-TypeScript file because the ambient module declaration
+// prevents us creating any variable called freedom in TypeScript-land.
+var freedom = {
+  core: function() {
+    return {
+      'getLogger': function() {
+        return jasmine.createSpyObj('logger', ['then']);
+      }
+    };
+  }
+};

--- a/src/tcp/tcp.d.ts
+++ b/src/tcp/tcp.d.ts
@@ -61,8 +61,8 @@ declare module Tcp {
   }
 
   interface ConnectionInfo {
-    bound: Net.Endpoint;
-    remote: Net.Endpoint;
+    bound?: Net.Endpoint;
+    remote?: Net.Endpoint;
   }
 
   // Wraps up a single TCP connection to a client
@@ -113,4 +113,8 @@ declare module Tcp {
       CLOSED // Cannot change state.
     }
   }
+
+  // Private function, exported only for unit tests.
+  function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
+      : ConnectionInfo;
 }

--- a/src/tcp/tcp.spec.ts
+++ b/src/tcp/tcp.spec.ts
@@ -1,0 +1,37 @@
+/// <reference path='tcp.d.ts' />
+/// <reference path='../third_party/typings/jasmine/jasmine.d.ts' />
+
+describe('Tcp', function() {
+  it('conversion of a connected endpoint info', () => {
+    var input :freedom_TcpSocket.SocketInfo = {
+      localAddress: '127.0.0.1',
+      localPort: 1234,
+      peerAddress: '192.0.2.111',
+      peerPort: 1023,
+      connected: true
+    };
+
+    var output :Tcp.ConnectionInfo = {
+      bound: {
+        address: '127.0.0.1',
+        port: 1234
+      },
+      remote: {
+        address: '192.0.2.111',
+        port: 1023
+      }
+    };
+
+    expect(Tcp.endpointOfSocketInfo(input)).toEqual(output);
+  });
+
+  it('conversion of a closed endpoint info', () => {
+    var input :freedom_TcpSocket.SocketInfo = {
+      connected: false
+    };
+
+    var output :Tcp.ConnectionInfo = {};
+
+    expect(Tcp.endpointOfSocketInfo(input)).toEqual(output);
+  });
+});

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -21,26 +21,33 @@ module Tcp {
   }
 
   export interface ConnectionInfo {
-    bound: Net.Endpoint;
-    remote: Net.Endpoint;
+    bound?: Net.Endpoint;
+    remote?: Net.Endpoint;
   }
 
   // A limit on the max number of TCP connections before we start rejecting
   // new ones.
   var DEFAULT_MAX_CONNECTIONS = 1048576;
 
-  function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
+  // Private function, exported only for unit tests
+  export function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
       : ConnectionInfo {
-     return {
-       bound: {
-         address: info.localAddress,
-         port: info.localPort
-       },
-       remote: {
-         address: info.peerAddress,
-         port: info.peerPort
-       }
-     };
+    var retval :ConnectionInfo = {};
+    if (typeof info.localAddress == 'string' &&
+        typeof info.localPort == 'number') {
+      retval.bound = {
+        address: info.localAddress,
+        port: info.localPort
+      };
+    }
+    if (typeof info.peerAddress == 'string' &&
+        typeof info.peerPort == 'number') {
+      retval.remote = {
+        address: info.peerAddress,
+        port: info.peerPort
+      };
+    }
+    return retval;
   }
 
   // A static helper function to close a freedom socket object and then


### PR DESCRIPTION
Resolves https://github.com/uProxy/uproxy/issues/909

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/196)

<!-- Reviewable:end -->
