### PR TITLE
some cleanup of RtcToNet logging

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -339,6 +339,7 @@ module.exports = (grunt) ->
           'build/handler/queue.js'
           'build/logging/logging.js'
           'build/webrtc/*.js'
+          'build/tcp/tcp.js'
           'build/rtc-to-net/rtc-to-net.js'
         ])
         options:

--- a/src/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/rtc-to-net/rtc-to-net.spec.ts
@@ -102,7 +102,8 @@ describe("RtcToNet session", function() {
     mockDataChannel = <any>{
       closeDataChannel: noopPromise,
       onceClosed: noopPromise,
-      close: jasmine.createSpy('close')
+      close: jasmine.createSpy('close'),
+      getLabel: jasmine.createSpy('getLabel')
     };
     mockBytesReceived = jasmine.createSpyObj('bytes received handler', [
         'handle'
@@ -158,7 +159,7 @@ describe("RtcToNet session", function() {
     spyOn(session, 'getTcpConnection_').and.returnValue(Promise.resolve(mockTcpConnection));
 
     mockTcpConnection.onceConnected = Promise.resolve(mockConnectionInfo);
-    mockTcpConnection.onceClosed = Promise.resolve();
+    mockTcpConnection.onceClosed = Promise.resolve(Tcp.SocketCloseKind.WE_CLOSED_IT);
 
     session.start().then(session.onceStopped).then(done);
   });

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -257,8 +257,9 @@ module RtcToNet {
           return this.tcpConnection_.onceConnected;
         })
         .then((info:Tcp.ConnectionInfo) => {
-          log.debug('%1: connected to remote endpoint from local endpoint %2', [
-              this.longId(), JSON.stringify(info.bound)]);
+          log.debug('%1: connected to remote endpoint', [this.longId()]);
+          log.debug('%1: bound address: %2', [this.longId(),
+              JSON.stringify(info.bound)]);
           var reply = this.getReplyFromInfo_(info);
           this.replyToPeer_(reply, info);
         }, (e:any) => {

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -431,8 +431,18 @@ module RtcToNet {
         this.bytesReceivedFromPeer_.handle(data.buffer.byteLength);
         this.tcpConnection_.send(data.buffer)
         .catch((e:Error) => {
-          log.error('%1: failed to send data on socket: %2', [
-              this.longId(), e.message]);
+          // TODO: e is actually a freedom.Error (uproxy-lib 20+)
+          // errcode values are defined here:
+          //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json
+          if (e.errcode === 'NOT_CONNECTED') {
+            // This can happen if, for example, there was still data to be
+            // read on the datachannel's queue when the socket closed.
+            log.warn('%1: tried to send data on closed socket: %2', [
+                this.longId(), e.errcode]);
+          } else {
+            log.error('%1: failed to send data on socket: %2', [
+                this.longId(), e.errcode]);
+          }
         });
       });
     }

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -120,7 +120,12 @@ module RtcToNet {
       this.onceReady = this.peerConnection_.onceConnected.then(() => {});
       this.onceReady.catch(this.fulfillStopping_);
       this.peerConnection_.onceDisconnected
-          .then(this.fulfillStopping_, this.fulfillStopping_);
+        .then(() => {
+          log.debug('peerconnection terminated');
+        }, (e:Error) => {
+          log.error('peerconnection terminated with error: %1', [e.message]);
+        })
+        .then(this.fulfillStopping_, this.fulfillStopping_);
       this.onceClosed = this.onceStopping_.then(this.stopResources_);
 
       return this.onceReady;
@@ -128,7 +133,7 @@ module RtcToNet {
 
     private onPeerOpenedChannel_ = (channel:WebRtc.DataChannel) => {
       var channelLabel = channel.getLabel();
-      log.debug('creating new session for channel ' + channelLabel);
+      log.info('created new session %1', [channelLabel]);
 
       var session = new Session(
           channel,
@@ -136,15 +141,19 @@ module RtcToNet {
           this.bytesReceivedFromPeer,
           this.bytesSentToPeer);
       this.sessions_[channelLabel] = session;
-      session.start();
+      session.start().catch((e:Error) => {
+        log.warn('session %1 failed to connect to remote endpoint: %2', [
+            channelLabel, e.message]);
+      });
 
       var discard = () => {
         delete this.sessions_[channelLabel];
-        log.debug('discarded session ' + channelLabel + ' (' +
-            Object.keys(this.sessions_).length + ' sessions remaining)');
-      };
+        log.info('discarded session %1 (%2 remaining)', [
+            channelLabel, Object.keys(this.sessions_).length]);
+        };
       session.onceStopped().then(discard, (e:Error) => {
-        log.error('session ' + channelLabel + ' closed with error: ' + e.message);
+        log.info('discarded session %1 (%2 remaining)', [
+            channelLabel, Object.keys(this.sessions_).length]);
         discard();
       });
     }
@@ -153,6 +162,7 @@ module RtcToNet {
     // Returns onceClosed.
     // TODO: rename stop, ala SocksToRtc (API breakage).
     public close = () : Promise<void> => {
+      log.debug('stop requested');
       this.fulfillStopping_();
       return this.onceClosed;
     }
@@ -161,6 +171,7 @@ module RtcToNet {
     // Since its close() method should never throw, this should never reject.
     // TODO: close all sessions before fulfilling
     private stopResources_ = () : Promise<void> => {
+      log.debug('freeing resources');
       return new Promise<void>((F, R) => { this.peerConnection_.close(); F(); });
     }
 
@@ -233,10 +244,21 @@ module RtcToNet {
         }).then((tcpConnection:Tcp.Connection) => {
           this.tcpConnection_ = tcpConnection;
           // Shutdown once the TCP connection terminates.
-          this.tcpConnection_.onceClosed.then(this.fulfillStopping_);
+          this.tcpConnection_.onceClosed.then((kind:Tcp.SocketCloseKind) => {
+            if (kind === Tcp.SocketCloseKind.UNKOWN) {
+              log.error('%1: socket closed for unrecognized reason', [
+                  this.longId()]);
+            } else {
+              log.debug('%1: socket closed (%2)', [
+                  this.longId(), Tcp.SocketCloseKind[kind] || 'unknown reason']);
+            }
+          })
+          .then(this.fulfillStopping_);
           return this.tcpConnection_.onceConnected;
         })
         .then((info:Tcp.ConnectionInfo) => {
+          log.debug('%1: connected to remote endpoint from local endpoint %2', [
+              this.longId(), JSON.stringify(info.bound)]);
           var reply = this.getReplyFromInfo_(info);
           this.replyToPeer_(reply, info);
         }, (e:any) => {
@@ -252,7 +274,13 @@ module RtcToNet {
       this.onceReady.then(this.linkTcpAndPeerConnectionData_);
 
       this.onceReady.catch(this.fulfillStopping_);
-      this.dataChannel_.onceClosed.then(this.fulfillStopping_);
+
+      this.dataChannel_.onceClosed
+      .then(() => {
+        log.debug('%1: datachannel closed', [this.longId()]);
+      })
+      .then(this.fulfillStopping_);
+
       this.onceStopped_ = this.onceStopping_.then(this.stopResources_);
 
       return this.onceReady;
@@ -261,6 +289,7 @@ module RtcToNet {
     // Initiates shutdown of the TCP connection and peerconnection.
     // Returns onceStopped.
     public stop = () : Promise<void> => {
+      log.debug('%1: stop requested', [this.longId()]);
       this.fulfillStopping_();
       return this.onceStopped_;
     }
@@ -269,6 +298,7 @@ module RtcToNet {
     // closed, fulfilling once both have closed. Since neither object's
     // close() methods should ever reject, this should never reject.
     private stopResources_ = () : Promise<void> => {
+      log.debug('%1: freeing resources', [this.longId()]);
       // DataChannel.close() returns void, implying that the shutdown is
       // effectively immediate.  However, we wrap it in a promise to ensure
       // that any exception is sent to the Promise.catch, rather than
@@ -290,13 +320,15 @@ module RtcToNet {
       return new Promise((F,R) => {
         this.dataChannel_.dataFromPeerQueue.setSyncNextHandler((data:WebRtc.Data) => {
           if (!data.str) {
-            R(new Error('endpoint message must be a str'));
+            R(new Error('received non-string data from peer: ' +
+                JSON.stringify(data)));
             return;
           }
           try {
             var r :any = JSON.parse(data.str);
             if (!Socks.isValidRequest(r)) {
-              R(new Error('invalid request: ' + data.str));
+              R(new Error('received invalid request from peer: ' +
+                  JSON.stringify(data.str)));
               return;
             }
             var request :Socks.Request = r;
@@ -304,10 +336,13 @@ module RtcToNet {
               R(new Error('unexpected type for endpoint message'));
               return;
             }
+            log.debug('%1: received endpoint from peer: %2', [
+                this.longId(), JSON.stringify(request.endpoint)]);
             F(request.endpoint);
             return;
           } catch (e) {
-            R(new Error('could not parse requested endpoint: ' + e.message));
+            R(new Error('received malformed message during handshake: ' +
+                data.str));
             return;
           }
         });
@@ -318,7 +353,7 @@ module RtcToNet {
       if (ipaddr.isValid(endpoint.address) &&
           !this.isAllowedAddress_(endpoint.address)) {
         this.replyToPeer_(Socks.Reply.NOT_ALLOWED);
-        throw new Error('Tried to connect to disallowed address: ' +
+        throw new Error('tried to connect to disallowed address: ' +
                         endpoint.address);
       }
       return new Tcp.Connection({endpoint: endpoint});
@@ -374,25 +409,31 @@ module RtcToNet {
     // have completed.
     private linkTcpAndPeerConnectionData_ = () : void => {
       // Data from the TCP socket goes to the data channel.
-      this.tcpConnection_.dataFromSocketQueue.setSyncHandler((buffer) => {
-        log.debug(this.longId() + ': passing on data from tcp connection to pc (' +
-            buffer.byteLength + ' bytes)');
-        this.dataChannel_.send({buffer: buffer})
-          .catch((e:Error) => {
-            log.error('error forwarding received TCP data to peerconnection: ' + e.message);
-          });
-        this.bytesSentToPeer_.handle(buffer.byteLength);
+      this.tcpConnection_.dataFromSocketQueue.setSyncHandler((data) => {
+        log.debug('%1: socket received %2 bytes', [
+            this.longId(), data.byteLength]);
+        this.dataChannel_.send({buffer: data})
+        .catch((e:Error) => {
+          log.error('%1: failed to send data on datachannel: %2', [
+              this.longId(), e.message]);
+        });
+        this.bytesSentToPeer_.handle(data.byteLength);
       });
       // Data from the datachannel goes to the TCP socket.
       this.dataChannel_.dataFromPeerQueue.setSyncHandler((data:WebRtc.Data) => {
         if (!data.buffer) {
-          log.error(this.longId() + ': dataFromPeer: ' +
-              'got non-buffer data: ' + JSON.stringify(data));
+          log.error('%1: received non-buffer data from datachannel', [
+              this.longId()]);
           return;
         }
-        log.debug(this.longId() + ': dataFromPeer: ' + data.buffer.byteLength + ' bytes.');
+        log.debug('%1: datachannel received %2 bytes', [
+            this.longId(), data.buffer.byteLength]);
         this.bytesReceivedFromPeer_.handle(data.buffer.byteLength);
-        this.tcpConnection_.send(data.buffer);
+        this.tcpConnection_.send(data.buffer)
+        .catch((e:Error) => {
+          log.error('%1: failed to send data on socket: %2', [
+              this.longId(), e.message]);
+        });
       });
     }
 
@@ -417,8 +458,12 @@ module RtcToNet {
     }
 
     public longId = () : string => {
-      return 'session ' + this.channelLabel() + ' (TCP connection ' +
-          (this.tcpConnection_.isClosed() ? 'closed' : 'open') + ') ';
+      var s = 'session ' + this.channelLabel();
+      if (this.tcpConnection_) {
+        s += ' (TCP ' + (this.tcpConnection_.isClosed() ?
+            'closed' : 'open') + ')';
+      }
+      return s;
     }
 
     // For logging/debugging.

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -57,28 +57,30 @@ var giverBytesSent :number = 0;
 
 rtcNet.signalsForPeer.setSyncHandler(socksRtc.handleSignalFromPeer);
 
+// TODO: Re-enable received/sent messages when per-component logging is fixed:
+//         https://github.com/uProxy/uproxy/issues/906
 socksRtc.on('bytesReceivedFromPeer', (numBytes:number) => {
   getterBytesReceived += numBytes;
-  log.debug('Getter received ' + numBytes + ' bytes. (Total received: '
-    + getterBytesReceived + ' bytes)');
+  // log.debug('Getter received ' + numBytes + ' bytes. (Total received: '
+  //   + getterBytesReceived + ' bytes)');
 });
 
 socksRtc.on('bytesSentToPeer', (numBytes:number) => {
   getterBytesSent += numBytes;
-  log.debug('Getter sent ' + numBytes + ' bytes. (Total sent: '
-    + getterBytesSent + ' bytes)');
+  // log.debug('Getter sent ' + numBytes + ' bytes. (Total sent: '
+  //   + getterBytesSent + ' bytes)');
 });
 
 rtcNet.bytesReceivedFromPeer.setSyncHandler((numBytes:number) => {
   giverBytesReceived += numBytes;
-  log.debug('Giver received ' + numBytes + ' bytes. (Total received: '
-    + giverBytesReceived + ' bytes)');
+  // log.debug('Giver received ' + numBytes + ' bytes. (Total received: '
+  //   + giverBytesReceived + ' bytes)');
 });
 
 rtcNet.bytesSentToPeer.setSyncHandler((numBytes:number) => {
   giverBytesSent += numBytes;
-  log.debug('Giver sent ' + numBytes + ' bytes. (Total sent: '
-    + giverBytesSent + ' bytes)');
+  // log.debug('Giver sent ' + numBytes + ' bytes. (Total sent: '
+  //   + giverBytesSent + ' bytes)');
 });
 
 rtcNet.onceReady

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -320,10 +320,10 @@ module SocksToRtc {
       Promise.race<any>([
           tcpConnection.onceClosed.then((kind:Tcp.SocketCloseKind) => {
             if (kind === Tcp.SocketCloseKind.UNKOWN) {
-              log.error('%1: client socket closed for unrecognized reason', [
+              log.error('%1: socket closed for unrecognized reason', [
                   this.longId()]);
             } else {
-              log.debug('%1: client socket closed (%2)', [
+              log.debug('%1: socket closed (%2)', [
                   this.longId(), Tcp.SocketCloseKind[kind] || 'unknown reason']);
             }
           }),
@@ -441,7 +441,7 @@ module SocksToRtc {
       // Any further data just goes to the target site.
       this.tcpConnection_.dataFromSocketQueue.setSyncHandler(
           (data:ArrayBuffer) => {
-        log.debug('%1: client socket received %2 bytes', [
+        log.debug('%1: socket received %2 bytes', [
             this.longId(), data.byteLength]);
         this.dataChannel_.send({ buffer: data })
         .catch((e:Error) => {
@@ -468,10 +468,10 @@ module SocksToRtc {
           if (e.errcode === 'NOT_CONNECTED') {
             // This can happen if, for example, there was still data to be
             // read on the datachannel's queue when the socket closed.
-            log.warn('%1: tried to send data on closed client socket: %2', [
+            log.warn('%1: tried to send data on closed socket: %2', [
                 this.longId(), e.errcode]);
           } else {
-            log.error('%1: failed to send data on client socket: %2', [
+            log.error('%1: failed to send data on socket: %2', [
                 this.longId(), e.errcode]);            
           }
         });


### PR DESCRIPTION
Basically, bring `RtcToNet`'s logging up to scratch with `SocksToRtc`; largely, that means copying across the changes from these two pull requests:
1. https://github.com/uProxy/uproxy-networking/pull/164
2. https://github.com/uProxy/uproxy-networking/pull/197

Now, `RtcToNet` logging for fetching www.example.com looks like this:

```
RtcToNet I [1/17 15:4:23.249] created new session c0
RtcToNet D [1/17 15:4:23.256] session c0: received endpoint from peer: {"address":"2606:2800:220:1:248:1893:25c8:1946","port":80}
RtcToNet D [1/17 15:4:23.262] session c0 (TCP open): connected to remote endpoint
RtcToNet D [1/17 15:4:23.263] session c0 (TCP open): bound address: {"address":"2620:0:1003:1003:807c:c98e:f5cd:c8fd","port":50796}
RtcToNet D [1/17 15:4:23.274] session c0 (TCP open): datachannel received 79 bytes
RtcToNet D [1/17 15:4:23.277] session c0 (TCP open): socket received 1591 bytes
RtcToNet D [1/17 15:4:23.290] session c0 (TCP open): datachannel closed
RtcToNet D [1/17 15:4:23.290] session c0 (TCP open): freeing resources
RtcToNet D [1/17 15:4:23.291] session c0 (TCP closed): socket closed (WE_CLOSED_IT)
RtcToNet I [1/17 15:4:23.291] discarded session c0 (0 remaining)
```

For Simple SOCKS, you'll see combined `SocksToRtc`/`RtcToNet` logging:

```
SocksToRtc I [1/17 15:4:23.239] created new session c0 for new SOCKS client
SocksToRtc D [1/17 15:4:23.245] opened datachannel for session c0
RtcToNet I [1/17 15:4:23.249] created new session c0
SocksToRtc D [1/17 15:4:23.253] session c0 (TCP open): received endpoint from SOCKS client: {"address":"2606:2800:220:1:248:1893:25c8:1946","port":80}
RtcToNet D [1/17 15:4:23.256] session c0: received endpoint from peer: {"address":"2606:2800:220:1:248:1893:25c8:1946","port":80}
RtcToNet D [1/17 15:4:23.262] session c0 (TCP open): connected to remote endpoint
RtcToNet D [1/17 15:4:23.263] session c0 (TCP open): bound address: {"address":"2620:0:1003:1003:807c:c98e:f5cd:c8fd","port":50796}
SocksToRtc D [1/17 15:4:23.267] session c0 (TCP open): connected to remote host
SocksToRtc D [1/17 15:4:23.267] session c0 (TCP open): remote peer bound address: {"address":"2620:0:1003:1003:807c:c98e:f5cd:c8fd","port":50796}
SocksToRtc D [1/17 15:4:23.272] session c0 (TCP open): socket received 79 bytes
RtcToNet D [1/17 15:4:23.274] session c0 (TCP open): datachannel received 79 bytes
RtcToNet D [1/17 15:4:23.277] session c0 (TCP open): socket received 1591 bytes
SocksToRtc D [1/17 15:4:23.279] session c0 (TCP open): datachannel received 1591 bytes
SocksToRtc D [1/17 15:4:23.283] session c0 (TCP closed): socket closed (REMOTELY_CLOSED)
SocksToRtc D [1/17 15:4:23.283] session c0 (TCP closed): freeing resources
SocksToRtc I [1/17 15:4:23.284] discarded session c0 (0 remaining)
SocksToRtc D [1/17 15:4:23.290] session c0 (TCP closed): datachannel closed
RtcToNet D [1/17 15:4:23.290] session c0 (TCP open): datachannel closed
RtcToNet D [1/17 15:4:23.290] session c0 (TCP open): freeing resources
RtcToNet D [1/17 15:4:23.291] session c0 (TCP closed): socket closed (WE_CLOSED_IT)
RtcToNet I [1/17 15:4:23.291] discarded session c0 (0 remaining)
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/198)

<!-- Reviewable:end -->
