### PR TITLE
more verbose INFO logging

### DIFF
--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -133,7 +133,7 @@ module RtcToNet {
 
     private onPeerOpenedChannel_ = (channel:WebRtc.DataChannel) => {
       var channelLabel = channel.getLabel();
-      log.info('created new session %1', [channelLabel]);
+      log.info('associating session %1 with new datachannel', [channelLabel]);
 
       var session = new Session(
           channel,
@@ -249,7 +249,7 @@ module RtcToNet {
               log.error('%1: socket closed for unrecognized reason', [
                   this.longId()]);
             } else {
-              log.debug('%1: socket closed (%2)', [
+              log.info('%1: socket closed (%2)', [
                   this.longId(), Tcp.SocketCloseKind[kind] || 'unknown reason']);
             }
           })
@@ -257,7 +257,7 @@ module RtcToNet {
           return this.tcpConnection_.onceConnected;
         })
         .then((info:Tcp.ConnectionInfo) => {
-          log.debug('%1: connected to remote endpoint', [this.longId()]);
+          log.info('%1: connected to remote endpoint', [this.longId()]);
           log.debug('%1: bound address: %2', [this.longId(),
               JSON.stringify(info.bound)]);
           var reply = this.getReplyFromInfo_(info);
@@ -278,7 +278,7 @@ module RtcToNet {
 
       this.dataChannel_.onceClosed
       .then(() => {
-        log.debug('%1: datachannel closed', [this.longId()]);
+        log.info('%1: datachannel closed', [this.longId()]);
       })
       .then(this.fulfillStopping_);
 
@@ -337,7 +337,7 @@ module RtcToNet {
               R(new Error('unexpected type for endpoint message'));
               return;
             }
-            log.debug('%1: received endpoint from peer: %2', [
+            log.info('%1: received endpoint from peer: %2', [
                 this.longId(), JSON.stringify(request.endpoint)]);
             F(request.endpoint);
             return;

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -10,10 +10,7 @@
 // you're debugging. Since the proxy outputs quite a lot of messages,
 // show only warnings by default from the rest of the system.
 // Note that the proxy is extremely slow in debug (D) mode.
-freedom['loggingprovider']().setConsoleFilter([
-    '*:I',
-    'SocksToRtc:I',
-    'RtcToNet:I']);
+freedom['loggingprovider']().setConsoleFilter(['*:I']);
 
 var log :Logging.Log = new Logging.Log('simple-socks');
 

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -150,14 +150,14 @@ module SocksToRtc {
       onceReady.catch(this.fulfillStopping_);
       this.tcpServer_.onceShutdown()
         .then(() => {
-          log.debug('server socket closed');
+          log.info('server socket closed');
         }, (e:Error) => {
           log.error('server socket closed with error: %1', [e.message]);
         })
         .then(this.fulfillStopping_);
       this.peerConnection_.onceDisconnected
         .then(() => {
-          log.debug('peerconnection terminated');
+          log.info('peerconnection terminated');
         }, (e:Error) => {
           log.error('peerconnection terminated with error: %1', [e.message]);
         })
@@ -174,7 +174,7 @@ module SocksToRtc {
     // Initiates shutdown of the TCP server and peerconnection.
     // Returns onceStopped.
     public stop = () : Promise<void> => {
-      log.debug('stop requested');
+      log.info('stop requested');
       this.fulfillStopping_();
       return this.onceStopped_;
     }
@@ -214,10 +214,10 @@ module SocksToRtc {
     // Note that Session closes the TCP connection and datachannel on any error.
     private makeTcpToRtcSession_ = (tcpConnection:Tcp.Connection) : void => {
       var tag = obtainTag();
-      log.info('created new session %1 for new SOCKS client', [tag]);
+      log.info('associating session %1 with new TCP connection', [tag]);
 
 	    this.peerConnection_.openDataChannel(tag).then((channel:WebRtc.DataChannel) => {
-        log.debug('opened datachannel for session %1', [tag]);
+        log.info('opened datachannel for session %1', [tag]);
         var session = new Session();
         session.start(
             tcpConnection,
@@ -321,12 +321,12 @@ module SocksToRtc {
               log.error('%1: socket closed for unrecognized reason', [
                   this.longId()]);
             } else {
-              log.debug('%1: socket closed (%2)', [
+              log.info('%1: socket closed (%2)', [
                   this.longId(), Tcp.SocketCloseKind[kind] || 'unknown reason']);
             }
           }),
           dataChannel.onceClosed.then(() => {
-            log.debug('%1: datachannel closed', [this.longId()]);
+            log.info('%1: datachannel closed', [this.longId()]);
           })])
         .then(this.fulfillStopping_);
       this.onceStopped = this.onceStopping_.then(this.stopResources_);
@@ -405,7 +405,7 @@ module SocksToRtc {
               R(new Error('invalid response:' + data.str));
               return;
             }
-            log.debug('%1: connected to remote host', [this.longId()]);
+            log.info('%1: connected to remote host', [this.longId()]);
             log.debug('%1: remote peer bound address: %2', [
                 this.longId(), JSON.stringify(r.endpoint)]);
             F(r);
@@ -424,7 +424,7 @@ module SocksToRtc {
       return this.tcpConnection_.receiveNext()
         .then(Socks.interpretRequestBuffer)
         .then((request:Socks.Request) => {
-          log.debug('%1: received endpoint from SOCKS client: %2', [
+          log.info('%1: received endpoint from SOCKS client: %2', [
               this.longId(), JSON.stringify(request.endpoint)]);
           this.dataChannel_.send({ str: JSON.stringify(request) });
           return this.receiveResponseFromPeer_();


### PR DESCRIPTION
So, this is to help us get more useful bug reporting from the uProxy frontend.

Example output:

```
SocksToRtc I [1/18 12:10:11.524] associating session c292 with new TCP connection
SocksToRtc I [1/18 12:10:11.527] opened datachannel for session c292
SocksToRtc I [1/18 12:10:11.532] session c292 (TCP open): received endpoint from SOCKS client: {"address":"www.example.com","port":80}
RtcToNet I [1/18 12:10:11.532] associating session c292 with new datachannel
RtcToNet I [1/18 12:10:11.536] session c292: received endpoint from peer: {"address":"www.example.com","port":80}
RtcToNet I [1/18 12:10:11.544] session c292 (TCP open): connected to remote endpoint
SocksToRtc I [1/18 12:10:11.546] session c292 (TCP open): connected to remote host
SocksToRtc I [1/18 12:10:11.559] session c292 (TCP closed): socket closed (REMOTELY_CLOSED)
SocksToRtc I [1/18 12:10:11.560] discarded session c292 (0 remaining)
SocksToRtc I [1/18 12:10:11.565] session c292 (TCP closed): datachannel closed
RtcToNet I [1/18 12:10:11.565] session c292 (TCP open): datachannel closed
RtcToNet I [1/18 12:10:11.566] session c292 (TCP closed): socket closed (WE_CLOSED_IT)
RtcToNet I [1/18 12:10:11.566] discarded session c292 (0 remaining)
```

Easy to filter on particular session; easy to identify lifecycle issues/missing events.

Only DEBUG outputs for every packet sent and received; the proxy should be perfectly usable at INFO level.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/199)

<!-- Reviewable:end -->
