### PR TITLE
improve responsiveness of SocksToRtc and RtcToNet queue processing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -404,7 +404,7 @@ module RtcToNet {
 
     // Sends a packet over the data channel.
     // Invoked when a packet is received over the TCP socket.
-    private readFromSocket_ = (data:ArrayBuffer) : void => {
+    private sendOnChannel_ = (data:ArrayBuffer) : void => {
       log.debug('%1: socket received %2 bytes', [
           this.longId(),
           data.byteLength]);
@@ -417,7 +417,7 @@ module RtcToNet {
 
     // Sends a packet over the TCP socket.
     // Invoked when a packet is received over the data channel.
-    private readFromChannel_ = (data:WebRtc.Data) : void => {
+    private sendOnSocket_ = (data:WebRtc.Data) : void => {
       if (!data.buffer) {
         log.error('%1: received non-buffer data from datachannel', [
             this.longId()]);
@@ -450,7 +450,7 @@ module RtcToNet {
     // been successfully established.
     private startReadLoops_ = () : void => {
       var socketReadLoop = (data:ArrayBuffer) => {
-        this.readFromSocket_(data);
+        this.sendOnChannel_(data);
         Session.nextTick_(() => {
           this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
               socketReadLoop);
@@ -460,7 +460,7 @@ module RtcToNet {
           socketReadLoop);
 
       var channelReadLoop = (data:WebRtc.Data) : void => {
-        this.readFromChannel_(data);
+        this.sendOnSocket_(data);
         Session.nextTick_(() => {
           this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
               channelReadLoop);

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -25,6 +25,8 @@ module RtcToNet {
 
   // The |RtcToNet| class holds a peer-connection and all its associated
   // proxied connections.
+  // TODO: Extract common code for this and SocksToRtc:
+  //         https://github.com/uProxy/uproxy/issues/977
   export class RtcToNet {
     // Configuration for the proxy endpoint. Note: all sessions share the same
     // (externally provided) proxyconfig.

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -268,7 +268,7 @@ module RtcToNet {
           }
           throw e;
         });
-      this.onceReady.then(this.linkTcpAndPeerConnectionData_);
+      this.onceReady.then(this.startReadLoops_);
 
       this.onceReady.catch(this.fulfillStopping_);
 
@@ -402,46 +402,75 @@ module RtcToNet {
       return reply;
     }
 
-    // Assumes that |receiveEndpointFromPeer| and |getTcpConnection_|
-    // have completed.
-    private linkTcpAndPeerConnectionData_ = () : void => {
-      // Data from the TCP socket goes to the data channel.
-      this.tcpConnection_.dataFromSocketQueue.setSyncHandler((data) => {
-        log.debug('%1: socket received %2 bytes', [
-            this.longId(), data.byteLength]);
-        this.dataChannel_.send({buffer: data})
-        .catch((e:Error) => {
-          log.error('%1: failed to send data on datachannel: %2', [
-              this.longId(), e.message]);
-        });
-        this.bytesSentToPeer_.handle(data.byteLength);
+    // Sends a packet over the data channel.
+    // Invoked when a packet is received over the TCP socket.
+    private readFromSocket_ = (data:ArrayBuffer) : void => {
+      log.debug('%1: socket received %2 bytes', [
+          this.longId(),
+          data.byteLength]);
+      this.dataChannel_.send({buffer: data}).catch((e:Error) => {
+        log.error('%1: failed to send data on datachannel: %2', [
+            this.longId(),
+            e.message]);
       });
-      // Data from the datachannel goes to the TCP socket.
-      this.dataChannel_.dataFromPeerQueue.setSyncHandler((data:WebRtc.Data) => {
-        if (!data.buffer) {
-          log.error('%1: received non-buffer data from datachannel', [
-              this.longId()]);
-          return;
+    }
+
+    // Sends a packet over the TCP socket.
+    // Invoked when a packet is received over the data channel.
+    private readFromChannel_ = (data:WebRtc.Data) : void => {
+      if (!data.buffer) {
+        log.error('%1: received non-buffer data from datachannel', [
+            this.longId()]);
+        return;
+      }
+      log.debug('%1: datachannel received %2 bytes', [
+          this.longId(),
+          data.buffer.byteLength]);
+      this.bytesReceivedFromPeer_.handle(data.buffer.byteLength);
+      this.tcpConnection_.send(data.buffer).catch((e:any) => {
+        // TODO: e is actually a freedom.Error (uproxy-lib 20+)
+        // errcode values are defined here:
+        //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json
+        if (e.errcode === 'NOT_CONNECTED') {
+          // This can happen if, for example, there was still data to be
+          // read on the datachannel's queue when the socket closed.
+          log.warn('%1: tried to send data on closed socket: %2', [
+              this.longId(),
+              e.errcode]);
+        } else {
+          log.error('%1: failed to send data on socket: %2', [
+              this.longId(),
+              e.errcode]);
         }
-        log.debug('%1: datachannel received %2 bytes', [
-            this.longId(), data.buffer.byteLength]);
-        this.bytesReceivedFromPeer_.handle(data.buffer.byteLength);
-        this.tcpConnection_.send(data.buffer)
-        .catch((e:any) => {
-          // TODO: e is actually a freedom.Error (uproxy-lib 20+)
-          // errcode values are defined here:
-          //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json
-          if (e.errcode === 'NOT_CONNECTED') {
-            // This can happen if, for example, there was still data to be
-            // read on the datachannel's queue when the socket closed.
-            log.warn('%1: tried to send data on closed socket: %2', [
-                this.longId(), e.errcode]);
-          } else {
-            log.error('%1: failed to send data on socket: %2', [
-                this.longId(), e.errcode]);
-          }
-        });
       });
+    }
+
+    // Configures forwarding of data from the TCP socket over the data channel
+    // and vice versa. Should only be called once both socket and channel have
+    // been successfully established.
+    private startReadLoops_ = () : void => {
+      // Note that setTimeout is used by both handlers to preserve
+      // responsiveness when large amounts of data are being received:
+      //   https://github.com/uProxy/uproxy/issues/967
+      var socketReadLoop = (data:ArrayBuffer) => {
+        this.readFromSocket_(data);
+        setTimeout(() => {
+          this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
+              socketReadLoop);
+        }, 0);
+      }
+      this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
+          socketReadLoop);
+
+      var channelReadLoop = (data:WebRtc.Data) : void => {
+        this.readFromChannel_(data);
+        setTimeout(() => {
+          this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
+              channelReadLoop);
+        }, 0);
+      };
+      this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
+          channelReadLoop);
     }
 
     private isAllowedAddress_ = (addressString:string) : boolean => {

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -268,7 +268,7 @@ module RtcToNet {
           }
           throw e;
         });
-      this.onceReady.then(this.startReadLoops_);
+      this.onceReady.then(this.linkSocketAndChannel_);
 
       this.onceReady.catch(this.fulfillStopping_);
 
@@ -448,7 +448,7 @@ module RtcToNet {
     // Configures forwarding of data from the TCP socket over the data channel
     // and vice versa. Should only be called once both socket and channel have
     // been successfully established.
-    private startReadLoops_ = () : void => {
+    private linkSocketAndChannel_ = () : void => {
       var socketReadLoop = (data:ArrayBuffer) => {
         this.sendOnChannel_(data);
         Session.nextTick_(() => {

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -449,25 +449,22 @@ module RtcToNet {
     // and vice versa. Should only be called once both socket and channel have
     // been successfully established.
     private startReadLoops_ = () : void => {
-      // Note that setTimeout is used by both handlers to preserve
-      // responsiveness when large amounts of data are being received:
-      //   https://github.com/uProxy/uproxy/issues/967
       var socketReadLoop = (data:ArrayBuffer) => {
         this.readFromSocket_(data);
-        setTimeout(() => {
+        Session.nextTick_(() => {
           this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
               socketReadLoop);
-        }, 0);
+        });
       }
       this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
           socketReadLoop);
 
       var channelReadLoop = (data:WebRtc.Data) : void => {
         this.readFromChannel_(data);
-        setTimeout(() => {
+        Session.nextTick_(() => {
           this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
               channelReadLoop);
-        }, 0);
+        });
       };
       this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
           channelReadLoop);
@@ -512,6 +509,13 @@ module RtcToNet {
         channelLabel_: this.channelLabel(),
         tcpConnection: tcpString
       });
+    }
+
+    // Runs callback once the current event loop has run to completion.
+    // Uses setTimeout in lieu of something like Node's process.nextTick:
+    //   https://github.com/uProxy/uproxy/issues/967
+    private static nextTick_ = (callback:Function) : void => {
+      setTimeout(callback, 0);
     }
   }  // Session
 

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -487,23 +487,30 @@ module SocksToRtc {
       //   https://github.com/uProxy/uproxy/issues/967
       var socketReadLoop = (data:ArrayBuffer) => {
         this.readFromSocket_(data);
-        setTimeout(() => {
+        Session.nextTick_(() => {
           this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
               socketReadLoop);
-        }, 0);
+        });
       }
       this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
           socketReadLoop);
 
       var channelReadLoop = (data:WebRtc.Data) : void => {
         this.readFromChannel_(data);
-        setTimeout(() => {
+        Session.nextTick_(() => {
           this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
               channelReadLoop);
-        }, 0);
+        });
       };
       this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
           channelReadLoop);
+    }
+
+    // Runs callback once the current event loop has run to completion.
+    // Uses setTimeout in lieu of something like Node's process.nextTick:
+    //   https://github.com/uProxy/uproxy/issues/967
+    private static nextTick_ = (callback:Function) : void => {
+      setTimeout(callback, 0);
     }
   }  // Session
 

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -437,7 +437,7 @@ module SocksToRtc {
 
     // Sends a packet over the data channel.
     // Invoked when a packet is received over the TCP socket.
-    private readFromSocket_ = (data:ArrayBuffer) : void => {
+    private sendOnChannel_ = (data:ArrayBuffer) : void => {
       log.debug('%1: socket received %2 bytes', [
           this.longId(),
           data.byteLength]);
@@ -450,7 +450,7 @@ module SocksToRtc {
 
     // Sends a packet over the TCP socket.
     // Invoked when a packet is received over the data channel.
-    private readFromChannel_ = (data:WebRtc.Data) : void => {
+    private sendOnSocket_ = (data:WebRtc.Data) : void => {
       if (!data.buffer) {
         log.error('%1: received non-buffer data from datachannel', [
             this.longId()]);
@@ -486,7 +486,7 @@ module SocksToRtc {
       // responsiveness when large amounts of data are being received:
       //   https://github.com/uProxy/uproxy/issues/967
       var socketReadLoop = (data:ArrayBuffer) => {
-        this.readFromSocket_(data);
+        this.sendOnChannel_(data);
         Session.nextTick_(() => {
           this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
               socketReadLoop);
@@ -496,7 +496,7 @@ module SocksToRtc {
           socketReadLoop);
 
       var channelReadLoop = (data:WebRtc.Data) : void => {
-        this.readFromChannel_(data);
+        this.sendOnSocket_(data);
         Session.nextTick_(() => {
           this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
               channelReadLoop);

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -22,6 +22,8 @@ module SocksToRtc {
   // The |SocksToRtc| class runs a SOCKS5 proxy server which passes requests
   // remotely through WebRTC peer connections.
   // TODO: rename this 'Server'.
+  // TODO: Extract common code for this and SocksToRtc:
+  //         https://github.com/uProxy/uproxy/issues/977
   export class SocksToRtc {
 
     // Call this to initiate shutdown.

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -311,7 +311,7 @@ module SocksToRtc {
 
       // Startup notifications.
       this.onceReady = this.doAuthHandshake_().then(this.doRequestHandshake_);
-      this.onceReady.then(this.startReadLoops_);
+      this.onceReady.then(this.linkSocketAndChannel_);
 
       // Shutdown once TCP connection or datachannel terminate.
       this.onceReady.catch(this.fulfillStopping_);
@@ -481,7 +481,7 @@ module SocksToRtc {
     // Configures forwarding of data from the TCP socket over the data channel
     // and vice versa. Should only be called once both socket and channel have
     // been successfully established and the handshake has completed.
-    private startReadLoops_ = () : void => {
+    private linkSocketAndChannel_ = () : void => {
       // Note that setTimeout is used by both handlers to preserve
       // responsiveness when large amounts of data are being received:
       //   https://github.com/uProxy/uproxy/issues/967


### PR DESCRIPTION
So, inspired by this pull request:
https://github.com/uProxy/uproxy-lib/pull/126/files

This greatly improves the responsiveness of the proxy under high load. Specifically, with this change the proxy is sitll responsive while there is a fast download taking place, e.g.:
1. start curl-ing a large file
2. try to browse "normal" web pages with a browser

This does not currently work. General idea is to yield after each fetch from the socket and data channel's queue. More info here:
https://github.com/uProxy/uproxy/issues/967

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/203)

<!-- Reviewable:end -->
