### PR TITLE
eliminate uncaught promise warnings and fix 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -339,9 +339,8 @@ module RtcToNet {
           }
           throw e;
         });
-      this.onceReady.then(this.linkSocketAndChannel_);
 
-      this.onceReady.catch(this.fulfillStopping_);
+      this.onceReady.then(this.linkSocketAndChannel_, this.fulfillStopping_);
 
       this.dataChannel_.onceClosed
       .then(() => {

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -218,8 +218,8 @@ module RtcToNet {
             channelLabel, Object.keys(this.sessions_).length]);
         };
       session.onceStopped().then(discard, (e:Error) => {
-        log.info('discarded session %1 (%2 remaining)', [
-            channelLabel, Object.keys(this.sessions_).length]);
+        log.error('session %1 terminated with error: %2', [
+            tag, e.message]);
         discard();
       });
     }

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -219,7 +219,7 @@ module RtcToNet {
         };
       session.onceStopped().then(discard, (e:Error) => {
         log.error('session %1 terminated with error: %2', [
-            tag, e.message]);
+            channelLabel, e.message]);
         discard();
       });
     }

--- a/src/socks-to-rtc/socks-to-rtc.d.ts
+++ b/src/socks-to-rtc/socks-to-rtc.d.ts
@@ -40,10 +40,10 @@ declare module SocksToRtc {
         dataChannel:WebRtc.DataChannel,
         bytesSentToPeer:Handler.Queue<number,void>,
         bytesReceivedFromPeer:Handler.Queue<number,void>)
-        => Promise<Net.Endpoint>;
+        => Promise<void>;
     public stop :() => Promise<void>;
     public tcpConnection :Tcp.Connection;
-    public onceReady :Promise<Net.Endpoint>;
+    public onceReady :Promise<void>;
     public onceStopped :Promise<void>;
     public longId :() => string;
     public channelLabel :() => string;

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -2,6 +2,7 @@
 /// <reference path='../third_party/typings/es6-promise/es6-promise.d.ts' />
 /// <reference path='../third_party/typings/jasmine/jasmine.d.ts' />
 
+/// <reference path='../socks-common/socks-headers.d.ts' />
 /// <reference path='../tcp/tcp.d.ts' />
 /// <reference path='../handler/queue.d.ts' />
 /// <reference path='../webrtc/datachannel.d.ts' />
@@ -168,14 +169,16 @@ describe("SOCKS session", function() {
 
   it('onceReady fulfills on successful negotiation', (done) => {
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: Socks.Reply.SUCCEEDED}));
 
     session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived).then(done);
   });
 
   it('onceReady rejects and onceStopped fulfills on unsuccessful negotiation', (done) => {
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.reject(new Error('unknown hostname')));
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: Socks.Reply.FAILURE}));
 
     session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived)
       .catch((e:Error) => { return session.onceStopped; }).then(done);
@@ -185,7 +188,8 @@ describe("SOCKS session", function() {
     mockTcpConnection.onceClosed = Promise.resolve();
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: Socks.Reply.SUCCEEDED}));
 
     session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived)
       .then(() => { return session.onceStopped; }).then(done);
@@ -196,7 +200,8 @@ describe("SOCKS session", function() {
     mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: Socks.Reply.SUCCEEDED}));
 
     session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived)
       .then(session.stop).then(() => { return session.onceStopped; }).then(done);
@@ -207,7 +212,8 @@ describe("SOCKS session", function() {
     mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: Socks.Reply.SUCCEEDED}));
 
     var buffer = new Uint8Array([1,2,3]).buffer;
     session.start(
@@ -228,7 +234,8 @@ describe("SOCKS session", function() {
     mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: Socks.Reply.SUCCEEDED}));
 
     var message :WebRtc.Data = {
       buffer: new Uint8Array([1,2,3]).buffer

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -166,21 +166,16 @@ describe("SOCKS session", function() {
     mockBytesSent = new Handler.Queue<number, void>()
   });
 
-  it('onceReady fulfills with listening endpoint on successful negotiation', (done) => {
+  it('onceReady fulfills on successful negotiation', (done) => {
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
 
-    session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived)
-      .then((result:Net.Endpoint) => {
-        expect(result.address).toEqual(mockEndpoint.address);
-        expect(result.port).toEqual(mockEndpoint.port);
-      })
-      .then(done);
+    session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived).then(done);
   });
 
   it('onceReady rejects and onceStopped fulfills on unsuccessful negotiation', (done) => {
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.reject('unknown hostname'));
+    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.reject(new Error('unknown hostname')));
 
     session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived)
       .catch((e:Error) => { return session.onceStopped; }).then(done);
