### PR TITLE
Fix paths in Gruntfile for socks-echo integration tests.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -467,7 +467,8 @@ module.exports = (grunt) ->
           devBuildPath + '/integration-tests/socks-echo/freedom-module.static.js'
           devBuildPath + '/integration-tests/socks-echo/freedom-module.json'
           freedomForChromePath + '/freedom-for-chrome.js'
-          devBuildPath + '/integration-tests/socks-echo/tcp.core-env.spec.static.js'
+          devBuildPath + '/integration-tests/socks-echo/nochurn.core-env.spec.static.js'
+          devBuildPath + '/integration-tests/socks-echo/churn.core-env.spec.static.js'
         ]
         options:
           paths: [


### PR DESCRIPTION
This does not cause the tests to run (they are still
blocked by an error related to require.js's use of string
evaluation) but at least it loads the right files.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/215)

<!-- Reviewable:end -->
