### PR TITLE
Pause and resume around the initial getInfo.

### DIFF
--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -56,7 +56,7 @@ export function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
 function destroyFreedomSocket_(socket:freedom_TcpSocket.Socket)
     : Promise<void> {
   // Note that :
-  // freedom['core.tcpsocket'].close =/= freedom['core.tcpsocket']().close
+  // freedom['core.tcpsocket'].close != freedom['core.tcpsocket']().close
   // The former destroys the freedom interface & communication channels.
   // The latter is a method on the constructed interface object that is on
   // the instance of the freedom tcp-socket's API.
@@ -302,12 +302,20 @@ export class Connection {
     } else if (connectionKind.endpoint) {
       // Create a new tcp socket to the given endpoint.
       this.connectionSocket_ = freedom['core.tcpsocket']();
+      // We don't declare ourselves connected until we know the IP address to
+      // which we have connected.  To speed this process up, we immediately
+      // pause the socket as soon as it's connected, so that CPU time is not
+      // wasted sending events that we can't pass on until getInfo returns.
       this.onceConnected =
           this.connectionSocket_
               .connect(connectionKind.endpoint.address,
                        connectionKind.endpoint.port)
+              .then(this.pause)
               .then(this.connectionSocket_.getInfo)
-              .then(endpointOfSocketInfo)
+              .then((info:freedom_TcpSocket.SocketInfo) => {
+                this.resume();
+                return endpointOfSocketInfo(info);
+              })
       this.state_ = Connection.State.CONNECTING;
       this.onceConnected
           .then(() => {
@@ -382,6 +390,14 @@ export class Connection {
         this.fulfillClosed_(SocketCloseKind.UNKOWN);
       }
     });
+  }
+
+  public pause = () => {
+    this.connectionSocket_.pause();
+  }
+
+  public resume = () => {
+    this.connectionSocket_.resume();
   }
 
   // This is called to close the underlying socket. This fulfills the


### PR DESCRIPTION
This should hopefully enable faster startup on fast downloads.

Tested by running the TCP integration tests (which pass).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/214)

<!-- Reviewable:end -->