@@ -190,7 +185,7 @@ describe("SOCKS session", function() {
     mockTcpConnection.onceClosed = Promise.resolve();
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
 
     session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived)
       .then(() => { return session.onceStopped; }).then(done);
@@ -201,7 +196,7 @@ describe("SOCKS session", function() {
     mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
 
     session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived)
       .then(session.stop).then(() => { return session.onceStopped; }).then(done);
@@ -212,7 +207,7 @@ describe("SOCKS session", function() {
     mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
 
     var buffer = new Uint8Array([1,2,3]).buffer;
     session.start(
@@ -233,7 +228,7 @@ describe("SOCKS session", function() {
     mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
 
     spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
-    spyOn(session, 'doRequestHandshake_').and.returnValue(Promise.resolve(mockEndpoint));
+    spyOn(session, 'doRequestHandshake_').and.returnValue(voidPromise);
 
     var message :WebRtc.Data = {
       buffer: new Uint8Array([1,2,3]).buffer

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -218,7 +218,7 @@ module SocksToRtc {
       var tag = obtainTag();
       log.info('associating session %1 with new TCP connection', [tag]);
 
-	    this.peerConnection_.openDataChannel(tag).then((channel:WebRtc.DataChannel) => {
+      this.peerConnection_.openDataChannel(tag).then((channel:WebRtc.DataChannel) => {
         log.info('opened datachannel for session %1', [tag]);
         var session = new Session();
         session.start(

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -311,12 +311,11 @@ module SocksToRtc {
       this.bytesSentToPeer_ = bytesSentToPeer;
       this.bytesReceivedFromPeer_ = bytesReceivedFromPeer;
 
-      // Startup notifications.
+      // Do handshake. If it fails, shutdown.
       this.onceReady = this.doAuthHandshake_().then(this.doRequestHandshake_);
-      this.onceReady.then(this.linkSocketAndChannel_);
+      this.onceReady.then(this.linkSocketAndChannel_, this.fulfillStopping_);
 
       // Shutdown once TCP connection or datachannel terminate.
-      this.onceReady.catch(this.fulfillStopping_);
       Promise.race<any>([
           tcpConnection.onceClosed.then((kind:Tcp.SocketCloseKind) => {
             log.info('%1: socket closed (%2)', [

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -226,7 +226,7 @@ module SocksToRtc {
             channel,
             this.bytesSentToPeer_,
             this.bytesReceivedFromPeer_)
-        .then((endpoint:Net.Endpoint) => {
+        .then(() => {
           this.sessions_[tag] = session;
         }, (e:Error) => {
           log.warn('session %1 failed to connect to remote endpoint: %2', [
@@ -277,10 +277,9 @@ module SocksToRtc {
     private bytesSentToPeer_ :Handler.Queue<number,void>;
     private bytesReceivedFromPeer_ :Handler.Queue<number,void>;
 
-    // Fulfills with the bound endpoint which RtcToNet is using to connect to the
-    // remote host. Rejects if RtcToNet could not connect to the remote host
-    // or if there is some error negotiating the SOCKS session.
-    public onceReady :Promise<Net.Endpoint>;
+    // Fulfills once the SOCKS negotiation process has successfully completed.
+    // Rejects if negotiation fails for any reason.
+    public onceReady :Promise<void>;
 
     // Call this to initiate shutdown.
     private fulfillStopping_ :() => void;
@@ -305,18 +304,22 @@ module SocksToRtc {
         dataChannel:WebRtc.DataChannel,
         bytesSentToPeer:Handler.Queue<number,void>,
         bytesReceivedFromPeer:Handler.Queue<number,void>)
-        : Promise<Net.Endpoint> => {
+        : Promise<void> => {
       this.tcpConnection_ = tcpConnection;
       this.dataChannel_ = dataChannel;
       this.bytesSentToPeer_ = bytesSentToPeer;
       this.bytesReceivedFromPeer_ = bytesReceivedFromPeer;
 
-      // Do handshake. If it fails, shutdown.
+      // The session is ready once we've completed both
+      // auth and request handshakes.
       this.onceReady = this.doAuthHandshake_().then(this.doRequestHandshake_);
-      this.onceReady.then(this.linkSocketAndChannel_, this.fulfillStopping_);
 
-      // Shutdown once TCP connection or datachannel terminate.
-      Promise.race<any>([
+      // Once the handshakes have completed, start forwarding data between the
+      // socket and channel and listen for socket and channel termination.
+      // If handshake fails, shutdown.
+      this.onceReady.then(() => {
+        this.linkSocketAndChannel_();
+        Promise.race<any>([
           tcpConnection.onceClosed.then((kind:Tcp.SocketCloseKind) => {
             log.info('%1: socket closed (%2)', [
                 this.longId(),
@@ -324,8 +327,10 @@ module SocksToRtc {
           }),
           dataChannel.onceClosed.then(() => {
             log.info('%1: datachannel closed', [this.longId()]);
-          })])
-        .then(this.fulfillStopping_);
+          })]).then(this.fulfillStopping_);
+      }, this.fulfillStopping_);
+
+      // Once shutdown has been requested, free resources.
       this.onceStopped = this.onceStopping_.then(this.stopResources_);
 
       return this.onceReady;
@@ -373,6 +378,7 @@ module SocksToRtc {
 
     // Receive a socks connection and send the initial Auth messages.
     // Assumes: no packet fragmentation.
+    // TODO: send failure to client if auth fails
     // TODO: handle packet fragmentation:
     //   https://github.com/uProxy/uproxy/issues/323
     // TODO: Needs unit tests badly since it's mocked by several other tests.
@@ -386,55 +392,71 @@ module SocksToRtc {
         });
     }
 
-    // Sets the next data hanlder to get next data from peer, assuming it's
-    // stringified version of the destination.
+    // Handles the SOCKS handshake, fulfilling iff all of the following
+    // steps succeed and the Socks.Response instance received from
+    // RtcToNet has a SUCCESSFUL reply field:
+    //  - reads the next packet from the socket
+    //  - parses this packet as a Socks.Request instance
+    //  - forwards this to RtcToNet
+    //  - receives the next message from the channel
+    //  - parses this message as a Socks.Response instance
+    //  - forwards the Socks.Response to the SOCKS client
+    // If a response is not received from RtcToNet or any other error
+    // occurs then we send a generic FAILURE response back to the SOCKS
+    // client before rejecting.
     // TODO: Needs unit tests badly since it's mocked by several other tests.
-    private receiveResponseFromPeer_ = () : Promise<Socks.Response> => {
-      return new Promise((F,R) => {
-        this.dataChannel_.dataFromPeerQueue.setSyncNextHandler((data:WebRtc.Data) => {
-          if (!data.str) {
-            R(new Error('received non-string data during handshake: ' +
-                JSON.stringify(data)));
-            return;
-          }
-          try {
-            var r :any = JSON.parse(data.str);
-            if (!Socks.isValidResponse(r)) {
-              R(new Error('invalid response:' + data.str));
-              return;
-            }
-            log.info('%1: connected to remote host', [this.longId()]);
-            log.debug('%1: remote peer bound address: %2', [
-                this.longId(), JSON.stringify(r.endpoint)]);
-            F(r);
-          } catch(e) {
-            R(new Error('received malformed response during handshake: ' +
-                data.str));
-          }
-        });
-      });
-    }
-
-    // Assumes that |doAuthHandshake_| has completed and that a peer-conneciton
-    // has been established. Promise returns the bound address used to connect.
-    private doRequestHandshake_ = ()
-        : Promise<Net.Endpoint> => {
+    private doRequestHandshake_ = () : Promise<void> => {
       return this.tcpConnection_.receiveNext()
         .then(Socks.interpretRequestBuffer)
         .then((request:Socks.Request) => {
           log.info('%1: received endpoint from SOCKS client: %2', [
               this.longId(), JSON.stringify(request.endpoint)]);
-          this.dataChannel_.send({ str: JSON.stringify(request) });
-          return this.receiveResponseFromPeer_();
+          return this.dataChannel_.send({ str: JSON.stringify(request) });
+        })
+        .then(() => {
+          // Equivalent to channel.receiveNext(), if it existed.
+          return new Promise((F, R) => {
+            this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(F).catch(R);
+          });
+        })
+        .then((data:WebRtc.Data) => {
+          if (!data.str) {
+            throw new Error('received non-string data from peer ' +
+              'during handshake: ' + JSON.stringify(data));
+          }
+          try {
+            var response :Socks.Response = JSON.parse(data.str);
+            if (!Socks.isValidResponse(response)) {
+              throw new Error('invalid response received from peer ' +
+                  'during handshake: ' + data.str);
+            }
+            return response;
+          } catch (e) {
+            throw new Error('could not parse response from peer: ' + e.message);
+          }
+        })
+        .catch((e:Error) => {
+          log.debug('%1: unexpected failure during handshake, ' +
+              'returning generic FAILURE to SOCKS client: %2', [
+              this.longId(),
+              e.message]);
+          return {
+            reply: Socks.Reply.FAILURE
+          };
         })
         .then((response:Socks.Response) => {
-          // TODO: test and close: https://github.com/uProxy/uproxy/issues/324
-          this.tcpConnection_.send(Socks.composeResponseBuffer(response));
-          if (response.reply != Socks.Reply.SUCCEEDED) {
-            this.stop();
-          }
-          return response.endpoint;
+          return this.tcpConnection_.send(Socks.composeResponseBuffer(
+              response)).then((discard:any) => {
+            if (response.reply !== Socks.Reply.SUCCEEDED) {
+              throw new Error('handshake failed with reply code ' +
+                  Socks.Reply[response.reply]);
+            }
+            log.info('%1: connected to remote host', [this.longId()]);
+            log.debug('%1: remote peer bound address: %2', [
+                this.longId(),
+                JSON.stringify(response.endpoint)]);
         });
+      });
     }
 
     // Sends a packet over the data channel.


### PR DESCRIPTION
Two main things in here:
- eliminate uncaught promise warnings in Chrome (namely `onceReady`)
- refactor `SocksToRtc.doRequestHandshake`, fixing an issue where it ignored unsuccessful connect messages from `RtcToNet`

I believe this addresses this issue:
https://github.com/uProxy/uproxy/issues/952

I also filed a couple of issues we should also look into:
1. https://github.com/uProxy/uproxy/issues/1032
2. https://github.com/uProxy/uproxy/issues/1030

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/208)

<!-- Reviewable:end -->
