### PR TITLE
instrumentation for RtcToNet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "5.2.6",
+  "version": "5.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -69,6 +69,7 @@ declare module RtcToNet {
     public onceClosed :Promise<void>;
     public close :() => void;
     public handleSignalFromPeer :(signal:WebRtc.SignallingMessage) => void;
+    public initiateSnapshotting :() => void;
     public toString :() => string;
   }
   class Session {

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -25,8 +25,6 @@ declare module RtcToNet {
     bytesSent :number;
     // Total number of bytes received since the connection was created.
     bytesReceived :number;
-    // True iff the socket is paused right now.
-    paused :boolean;
     // Data received from the peer.
     dataIn :HandlerQueueSnapshot;
   }

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -15,29 +15,29 @@ declare module RtcToNet {
   // for later analysis.
   interface HandlerQueueSnapshot {
     // Number of objects waiting to be handled right now.
-    length :number;
+    size :number;
     // True iff there is a handler attached right now.
     handling :boolean;
   }
 
   interface SocketSnapshot {
     // Total number of bytes sent since the connection was created.
-    bytesSent :number;
+    sent :number;
     // Total number of bytes received since the connection was created.
-    bytesReceived :number;
+    received :number;
     // Data received from the peer.
-    dataIn :HandlerQueueSnapshot;
+    queue :HandlerQueueSnapshot;
   }
 
   interface DataChannelSnapshot {
     // Total number of bytes sent since the channel was created.
-    bytesSent :number;
+    sent :number;
     // Total number of bytes received since the channel was created.
-    bytesReceived :number;
+    received :number;
     // Number of bytes sitting in the buffer right now.
-    bytesBuffered :number;
+    buffered :number;
     // Data received from the peer.
-    dataIn :HandlerQueueSnapshot;
+    queue :HandlerQueueSnapshot;
   }
 
   interface SessionSnapshot {

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -89,6 +89,6 @@ declare module RtcToNet {
     public channelLabel :() => string;
     public longId :() => string;
     public toString :() => string;
-    public getSnapshot :() => SessionSnapshot;
+    public getSnapshot :() => Promise<SessionSnapshot>;
   }
 }

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -9,6 +9,57 @@ declare module RtcToNet {
   interface ProxyConfig {
     allowNonUnicast :boolean;
   }
+
+  // Type checking for snapshots.
+  // Snapshots are spewed out every couple of seconds in DEBUG mode
+  // for later analysis.
+  interface HandlerQueueSnapshot {
+    // Number of objects waiting to be handled right now.
+    length :number;
+    // True iff there is a handler attached right now.
+    handling :boolean;
+  }
+
+  interface SocketSnapshot {
+    // Total number of bytes sent since the connection was created.
+    bytesSent :number;
+    // Total number of bytes received since the connection was created.
+    bytesReceived :number;
+    // True iff the socket is paused right now.
+    paused :boolean;
+    // Data received from the peer.
+    dataIn :HandlerQueueSnapshot;
+    // Data to be sent to the peer.
+    dataOut :HandlerQueueSnapshot;
+  }
+
+  interface DataChannelSnapshot {
+    // Total number of bytes sent since the channel was created.
+    bytesSent :number;
+    // Total number of bytes received since the channel was created.
+    bytesReceived :number;
+    // Number of bytes sitting in the buffer right now.
+    bytesBuffered :number;
+    // Data received from the peer.
+    dataIn :HandlerQueueSnapshot;
+    // Data to be sent to the peer.
+    dataOut :HandlerQueueSnapshot;
+  }
+
+  interface SessionSnapshot {
+    // Name of this session, e.g. c0 or c221.
+    name :string;
+    // Data channel associated with this session.
+    channel :DataChannelSnapshot;
+    // TCP connection associated with this session.
+    socket :SocketSnapshot;
+  }
+
+  interface RtcToNetSnapshot {
+    // All sessions open right now.
+    sessions :SessionSnapshot[];
+  }
+
   class RtcToNet {
     constructor(pcConfig?:freedom_RTCPeerConnection.RTCConfiguration,
                 proxyConfig?:ProxyConfig,
@@ -44,5 +95,6 @@ declare module RtcToNet {
     public channelLabel :() => string;
     public longId :() => string;
     public toString :() => string;
+    public getSnapshot :() => SessionSnapshot;
   }
 }

--- a/src/rtc-to-net/rtc-to-net.d.ts
+++ b/src/rtc-to-net/rtc-to-net.d.ts
@@ -29,8 +29,6 @@ declare module RtcToNet {
     paused :boolean;
     // Data received from the peer.
     dataIn :HandlerQueueSnapshot;
-    // Data to be sent to the peer.
-    dataOut :HandlerQueueSnapshot;
   }
 
   interface DataChannelSnapshot {
@@ -42,8 +40,6 @@ declare module RtcToNet {
     bytesBuffered :number;
     // Data received from the peer.
     dataIn :HandlerQueueSnapshot;
-    // Data to be sent to the peer.
-    dataOut :HandlerQueueSnapshot;
   }
 
   interface SessionSnapshot {

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -174,7 +174,7 @@ module RtcToNet {
         loop = false;
       });
       var writeSnapshot = () => {
-        log.debug('snapshot: %1', [JSON.stringify(this.getSnapshot())]);
+        log.info('snapshot: %1', [JSON.stringify(this.getSnapshot())]);
         if (loop) {
           setTimeout(writeSnapshot, RtcToNet.SNAPSHOTTING_INTERVAL_MS);
         }

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -160,13 +160,13 @@ module RtcToNet {
       this.onceClosed = this.onceStopping_.then(this.stopResources_);
 
       // Uncomment this to see instrumentation data in the console.
-      // this.onceReady.then(this.initiateSnapshotting_);
+      // this.onceReady.then(this.initiateSnapshotting);
 
       return this.onceReady;
     }
 
     // Loops until onceClosed fulfills.
-    private initiateSnapshotting_ = () => {
+    public initiateSnapshotting = () => {
       var loop = true;
       this.onceClosed.then(() => {
         loop = false;

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -159,7 +159,8 @@ module RtcToNet {
         .then(this.fulfillStopping_, this.fulfillStopping_);
       this.onceClosed = this.onceStopping_.then(this.stopResources_);
 
-      this.onceReady.then(this.initiateSnapshotting_);
+      // Uncomment this to see instrumentation data in the console.
+      // this.onceReady.then(this.initiateSnapshotting_);
 
       return this.onceReady;
     }

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -58,7 +58,7 @@ module RtcToNet {
   // proxied connections.
   export class RtcToNet {
     // Time between outputting snapshots.
-    private static SNAPSHOTTING_INTERVAL_MS = 1000;
+    private static SNAPSHOTTING_INTERVAL_MS = 5000;
 
     // Configuration for the proxy endpoint. Note: all sessions share the same
     // (externally provided) proxyconfig.

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -23,6 +23,52 @@ module RtcToNet {
     allowNonUnicast :boolean;
   }
 
+  // Type checking for snapshots.
+  // Snapshots are spewed out every couple of seconds in DEBUG mode
+  // for later analysis.
+  interface HandlerQueueSnapshot {
+    // Number of objects waiting to be handled right now.
+    length :number;
+    // True iff there is a handler attached right now.
+    handling :boolean;
+  }
+  interface SocketSnapshot {
+    // Total number of bytes sent since the connection was created.
+    bytesSent :number;
+    // Total number of bytes received since the connection was created.
+    bytesReceived :number;
+    // True iff the socket is paused right now.
+    paused :boolean;
+    // Data received from the peer.
+    dataIn :HandlerQueueSnapshot;
+    // Data to be sent to the peer.
+    dataOut :HandlerQueueSnapshot;
+  }
+  interface DataChannelSnapshot {
+    // Total number of bytes sent since the channel was created.
+    bytesSent :number;
+    // Total number of bytes received since the channel was created.
+    bytesReceived :number;
+    // Number of bytes sitting in the buffer right now.
+    bytesBuffered :number;
+    // Data received from the peer.
+    dataIn :HandlerQueueSnapshot;
+    // Data to be sent to the peer.
+    dataOut :HandlerQueueSnapshot;
+  }
+  interface SessionSnapshot {
+    // Name of this session, e.g. c0 or c221.
+    name :string;
+    // Data channel associated with this session.
+    channel :DataChannelSnapshot;
+    // TCP connection associated with this session.
+    socket :SocketSnapshot;
+  }
+  interface RtcToNetSnapshot {
+    // All sessions open right now.
+    sessions :SessionSnapshot[];
+  }
+
   // The |RtcToNet| class holds a peer-connection and all its associated
   // proxied connections.
   export class RtcToNet {

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -33,7 +33,6 @@ module RtcToNet {
     bytesReceived :number;
     paused :boolean;
     dataIn :HandlerQueueSnapshot;
-    dataOut :HandlerQueueSnapshot;
   }
 
   export interface DataChannelSnapshot {
@@ -41,7 +40,6 @@ module RtcToNet {
     bytesReceived :number;
     bytesBuffered :number;
     dataIn :HandlerQueueSnapshot;
-    dataOut :HandlerQueueSnapshot;
   }
 
   export interface SessionSnapshot {
@@ -538,12 +536,8 @@ module RtcToNet {
           bytesReceived: 1,
           bytesBuffered: 1,
           dataIn: {
-            length: 1,
-            handling: true
-          },
-          dataOut: {
-            length: 1,
-            handling: true
+            length: this.dataChannel_.dataFromPeerQueue.getLength(),
+            handling: this.dataChannel_.dataFromPeerQueue.isHandling()
           }
         },
         socket: {
@@ -551,12 +545,8 @@ module RtcToNet {
           bytesReceived: 1,
           paused: false,
           dataIn: {
-            length: 1,
-            handling: true
-          },
-          dataOut: {
-            length: 1,
-            handling: true
+            length: this.tcpConnection_.dataFromSocketQueue.getLength(),
+            handling: this.tcpConnection_.dataFromSocketQueue.isHandling()
           }
         }
       };

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -31,7 +31,6 @@ module RtcToNet {
   export interface SocketSnapshot {
     bytesSent :number;
     bytesReceived :number;
-    paused :boolean;
     dataIn :HandlerQueueSnapshot;
   }
 
@@ -554,7 +553,6 @@ module RtcToNet {
         socket: {
           bytesSent: this.socketSentBytes_,
           bytesReceived: this.socketReceivedBytes_,
-          paused: false,
           dataIn: {
             length: this.tcpConnection_.dataFromSocketQueue.getLength(),
             handling: this.tcpConnection_.dataFromSocketQueue.isHandling()

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -24,21 +24,21 @@ module RtcToNet {
   }
 
   export interface HandlerQueueSnapshot {
-    length :number;
+    size :number;
     handling :boolean;
   }
 
   export interface SocketSnapshot {
-    bytesSent :number;
-    bytesReceived :number;
-    dataIn :HandlerQueueSnapshot;
+    sent :number;
+    received :number;
+    queue :HandlerQueueSnapshot;
   }
 
   export interface DataChannelSnapshot {
-    bytesSent :number;
-    bytesReceived :number;
-    bytesBuffered :number;
-    dataIn :HandlerQueueSnapshot;
+    sent :number;
+    received :number;
+    buffered :number;
+    queue :HandlerQueueSnapshot;
   }
 
   export interface SessionSnapshot {
@@ -542,20 +542,20 @@ module RtcToNet {
       return {
         name: this.channelLabel(),
         channel: {
-          bytesSent: this.channelSentBytes_,
-          bytesReceived: this.channelReceivedBytes_,
+          sent: this.channelSentBytes_,
+          received: this.channelReceivedBytes_,
           // TODO: this is not currently exposed by datachannel.ts
-          bytesBuffered: 0,
-          dataIn: {
-            length: this.dataChannel_.dataFromPeerQueue.getLength(),
+          buffered: 0,
+          queue: {
+            size: this.dataChannel_.dataFromPeerQueue.getLength(),
             handling: this.dataChannel_.dataFromPeerQueue.isHandling()
           }
         },
         socket: {
-          bytesSent: this.socketSentBytes_,
-          bytesReceived: this.socketReceivedBytes_,
-          dataIn: {
-            length: this.tcpConnection_.dataFromSocketQueue.getLength(),
+          sent: this.socketSentBytes_,
+          received: this.socketReceivedBytes_,
+          queue: {
+            size: this.tcpConnection_.dataFromSocketQueue.getLength(),
             handling: this.tcpConnection_.dataFromSocketQueue.isHandling()
           }
         }

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -23,49 +23,34 @@ module RtcToNet {
     allowNonUnicast :boolean;
   }
 
-  // Type checking for snapshots.
-  // Snapshots are spewed out every couple of seconds in DEBUG mode
-  // for later analysis.
-  interface HandlerQueueSnapshot {
-    // Number of objects waiting to be handled right now.
+  export interface HandlerQueueSnapshot {
     length :number;
-    // True iff there is a handler attached right now.
     handling :boolean;
   }
-  interface SocketSnapshot {
-    // Total number of bytes sent since the connection was created.
+
+  export interface SocketSnapshot {
     bytesSent :number;
-    // Total number of bytes received since the connection was created.
     bytesReceived :number;
-    // True iff the socket is paused right now.
     paused :boolean;
-    // Data received from the peer.
     dataIn :HandlerQueueSnapshot;
-    // Data to be sent to the peer.
     dataOut :HandlerQueueSnapshot;
   }
-  interface DataChannelSnapshot {
-    // Total number of bytes sent since the channel was created.
+
+  export interface DataChannelSnapshot {
     bytesSent :number;
-    // Total number of bytes received since the channel was created.
     bytesReceived :number;
-    // Number of bytes sitting in the buffer right now.
     bytesBuffered :number;
-    // Data received from the peer.
     dataIn :HandlerQueueSnapshot;
-    // Data to be sent to the peer.
     dataOut :HandlerQueueSnapshot;
   }
-  interface SessionSnapshot {
-    // Name of this session, e.g. c0 or c221.
+
+  export interface SessionSnapshot {
     name :string;
-    // Data channel associated with this session.
     channel :DataChannelSnapshot;
-    // TCP connection associated with this session.
     socket :SocketSnapshot;
   }
-  interface RtcToNetSnapshot {
-    // All sessions open right now.
+
+  export interface RtcToNetSnapshot {
     sessions :SessionSnapshot[];
   }
 
@@ -199,8 +184,12 @@ module RtcToNet {
 
     // Snapshots the state of this RtcToNet instance.
     private getSnapshot = () : RtcToNetSnapshot => {
+      var sessionSnapshots :SessionSnapshot[] = [];
+      Object.keys(this.sessions_).forEach((key:string) => {
+        sessionSnapshots.push(this.sessions_[key].getSnapshot())
+      });
       return {
-        sessions: []
+        sessions: sessionSnapshots
       };
     }
 
@@ -539,6 +528,38 @@ module RtcToNet {
         // the caller.
         return false;
       }
+    }
+
+    public getSnapshot = () : SessionSnapshot => {
+      return {
+        name: this.channelLabel(),
+        channel: {
+          bytesSent: 1,
+          bytesReceived: 1,
+          bytesBuffered: 1,
+          dataIn: {
+            length: 1,
+            handling: true
+          },
+          dataOut: {
+            length: 1,
+            handling: true
+          }
+        },
+        socket: {
+          bytesSent: 1,
+          bytesReceived: 1,
+          paused: false,
+          dataIn: {
+            length: 1,
+            handling: true
+          },
+          dataOut: {
+            length: 1,
+            handling: true
+          }
+        }
+      };
     }
 
     public longId = () : string => {

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -544,7 +544,8 @@ module RtcToNet {
         channel: {
           bytesSent: this.channelSentBytes_,
           bytesReceived: this.channelReceivedBytes_,
-          bytesBuffered: 1,
+          // TODO: this is not currently exposed by datachannel.ts
+          bytesBuffered: 0,
           dataIn: {
             length: this.dataChannel_.dataFromPeerQueue.getLength(),
             handling: this.dataChannel_.dataFromPeerQueue.isHandling()

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -10,7 +10,7 @@
 // you're debugging. Since the proxy outputs quite a lot of messages,
 // show only warnings by default from the rest of the system.
 // Note that the proxy is extremely slow in debug (D) mode.
-freedom['loggingprovider']().setConsoleFilter(['*:I']);
+freedom['loggingprovider']().setConsoleFilter(['*:D']);
 
 var log :Logging.Log = new Logging.Log('simple-socks');
 

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -10,7 +10,7 @@
 // you're debugging. Since the proxy outputs quite a lot of messages,
 // show only warnings by default from the rest of the system.
 // Note that the proxy is extremely slow in debug (D) mode.
-freedom['loggingprovider']().setConsoleFilter(['*:D']);
+freedom['loggingprovider']().setConsoleFilter(['*:I']);
 
 var log :Logging.Log = new Logging.Log('simple-socks');
 


### PR DESCRIPTION
This adds the notion of "snapshots" to `RtcToNet`. These are for instrumentation, so that we can visualise the behaviour of the proxy over time.

Snapshots are dumped every 5 seconds, as JSON in the format:

``` json
{  
  "sessions":[  
    {  
      "name":"c0",
      "channel":{  
        "sent":19289,
        "received":61599,
        "buffered":0,
        "queue":{  
          "size":0,
          "handling":true
        }
      },
      "socket":{  
        "sent":61599,
        "received":19289,
        "queue":{  
          "size":0,
          "handling":true
        }
      }
    },
    {  
      "name":"c1",
      "channel":{  
        "sent":29504,
        "received":5842,
        "buffered":0,
        "queue":{  
          "size":0,
          "handling":true
        }
      },
      "socket":{  
        "sent":5842,
        "received":29504,
        "queue":{  
          "size":0,
          "handling":true
        }
      }
    }
  ]
}
```

@mollyling: Is this something you can work with to make graphs? What would you change?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/201)

<!-- Reviewable:end -->
