### PR TITLE
drain incoming data channel and socket queues before terminating SOCKS sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/rtc-to-net/rtc-to-net.spec.ts
@@ -230,10 +230,11 @@ describe("RtcToNet session", function() {
     var message :WebRtc.Data = {
       buffer: new Uint8Array([1,2,3]).buffer
     };
-    mockDataChannel.dataFromPeerQueue.handle(message);
-    mockDataChannel.dataFromPeerQueue.handle(message);
+    var onceMessageHandled = mockDataChannel.dataFromPeerQueue.handle(message);
 
     session.start().then(session.onceStopped).then(() => {
+      return onceMessageHandled;
+    }).then(() => {
       expect(mockDataChannel.dataFromPeerQueue.getLength()).toEqual(0);
       done();
     });
@@ -250,10 +251,11 @@ describe("RtcToNet session", function() {
     (<any>mockTcpConnection.isClosed).and.returnValue(true);
 
     var buffer = new Uint8Array([1,2,3]).buffer;
-    mockTcpConnection.dataFromSocketQueue.handle(buffer);
-    mockTcpConnection.dataFromSocketQueue.handle(buffer);
+    var onceMessageHandled = mockTcpConnection.dataFromSocketQueue.handle(buffer);
 
     session.start().then(session.onceStopped).then(() => {
+      return onceMessageHandled;
+    }).then(() => {
       expect(mockTcpConnection.dataFromSocketQueue.getLength()).toEqual(0);
       done();
     });

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -264,6 +264,9 @@ module RtcToNet {
   export class Session {
     private tcpConnection_ :Tcp.Connection;
 
+    // There is no equivalent of datachannel.isClosed().
+    private isChannelClosed_ :boolean = false;
+
     // Fulfills once a connection has been established with the remote peer.
     // Rejects if a connection cannot be made for any reason.
     public onceReady :Promise<void>;
@@ -308,13 +311,21 @@ module RtcToNet {
           throw e;
         }).then((tcpConnection:Tcp.Connection) => {
           this.tcpConnection_ = tcpConnection;
-          // Shutdown once the TCP connection terminates.
+
+          // Shutdown once the TCP connection terminates and has drained.
           this.tcpConnection_.onceClosed.then((kind:Tcp.SocketCloseKind) => {
-            log.info('%1: socket closed (%2)', [
-                this.longId(),
-                Tcp.SocketCloseKind[kind]]);
-          })
-          .then(this.fulfillStopping_);
+            if (this.tcpConnection_.dataFromSocketQueue.getLength() === 0) {
+              log.info('%1: socket closed (%2), all incoming data processed',
+                  this.longId(),
+                  Tcp.SocketCloseKind[kind]);
+              this.fulfillStopping_();
+            } else {
+              log.info('%1: socket closed (%2), still processing incoming data',
+                  this.longId(),
+                  Tcp.SocketCloseKind[kind]);
+            }
+          });
+
           return this.tcpConnection_.onceConnected;
         })
         .then((info:Tcp.ConnectionInfo) => {
@@ -336,11 +347,16 @@ module RtcToNet {
 
       this.onceReady.then(this.linkSocketAndChannel_, this.fulfillStopping_);
 
-      this.dataChannel_.onceClosed
-      .then(() => {
-        log.info('%1: datachannel closed', [this.longId()]);
-      })
-      .then(this.fulfillStopping_);
+      // Shutdown once the data channel terminates and has drained.
+      this.dataChannel_.onceClosed.then(() => {
+        this.isChannelClosed_ = true;
+        if (this.dataChannel_.dataFromPeerQueue.getLength() === 0) {
+          log.info('%1: channel closed, all incoming data processed', this.longId());
+          this.fulfillStopping_();
+        } else {
+          log.info('%1: channel closed, still processing incoming data', this.longId());
+        }
+      });
 
       this.onceStopped_ = this.onceStopping_.then(this.stopResources_);
 
@@ -468,73 +484,91 @@ module RtcToNet {
 
     // Sends a packet over the data channel.
     // Invoked when a packet is received over the TCP socket.
-    private sendOnChannel_ = (data:ArrayBuffer) : void => {
-      this.socketReceivedBytes_ += data.byteLength;
+    private sendOnChannel_ = (data:ArrayBuffer) : Promise<void> => {
       log.debug('%1: socket received %2 bytes', [
           this.longId(),
           data.byteLength]);
-      this.dataChannel_.send({buffer: data}).then(() => {
-        this.bytesSentToPeer_.handle(data.byteLength);
-        this.channelSentBytes_ += data.byteLength;
-      }).catch((e:Error) => {
-        log.error('%1: failed to send data on datachannel: %2', [
-            this.longId(),
-            e.message]);
-      });
+      this.socketReceivedBytes_ += data.byteLength;
+
+      return this.dataChannel_.send({buffer: data});
     }
 
     // Sends a packet over the TCP socket.
     // Invoked when a packet is received over the data channel.
-    private sendOnSocket_ = (data:WebRtc.Data) : void => {
-      this.channelReceivedBytes_ += data.buffer.byteLength;
+    private sendOnSocket_ = (data:WebRtc.Data) : Promise<freedom_TcpSocket.WriteInfo> => {
       if (!data.buffer) {
-        log.error('%1: received non-buffer data from datachannel', [
-            this.longId()]);
-        return;
+        return Promise.reject(new Error(
+            'received non-buffer data from datachannel'));
       }
       log.debug('%1: datachannel received %2 bytes', [
           this.longId(),
           data.buffer.byteLength]);
       this.bytesReceivedFromPeer_.handle(data.buffer.byteLength);
-      this.tcpConnection_.send(data.buffer).then(() => {
-        this.socketSentBytes_ += data.buffer.byteLength;
-      }).catch((e:any) => {
-        // TODO: e is actually a freedom.Error (uproxy-lib 20+)
-        // errcode values are defined here:
-        //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json
-        if (e.errcode === 'NOT_CONNECTED') {
-          // This can happen if, for example, there was still data to be
-          // read on the datachannel's queue when the socket closed.
-          log.warn('%1: tried to send data on closed socket: %2', [
-              this.longId(),
-              e.errcode]);
-        } else {
-          log.error('%1: failed to send data on socket: %2', [
-              this.longId(),
-              e.errcode]);
-        }
-      });
+
+      return this.tcpConnection_.send(data.buffer);
     }
 
     // Configures forwarding of data from the TCP socket over the data channel
     // and vice versa. Should only be called once both socket and channel have
     // been successfully established.
     private linkSocketAndChannel_ = () : void => {
+      // Note that setTimeout is used by both loops to preserve system
+      // responsiveness when large amounts of data are being received:
+      //   https://github.com/uProxy/uproxy/issues/967
       var socketReadLoop = (data:ArrayBuffer) => {
-        this.sendOnChannel_(data);
-        Session.nextTick_(() => {
-          this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
-              socketReadLoop);
+        this.sendOnChannel_(data).then(() => {
+          this.bytesSentToPeer_.handle(data.byteLength);
+          this.channelSentBytes_ += data.byteLength;
+          // Shutdown once the TCP connection terminates and has drained,
+          // otherwise keep draining.
+          if (this.tcpConnection_.isClosed() &&
+              this.tcpConnection_.dataFromSocketQueue.getLength() === 0) {
+            log.info('%1: socket drained', this.longId());
+            this.fulfillStopping_();
+          } else {
+            Session.nextTick_(() => {
+              this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
+                  socketReadLoop);
+            });
+          }
+        }, (e:Error) => {
+          log.error('%1: failed to send data on datachannel: %2',
+              this.longId(),
+              e.message);
         });
-      }
-      this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
-          socketReadLoop);
+      };
+      this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(socketReadLoop);
 
       var channelReadLoop = (data:WebRtc.Data) : void => {
-        this.sendOnSocket_(data);
-        Session.nextTick_(() => {
-          this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
-              channelReadLoop);
+        this.sendOnSocket_(data).then((writeInfo:freedom_TcpSocket.WriteInfo) => {
+          this.socketSentBytes_ += data.buffer.byteLength;
+          // Shutdown once the data channel terminates and has drained,
+          // otherwise keep draining.
+          if (this.isChannelClosed_ &&
+              this.dataChannel_.dataFromPeerQueue.getLength() === 0) {
+            log.info('%1: channel drained', this.longId());
+            this.fulfillStopping_();
+          } else {
+            Session.nextTick_(() => {
+              this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
+                  channelReadLoop);
+            });
+          }
+        }, (e:any) => {
+          // TODO: e is actually a freedom.Error (uproxy-lib 20+)
+          // errcode values are defined here:
+          //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json
+          if (e.errcode === 'NOT_CONNECTED') {
+            // This can happen if, for example, there was still data to be
+            // read on the datachannel's queue when the socket closed.
+            log.warn('%1: tried to send data on closed socket: %2', [
+                this.longId(),
+                e.errcode]);
+          } else {
+            log.error('%1: failed to send data on socket: %2', [
+                this.longId(),
+                e.errcode]);
+          }
         });
       };
       this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -335,7 +335,7 @@ module RtcToNet {
               JSON.stringify(info.bound)]);
           var reply = this.getReplyFromInfo_(info);
           this.replyToPeer_(reply, info);
-        }, (e:any) => {
+        }, (e:{ errcode: string }) => {
           // TODO: e is actually a freedom.Error (uproxy-lib 20+)
           // If this.tcpConnection_ is not defined, then getTcpConnection_
           // failed and we've already replied with UNSUPPORTED_COMMAND.
@@ -555,7 +555,7 @@ module RtcToNet {
                   channelReadLoop);
             });
           }
-        }, (e:any) => {
+        }, (e:{ errcode: string }) => {
           // TODO: e is actually a freedom.Error (uproxy-lib 20+)
           // errcode values are defined here:
           //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -264,7 +264,8 @@ module RtcToNet {
   export class Session {
     private tcpConnection_ :Tcp.Connection;
 
-    // There is no equivalent of datachannel.isClosed().
+    // TODO: There's no equivalent of datachannel.isClosed():
+    //         https://github.com/uProxy/uproxy/issues/1075
     private isChannelClosed_ :boolean = false;
 
     // Fulfills once a connection has been established with the remote peer.

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -268,8 +268,7 @@ describe("SOCKS session", function() {
     var message :WebRtc.Data = {
       buffer: new Uint8Array([1,2,3]).buffer
     };
-    mockDataChannel.dataFromPeerQueue.handle(message);
-    mockDataChannel.dataFromPeerQueue.handle(message);
+    var onceMessageHandled = mockDataChannel.dataFromPeerQueue.handle(message);
 
     session.start(
         mockTcpConnection,
@@ -277,6 +276,8 @@ describe("SOCKS session", function() {
         mockBytesSent,
         mockBytesReceived);
     session.onceStopped.then(() => {
+      return onceMessageHandled;
+    }).then(() => {
       expect(mockDataChannel.dataFromPeerQueue.getLength()).toEqual(0);
       done();
     });
@@ -294,8 +295,7 @@ describe("SOCKS session", function() {
         Promise.resolve({reply: Socks.Reply.SUCCEEDED}));
 
     var buffer = new Uint8Array([1,2,3]).buffer;
-    mockTcpConnection.dataFromSocketQueue.handle(buffer);
-    mockTcpConnection.dataFromSocketQueue.handle(buffer);
+    var onceMessageHandled = mockTcpConnection.dataFromSocketQueue.handle(buffer);
 
     session.start(
         mockTcpConnection,
@@ -303,6 +303,8 @@ describe("SOCKS session", function() {
         mockBytesSent,
         mockBytesReceived);
     session.onceStopped.then(() => {
+      return onceMessageHandled;
+    }).then(() => {
       expect(mockTcpConnection.dataFromSocketQueue.getLength()).toEqual(0);
       done();
     });

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -145,12 +145,14 @@ describe("SOCKS session", function() {
     mockTcpConnection = jasmine.createSpyObj('tcp connection', [
         'onceClosed',
         'close',
-        'isClosed'
+        'isClosed',
+        'send'
       ]);
     mockTcpConnection.dataFromSocketQueue = new Handler.Queue<ArrayBuffer,void>();
     (<any>mockTcpConnection.close).and.returnValue(Promise.resolve(-1));
     mockTcpConnection.onceClosed = Promise.resolve(
         Tcp.SocketCloseKind.REMOTELY_CLOSED);
+    (<any>mockTcpConnection.send).and.returnValue(Promise.resolve({ bytesWritten: 1 }));
 
     mockDataChannel = <any>{
       getLabel: jasmine.createSpy('getLabel').and.returnValue('mock label'),
@@ -249,6 +251,33 @@ describe("SOCKS session", function() {
     });
     mockBytesReceived.setSyncNextHandler((numBytes:number) => {
       expect(numBytes).toEqual(message.buffer.byteLength);
+      done();
+    });
+  });
+
+  it('channel queue drains before termination', (done) => {
+    // TCP connection doesn't close "naturally" but the data
+    // channel is already closed when the session is started.
+    mockTcpConnection.onceClosed = new Promise<Tcp.SocketCloseKind>((F, R) => {});
+    mockDataChannel.onceClosed = voidPromise;
+
+    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: Socks.Reply.SUCCEEDED}));
+
+    var message :WebRtc.Data = {
+      buffer: new Uint8Array([1,2,3]).buffer
+    };
+    mockDataChannel.dataFromPeerQueue.handle(message);
+    mockDataChannel.dataFromPeerQueue.handle(message);
+
+    session.start(
+        mockTcpConnection,
+        mockDataChannel,
+        mockBytesSent,
+        mockBytesReceived);
+    session.onceStopped.then(() => {
+      expect(mockDataChannel.dataFromPeerQueue.getLength()).toEqual(0);
       done();
     });
   });

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -277,7 +277,8 @@ module SocksToRtc {
     private bytesSentToPeer_ :Handler.Queue<number,void>;
     private bytesReceivedFromPeer_ :Handler.Queue<number,void>;
 
-    // There is no equivalent of datachannel.isClosed().
+    // TODO: There's no equivalent of datachannel.isClosed():
+    //         https://github.com/uProxy/uproxy/issues/1075
     private isChannelClosed_ :boolean = false;
 
     // Fulfills once the SOCKS negotiation process has successfully completed.

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -548,7 +548,7 @@ module SocksToRtc {
                   channelReadLoop);
             });
           }
-        }, (e:any) => {
+        }, (e:{ errcode: string }) => {
           // TODO: e is actually a freedom.Error (uproxy-lib 20+)
           // errcode values are defined here:
           //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -277,6 +277,9 @@ module SocksToRtc {
     private bytesSentToPeer_ :Handler.Queue<number,void>;
     private bytesReceivedFromPeer_ :Handler.Queue<number,void>;
 
+    // There is no equivalent of datachannel.isClosed().
+    private isChannelClosed_ :boolean = false;
+
     // Fulfills once the SOCKS negotiation process has successfully completed.
     // Rejects if negotiation fails for any reason.
     public onceReady :Promise<void>;
@@ -329,15 +332,31 @@ module SocksToRtc {
       // If handshake fails, shutdown.
       this.onceReady.then(() => {
         this.linkSocketAndChannel_();
-        Promise.race<any>([
-          tcpConnection.onceClosed.then((kind:Tcp.SocketCloseKind) => {
-            log.info('%1: socket closed (%2)', [
+
+        // Shutdown once the TCP connection terminates and has drained.
+        this.tcpConnection_.onceClosed.then((kind:Tcp.SocketCloseKind) => {
+          if (this.tcpConnection_.dataFromSocketQueue.getLength() === 0) {
+            log.info('%1: socket closed (%2), all incoming data processed',
                 this.longId(),
-                Tcp.SocketCloseKind[kind]]);
-          }),
-          dataChannel.onceClosed.then(() => {
-            log.info('%1: datachannel closed', [this.longId()]);
-          })]).then(this.fulfillStopping_);
+                Tcp.SocketCloseKind[kind]);
+            this.fulfillStopping_();
+          } else {
+            log.info('%1: socket closed (%2), still processing incoming data',
+                this.longId(),
+                Tcp.SocketCloseKind[kind]);
+          }
+        });
+
+        // Shutdown once the data channel terminates and has drained.
+        this.dataChannel_.onceClosed.then(() => {
+          this.isChannelClosed_ = true;
+          if (this.dataChannel_.dataFromPeerQueue.getLength() === 0) {
+            log.info('%1: channel closed, all incoming data processed', this.longId());
+            this.fulfillStopping_();
+          } else {
+            log.info('%1: channel closed, still processing incoming data', this.longId());
+          }
+        });
       }, this.fulfillStopping_);
 
       // Once shutdown has been requested, free resources.
@@ -461,71 +480,88 @@ module SocksToRtc {
 
     // Sends a packet over the data channel.
     // Invoked when a packet is received over the TCP socket.
-    private sendOnChannel_ = (data:ArrayBuffer) : void => {
+    private sendOnChannel_ = (data:ArrayBuffer) : Promise<void> => {
       log.debug('%1: socket received %2 bytes', [
           this.longId(),
           data.byteLength]);
-      this.dataChannel_.send({buffer: data}).then(() => {
-        this.bytesSentToPeer_.handle(data.byteLength);
-      }).catch((e:Error) => {
-        log.error('%1: failed to send data on datachannel: %2', [
-            this.longId(),
-            e.message]);
-      });
+
+      return this.dataChannel_.send({buffer: data});
     }
 
     // Sends a packet over the TCP socket.
     // Invoked when a packet is received over the data channel.
-    private sendOnSocket_ = (data:WebRtc.Data) : void => {
+    private sendOnSocket_ = (data:WebRtc.Data) : Promise<freedom_TcpSocket.WriteInfo> => {
       if (!data.buffer) {
-        log.error('%1: received non-buffer data from datachannel', [
-            this.longId()]);
-        return;
+        return Promise.reject(new Error(
+            'received non-buffer data from datachannel'));
       }
       log.debug('%1: datachannel received %2 bytes', [
           this.longId(),
           data.buffer.byteLength]);
       this.bytesReceivedFromPeer_.handle(data.buffer.byteLength);
-      this.tcpConnection_.send(data.buffer).catch((e:any) => {
-        // TODO: e is actually a freedom.Error (uproxy-lib 20+)
-        // errcode values are defined here:
-        //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json
-        if (e.errcode === 'NOT_CONNECTED') {
-          // This can happen if, for example, there was still data to be
-          // read on the datachannel's queue when the socket closed.
-          log.warn('%1: tried to send data on closed socket: %2', [
-              this.longId(),
-              e.errcode]);
-        } else {
-          log.error('%1: failed to send data on socket: %2', [
-              this.longId(),
-              e.errcode]);
-        }
-      });
+
+      return this.tcpConnection_.send(data.buffer);
     }
 
     // Configures forwarding of data from the TCP socket over the data channel
     // and vice versa. Should only be called once both socket and channel have
-    // been successfully established and the handshake has completed.
+    // been successfully established.
     private linkSocketAndChannel_ = () : void => {
-      // Note that setTimeout is used by both handlers to preserve
+      // Note that setTimeout is used by both loops to preserve system
       // responsiveness when large amounts of data are being received:
       //   https://github.com/uProxy/uproxy/issues/967
       var socketReadLoop = (data:ArrayBuffer) => {
-        this.sendOnChannel_(data);
-        Session.nextTick_(() => {
-          this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
-              socketReadLoop);
+        this.sendOnChannel_(data).then(() => {
+          this.bytesSentToPeer_.handle(data.byteLength);
+          // Shutdown once the TCP connection terminates and has drained,
+          // otherwise keep draining.
+          if (this.tcpConnection_.isClosed() &&
+              this.tcpConnection_.dataFromSocketQueue.getLength() === 0) {
+            log.info('%1: socket drained', this.longId());
+            this.fulfillStopping_();
+          } else {
+            Session.nextTick_(() => {
+              this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
+                  socketReadLoop);
+            });
+          }
+        }, (e:Error) => {
+          log.error('%1: failed to send data on datachannel: %2',
+              this.longId(),
+              e.message);
         });
-      }
-      this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(
-          socketReadLoop);
+      };
+      this.tcpConnection_.dataFromSocketQueue.setSyncNextHandler(socketReadLoop);
 
       var channelReadLoop = (data:WebRtc.Data) : void => {
-        this.sendOnSocket_(data);
-        Session.nextTick_(() => {
-          this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
-              channelReadLoop);
+        this.sendOnSocket_(data).then((writeInfo:freedom_TcpSocket.WriteInfo) => {
+          // Shutdown once the data channel terminates and has drained,
+          // otherwise keep draining.
+          if (this.isChannelClosed_ &&
+              this.dataChannel_.dataFromPeerQueue.getLength() === 0) {
+            log.info('%1: channel drained', this.longId());
+            this.fulfillStopping_();
+          } else {
+            Session.nextTick_(() => {
+              this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
+                  channelReadLoop);
+            });
+          }
+        }, (e:any) => {
+          // TODO: e is actually a freedom.Error (uproxy-lib 20+)
+          // errcode values are defined here:
+          //   https://github.com/freedomjs/freedom/blob/master/interface/core.tcpsocket.json
+          if (e.errcode === 'NOT_CONNECTED') {
+            // This can happen if, for example, there was still data to be
+            // read on the datachannel's queue when the socket closed.
+            log.warn('%1: tried to send data on closed socket: %2', [
+                this.longId(),
+                e.errcode]);
+          } else {
+            log.error('%1: failed to send data on socket: %2', [
+                this.longId(),
+                e.errcode]);
+          }
         });
       };
       this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(


### PR DESCRIPTION
This addresses the following issue:
- https://github.com/uProxy/uproxy/issues/1033

Two main changes:
1. wait for `send()` callbacks to fulfill before calling `close()` (this is not important for data channels, whose `close()` method is essentially synchronous, but is important for TCP sockets)
2. once a socket or data channel has closed, wait for its incoming data queue to be fully processed before terminating the session

I think the first change is clearly important. I want to describe the second change in more detail... Currently, both `SocksToRtc` and `RtcToNet` closes a SOCKS session when either:
- the data channel closes
- the socket closes

The problem is when there is still data remaining to be processed on either the channel's or socket's incoming queue. Now, SOCKS sessions will close when:
- the data channel closes _and_ there is no (incoming) data on the channel's queue
- the socket closes _and_ there is no (incoming) data on the socket's queue

Tested primarily against the following URL:

```
curl -x socks5h://localhost:9999 http://www.armoryonpark.org/css/screen.css
```

Currently, this fails; curl will report 10-20k of unread data. With this change, the URL loads just fine. Though I didn't dig too deeply into the server's behaviour, I suspect this applies to any server which terminates its connection to the proxy as soon as it has sent all its data (most HTTP servers seem to wait for the client to terminate their connection first).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/212)

<!-- Reviewable:end -->
