### PR TITLE
Better request-size options in benchmark.

### DIFF
--- a/bin/make-data.sh
+++ b/bin/make-data.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 mkdir data
 pushd data
-for i in 1024 2048 4096 8192 1048576 2097152 16777216
+for i in 1024 2048 4096 8192 131072 262144 524288 1048576 2097152 16777216
 do
    dd if=/dev/urandom of=$i.bin bs=$i count=1 status=noxfer
    od -x $i.bin >$i.txt

--- a/bin/run-benchmark.js
+++ b/bin/run-benchmark.js
@@ -1,5 +1,4 @@
 var benchmark = require('../build/benchmark/benchmark.js').Benchmark;
-var runner = new benchmark.RequestManager([1024]);
 // babar isn't in DefinitelyTyped, I didn't feel like putting it in yet.
 var babar = require('babar');
 var argv = require('yargs')
@@ -12,6 +11,8 @@ var argv = require('yargs')
     .alias('s', 'speed')
     .default('maxtimeouts', 10)
     .alias('m', 'maxtimeouts')
+    .default('R', 1024)
+    .alias('R', 'requestsize')
     .argv;
 
 var should_sleep = true;
@@ -20,6 +21,7 @@ var verbosity = argv.verbose;
 var concurrency = argv.concurrency
 var tail_lat = 1000 / argv.speed;
 var max_timeouts = argv.maxtimeouts;
+var runner = new benchmark.RequestManager([argv.requestsize]);
 console.log("Configured arguments: num tests: " + num_tests + ", concurrency: " + concurrency + 
             ", max timeouts: " + max_timeouts);
 

--- a/src/benchmark/benchmark.ts
+++ b/src/benchmark/benchmark.ts
@@ -254,7 +254,7 @@ export module Benchmark {
       var latency_ms = result_time - req.requestTime;
 
       // first verify that the body is fully-formed
-      if (!request_in_error && (!body || body.length != req.requestSize)) {
+      if (!request_in_error && (!body || !body.length || body.length != req.requestSize)) {
           request_in_error = true;
       }
 


### PR DESCRIPTION
Adds in 128k, 256k, and 512k sizes for the generated data directory, and a -R option in the benchmark script to use them.  One small error fix (I don't know why the library gives me body but not body.length sometimes, but it doesn't matter...).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/207)

<!-- Reviewable:end -->
