### PR TITLE
improve TCP connection disconnect logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -245,13 +245,9 @@ module RtcToNet {
           this.tcpConnection_ = tcpConnection;
           // Shutdown once the TCP connection terminates.
           this.tcpConnection_.onceClosed.then((kind:Tcp.SocketCloseKind) => {
-            if (kind === Tcp.SocketCloseKind.UNKOWN) {
-              log.error('%1: socket closed for unrecognized reason', [
-                  this.longId()]);
-            } else {
-              log.info('%1: socket closed (%2)', [
-                  this.longId(), Tcp.SocketCloseKind[kind] || 'unknown reason']);
-            }
+            log.info('%1: socket closed (%2)', [
+                this.longId(),
+                Tcp.SocketCloseKind[kind]]);
           })
           .then(this.fulfillStopping_);
           return this.tcpConnection_.onceConnected;

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -317,13 +317,9 @@ module SocksToRtc {
       this.onceReady.catch(this.fulfillStopping_);
       Promise.race<any>([
           tcpConnection.onceClosed.then((kind:Tcp.SocketCloseKind) => {
-            if (kind === Tcp.SocketCloseKind.UNKOWN) {
-              log.error('%1: socket closed for unrecognized reason', [
-                  this.longId()]);
-            } else {
-              log.info('%1: socket closed (%2)', [
-                  this.longId(), Tcp.SocketCloseKind[kind] || 'unknown reason']);
-            }
+            log.info('%1: socket closed (%2)', [
+                this.longId(),
+                Tcp.SocketCloseKind[kind]]);
           }),
           dataChannel.onceClosed.then(() => {
             log.info('%1: datachannel closed', [this.longId()]);

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -359,10 +359,12 @@ module Tcp {
     // fullfilled.  If there's an error, onceDisconnected is rejected with the
     // error.
     private onDisconnectHandler_ = (info:freedom_TcpSocket.DisconnectInfo) : void => {
-      //log.debug(this.connectionId + ': onDisconnectHandler_');
-      if(this.state_ === Connection.State.CLOSED) {
-        //log.warn(this.connectionId + ': Got onDisconnect in closed state' +
-        //    '(errcode=' + info.errcode + '; msg=' + info.message + ')');
+      log.debug('%1: Disconnected: %2', [
+          this.connectionId,
+          JSON.stringify(info)]);
+
+      if (this.state_ === Connection.State.CLOSED) {
+        log.warn('%1: Got onDisconnect in closed state', [this.connectionId]);
         return;
       }
 
@@ -375,8 +377,6 @@ module Tcp {
         } else if (info.errcode === 'CONNECTION_CLOSED') {
           this.fulfillClosed_(SocketCloseKind.REMOTELY_CLOSED);
         } else {
-          //log.warn(this.connectionId + ': Disconnected with errcode '
-          //  + info.errcode + ': ' + info.message);
           this.fulfillClosed_(SocketCloseKind.UNKOWN);
         }
       });


### PR DESCRIPTION
Related issue:
https://github.com/uProxy/uproxy/issues/964

I don't think `RtcToNet` really cares why the connection was closed, so let's stop logging it. Since I don't see any issues with proxy behaviour after encountering lots of these messages, let's just log them all as INFO.

I think it _would_ be useful to improve the logging in `tcp.ts`. Having done that, I see several of these warnings:

```
Got onDisconnect in closed state
```

I will update the issue and continue to investigate. Might be harmless, might not.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/202)

<!-- Reviewable:end -->
