### PR TITLE
Pause the incoming socket when the downstream data channel overflows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "socks5-http-client": "^0.1.6",
     "tsd": "^0.5.7",
     "typescript": "^1.4.1",
-    "uproxy-lib": "^20.0.0",
+    "uproxy-lib": "^20.1.0",
     "utransformers": "^0.2.1",
     "wup": "^1.0.0",
     "yargs": "^3.0.4"

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -270,7 +270,7 @@ export class Connection {
   private fulfillClosed_ :(reason:SocketCloseKind)=>void;
 
   // A TCP connection for a given socket.
-  constructor(connectionKind:Connection.Kind) {
+  constructor(connectionKind:Connection.Kind, private startPaused_?:boolean) {
     this.connectionId = 'N' + Connection.globalConnectionId_++;
 
     this.dataFromSocketQueue = new handler.Queue<ArrayBuffer,void>();
@@ -313,7 +313,9 @@ export class Connection {
               .then(this.pause)
               .then(this.connectionSocket_.getInfo)
               .then((info:freedom_TcpSocket.SocketInfo) => {
-                this.resume();
+                if (!this.startPaused_) {
+                  this.resume();
+                }
                 return endpointOfSocketInfo(info);
               })
       this.state_ = Connection.State.CONNECTING;

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -39,6 +39,7 @@ module RtcToNet {
     channel_sent: number;
     channel_received: number;
     channel_buffered: number;
+    channel_js_buffered: number;
     channel_queue_size: number;
     channel_queue_handling: boolean;
     socket_sent: number;
@@ -632,6 +633,7 @@ module RtcToNet {
     public getSnapshot = () : Promise<SessionSnapshot> => {
       return this.dataChannel_.getBrowserBufferedAmount()
           .then((bufferedAmount:number) => {
+        var js_buffer = this.dataChannel_.getJavascriptBufferedAmount();
         return {
           name: this.channelLabel(),
           timestamp: performance.now(),
@@ -640,6 +642,7 @@ module RtcToNet {
           channel_buffered: bufferedAmount,
           channel_queue_size: this.dataChannel_.dataFromPeerQueue.getLength(),
           channel_queue_handling: this.dataChannel_.dataFromPeerQueue.isHandling(),
+          channel_js_buffered: js_buffer,
           socket_sent: this.socketSentBytes_,
           socket_received: this.socketReceivedBytes_,
           socket_queue_size: this.tcpConnection_.dataFromSocketQueue.getLength(),

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -593,10 +593,10 @@ module RtcToNet {
 
         if (overflow) {
           this.tcpConnection_.pause();
-          log.debug('Hit overflow, pausing socket');
+          log.debug('%1: Hit overflow, pausing socket', this.longId());
         } else {
           this.tcpConnection_.resume();
-          log.debug('Exited overflow, resuming socket');
+          log.debug('%1: Exited  overflow, resuming socket', this.longId());
         }
       });
     }

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -22,6 +22,17 @@ var mockEndpoint :net.Endpoint = {
   port: 1234
 };
 
+var mockRemoteEndpoint :net.Endpoint = {
+  // This address and port are both reserved for testing.
+  address: '192.0.2.111',
+  port: 1023
+};
+
+var mockConnectionInfo :tcp.ConnectionInfo = {
+  bound: mockEndpoint,
+  remote: mockRemoteEndpoint
+};
+
 var voidPromise = Promise.resolve<void>();
 
 // Neither fulfills nor rejects.
@@ -156,7 +167,9 @@ describe("SOCKS session", function() {
         'onceClosed',
         'close',
         'isClosed',
-        'send'
+        'send',
+        'pause',
+        'resume'
       ]);
     mockTcpConnection.dataFromSocketQueue = new handler.Queue<ArrayBuffer,void>();
     (<any>mockTcpConnection.close).and.returnValue(Promise.resolve(-1));
@@ -172,7 +185,9 @@ describe("SOCKS session", function() {
       getLabel: jasmine.createSpy('getLabel').and.returnValue('mock label'),
       onceClosed: noopPromise,
       onceOpened: noopPromise,
-      send: jasmine.createSpy('send')
+      send: jasmine.createSpy('send'),
+      isInOverflow: jasmine.createSpy('isInOverflow').and.returnValue(false),
+      setOverflowListener: jasmine.createSpy('setOverflowListener')
     };
 
     (<any>mockDataChannel.send).and.returnValue(voidPromise);
@@ -318,6 +333,87 @@ describe("SOCKS session", function() {
       return onceMessageHandled;
     }).then(() => {
       expect(mockTcpConnection.dataFromSocketQueue.getLength()).toEqual(0);
+      done();
+    });
+  });
+
+  it('backpressure', (done) => {
+    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: socks.Reply.SUCCEEDED}));
+
+    mockTcpConnection.onceConnected = Promise.resolve(mockConnectionInfo);
+    mockTcpConnection.onceClosed = new Promise<tcp.SocketCloseKind>((F, R) => {});
+
+    var overflowListener :(overflow:boolean) => void;
+    mockDataChannel.setOverflowListener = (listener) => { overflowListener = listener; };
+
+    var buffer = new Uint8Array([1,2,3]).buffer;
+
+    // Messages received before start sit in the TCP receive queue.
+    mockTcpConnection.dataFromSocketQueue.handle(buffer);
+    expect(mockTcpConnection.dataFromSocketQueue.getLength()).toEqual(1);
+    expect(mockDataChannel.send).not.toHaveBeenCalled();
+
+    session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived).then(() => {
+      // After start, the TCP queue should be drained into the datachannel.
+      expect(mockTcpConnection.dataFromSocketQueue.getLength()).toEqual(0);
+      expect(mockDataChannel.send).toHaveBeenCalled();
+
+      // After draining the queue, the TCP connection should be resumed.
+      expect(mockTcpConnection.pause).not.toHaveBeenCalled();
+      expect(mockTcpConnection.resume).toHaveBeenCalled();
+
+      // Enter overflow state.  This should trigger a call to pause.
+      overflowListener(true);
+      expect(mockTcpConnection.pause).toHaveBeenCalled();
+
+      // In the paused state, messages are still forwarded
+      mockTcpConnection.dataFromSocketQueue.handle(buffer);
+      expect(mockTcpConnection.dataFromSocketQueue.getLength()).toEqual(0);
+      expect((<any>mockDataChannel.send).calls.count()).toEqual(2);
+
+      // Exit overflow state.  This should trigger a call to resume.
+      overflowListener(false);
+      expect((<any>mockTcpConnection.resume).calls.count()).toEqual(2);
+
+      done();
+    });
+  });
+
+  it('backpressure with early flood', (done) => {
+    spyOn(session, 'doAuthHandshake_').and.returnValue(Promise.resolve());
+    spyOn(session, 'doRequestHandshake_').and.returnValue(
+        Promise.resolve({reply: socks.Reply.SUCCEEDED}));
+
+    mockTcpConnection.onceConnected = Promise.resolve(mockConnectionInfo);
+    mockTcpConnection.onceClosed = new Promise<tcp.SocketCloseKind>((F, R) => {});
+
+    var overflowListener :(overflow:boolean) => void;
+    mockDataChannel.setOverflowListener = (listener) => { overflowListener = listener; };
+    mockDataChannel.isInOverflow = <any>jasmine.createSpy('isInOverflow').and.returnValue(true);
+
+    var buffer = new Uint8Array([1,2,3]).buffer;
+
+    // Messages received before start sit in the TCP receive queue.
+    mockTcpConnection.dataFromSocketQueue.handle(buffer);
+    expect(mockTcpConnection.dataFromSocketQueue.getLength()).toEqual(1);
+    expect(mockDataChannel.send).not.toHaveBeenCalled();
+
+    session.start(mockTcpConnection, mockDataChannel, mockBytesSent, mockBytesReceived).then(() => {
+      // After start, the TCP queue should be drained into the datachannel.
+      expect(mockTcpConnection.dataFromSocketQueue.getLength()).toEqual(0);
+      expect(mockDataChannel.send).toHaveBeenCalled();
+
+      // If the initial queue is enough to trigger overflow, then the
+      // socket should not be resumed.
+      expect(mockTcpConnection.pause).not.toHaveBeenCalled();
+      expect(mockTcpConnection.resume).not.toHaveBeenCalled();
+
+      // Exit overflow state.  This should trigger a call to resume.
+      overflowListener(false);
+      expect(mockTcpConnection.resume).toHaveBeenCalled();
+
       done();
     });
   });


### PR DESCRIPTION
This change was tested using simple socks and the flood server.

Note that for testing, simple socks must be configured not to use
CHURN, and debug logging must be disabled.

This resolves https://github.com/uProxy/uproxy/issues/949.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/220)

<!-- Reviewable:end -->
