### PR TITLE
eliminate spurious 'Got onDisconnect in closed state' warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -467,8 +467,8 @@ module RtcToNet {
     public longId = () : string => {
       var s = 'session ' + this.channelLabel();
       if (this.tcpConnection_) {
-        s += ' (TCP ' + (this.tcpConnection_.isClosed() ?
-            'closed' : 'open') + ')';
+        s += ' (socket ' + this.tcpConnection_.connectionId + ' ' +
+            (this.tcpConnection_.isClosed() ? 'closed' : 'open') + ')';
       }
       return s;
     }

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -331,8 +331,9 @@ module SocksToRtc {
     }
 
     public longId = () : string => {
-      return 'session ' + this.channelLabel() + ' (TCP '
-          + (this.tcpConnection_.isClosed() ? 'closed' : 'open') + ')';
+      return 'session ' + this.channelLabel() + ' (socket ' +
+          this.tcpConnection_.connectionId + ' ' +
+          (this.tcpConnection_.isClosed() ? 'closed' : 'open') + ')';
     }
 
     // Initiates shutdown of the TCP server and peerconnection.

--- a/src/tcp/tcp.d.ts
+++ b/src/tcp/tcp.d.ts
@@ -71,7 +71,9 @@ declare module Tcp {
 
     public onceConnected :Promise<ConnectionInfo>;
     public onceClosed :Promise<SocketCloseKind>;
-    // The |close| method will cause onceClosed to be fulfilled.
+
+    // Closes the underlying socket.
+    // Returns onceClosed.
     public close :() => Promise<SocketCloseKind>;
 
     // Send writes data to the tcp socket = dataToSocketQueue.handle

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -368,6 +368,7 @@ module Tcp {
 
       this.state_ = Connection.State.CLOSED;
       this.dataToSocketQueue.stopHandling();
+      this.dataToSocketQueue.clear();
 
       destroyFreedomSocket_(this.connectionSocket_).then(() => {
         if (info.errcode === 'SUCCESS') {

--- a/src/tcp/tcp.ts
+++ b/src/tcp/tcp.ts
@@ -354,23 +354,21 @@ module Tcp {
       });
     }
 
-    // This happens when the Tcp connection is closed by the other end or
-    // because  of an error. When closed by the other end, onceDisconnected is
-    // fullfilled.  If there's an error, onceDisconnected is rejected with the
-    // error.
+    // Invoked when the socket is closed for any reason.
+    // Fulfills onceClosed.
     private onDisconnectHandler_ = (info:freedom_TcpSocket.DisconnectInfo) : void => {
-      log.debug('%1: Disconnected: %2', [
+      log.debug('%1: onDisconnect: %2', [
           this.connectionId,
           JSON.stringify(info)]);
 
       if (this.state_ === Connection.State.CLOSED) {
-        log.warn('%1: Got onDisconnect in closed state', [this.connectionId]);
+        log.warn('%1: duplicate onDisconnect event', [this.connectionId]);
         return;
       }
 
       this.state_ = Connection.State.CLOSED;
-
       this.dataToSocketQueue.stopHandling();
+
       destroyFreedomSocket_(this.connectionSocket_).then(() => {
         if (info.errcode === 'SUCCESS') {
           this.fulfillClosed_(SocketCloseKind.WE_CLOSED_IT);
@@ -382,23 +380,19 @@ module Tcp {
       });
     }
 
-    // This is called to close the underlying socket. This fulfills the
-    // disconnect Promise `onceDisconnected`.
     public close = () : Promise<SocketCloseKind> => {
-      //log.debug(this.connectionId + ': close');
+      log.debug('%1: close', [this.connectionId]);
+
       if (this.state_ === Connection.State.CLOSED) {
-        //log.warn(this.connectionId + ': close: called when already closed');
-        return;
+        log.debug('%1: close called when already closed', [
+            this.connectionId]);
+      } else {
+        this.connectionSocket_.close();
       }
-      this.dataToSocketQueue.stopHandling();
-      this.connectionSocket_.close();
-      // Note: calling close on the freedom socket will cause
-      // `onDisconnectHandler_` to be fired, but we need to fulfill the promise
-      // set closed here and fulfill here because on the onDisconnect Handler
-      // needs to also call this.connectionSocket_.close() to do freedom memory
-      // cleanup.
-      this.state_ = Connection.State.CLOSED;
-      this.fulfillClosed_(SocketCloseKind.WE_CLOSED_IT);
+
+      // The onDisconnect handler (which should only
+      // be invoked once) actually stops handling, fulfills
+      // onceClosed, etc.
       return this.onceClosed;
     }
 


### PR DESCRIPTION
So, main thing is to remove these warnings from `tcp.ts`:
https://github.com/uProxy/uproxy/issues/981

They were spurious and were happening every time the `onDisconnect` handler was invoked after `close` was invoked. That's a lot of the time! Better to have `close()` simply close the socket and have `onDisconnect` emit the relevant close type. Easier to understand now, too, I think? Tested manually with Simple SOCKS and `grunt test`.

Also include the TCP session ID in `SocksToRtc` and `RtcToNet` debugging so we can trace the whole lifecycle of a `tcp.ts` object (logging still a bit of a mess in there but getting better and better as we tackle these issues).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/204)

<!-- Reviewable:end -->
