### PR TITLE
add churn peerName to all log messages

### DIFF
--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -235,12 +235,12 @@ module Churn {
             this.peerName,
             JSON.stringify(endpoint));
       });
-      this.onceHaveWebRtcEndpoint_.then((endpoint:Churn.Endpoint) => {
+      this.onceHaveWebRtcEndpoint_.then((endpoint:freedom_ChurnPipe.Endpoint) => {
         log.debug('%1: obfuscated connection is bound to %2',
             this.peerName,
             JSON.stringify(endpoint));
       });
-      this.onceHaveRemoteEndpoint_.then((endpoint:Churn.Endpoint) => {
+      this.onceHaveRemoteEndpoint_.then((endpoint:freedom_ChurnPipe.Endpoint) => {
         log.debug('%1: remote peer is contactable at %2',
             this.peerName,
             JSON.stringify(endpoint));


### PR DESCRIPTION
Also some tidy up. I've been finding this useful this afternoon to debug things.

I also sent this pull request to make peerconnection output its signalling messages at debug level:
https://github.com/uProxy/uproxy-lib/pull/140

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/213)

<!-- Reviewable:end -->
