### PR TITLE
fix bytes sent counter and add unit tests for bytes sent and received

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/rtc-to-net/rtc-to-net.spec.ts
@@ -112,7 +112,7 @@ describe("RtcToNet session", function() {
     (<any>mockDataChannel.send).and.returnValue(voidPromise);
 
     mockBytesReceived = new Handler.Queue<number, void>();
-    mockBytesSent = new Handler.Queue<number, void>();    
+    mockBytesSent = new Handler.Queue<number, void>();
     session  = new RtcToNet.Session(
         mockDataChannel,
         mockProxyConfig,

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -410,7 +410,9 @@ module RtcToNet {
       log.debug('%1: socket received %2 bytes', [
           this.longId(),
           data.byteLength]);
-      this.dataChannel_.send({buffer: data}).catch((e:Error) => {
+      this.dataChannel_.send({buffer: data}).then(() => {
+        this.bytesSentToPeer_.handle(data.byteLength);
+      }).catch((e:Error) => {
         log.error('%1: failed to send data on datachannel: %2', [
             this.longId(),
             e.message]);

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -163,7 +163,7 @@ describe("SOCKS session", function() {
     (<any>mockDataChannel.send).and.returnValue(voidPromise);
 
     mockBytesReceived = new Handler.Queue<number, void>();
-    mockBytesSent = new Handler.Queue<number, void>();    
+    mockBytesSent = new Handler.Queue<number, void>()
   });
 
   it('onceReady fulfills with listening endpoint on successful negotiation', (done) => {

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -444,7 +444,9 @@ module SocksToRtc {
       log.debug('%1: socket received %2 bytes', [
           this.longId(),
           data.byteLength]);
-      this.dataChannel_.send({buffer: data}).catch((e:Error) => {
+      this.dataChannel_.send({buffer: data}).then(() => {
+        this.bytesSentToPeer_.handle(data.byteLength);
+      }).catch((e:Error) => {
         log.error('%1: failed to send data on datachannel: %2', [
             this.longId(),
             e.message]);


### PR DESCRIPTION
Oops, I broke the `bytesSent` counters in `SocksToRtc` and `RtcToNet` with this pull request:
https://github.com/uProxy/uproxy-networking/pull/203/files

This fixes them and adds unit tests, as per this issue:
https://github.com/uProxy/uproxy/issues/605

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/205)

<!-- Reviewable:end -->
