### PR TITLE
Fix copypaste-socks-chromeapp such that it can actually proxy again.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -115,7 +115,7 @@ module.exports = (grunt) ->
         files: [
           expand: true
           cwd: pgpPath
-          src: ['build/*.js', 'build/pgpapi.json']
+          src: ['dist/*.js', 'dist/pgpapi.json']
           dest: 'build/freedom-pgp-e2e/'
         ]
 

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.json
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.json
@@ -29,7 +29,7 @@
       "api": "churnPipe"
     },
     "pgp": {
-      "url": "lib/freedom-pgp-e2e/build/pgpapi.json",
+      "url": "lib/freedom-pgp-e2e/dist/pgpapi.json",
       "api": "crypto"
     }
   },


### PR DESCRIPTION
Apparently this app hasn't been used for a while.  The build succeeded, but the resulting app didn't work properly due to some outdated freedom-pgp-e2e paths.  (Shouldn't the build fail in such a case?)

The freedom-pgp-e2e are now located in `lib/freedom-pgp-e2e/dist`:

$ ll dist/samples/copypaste-socks-chromeapp/lib/freedom-pgp-e2e/dist/
total 3216
-rw-r--r--  1 mhild  eng    6021 Apr  3 16:27 e2e.js
-rw-r--r--  1 mhild  eng  970008 Apr  3 16:27 end-to-end.compiled.js
-rw-r--r--  1 mhild  eng  650999 Apr  3 16:27 freedom.js
-rw-r--r--  1 mhild  eng    1803 Apr  3 16:27 googstorage.js
-rw-r--r--  1 mhild  eng    1201 Apr  3 16:27 googstorage_mock.js
-rw-r--r--  1 mhild  eng    2678 Apr  3 16:27 pgpapi.json
-rw-r--r--  1 mhild  eng     233 Apr  3 16:27 test_mock.js

The `build` directory that was previously referenced does not exist anymore:

$ ll dist/samples/copypaste-socks-chromeapp/lib/freedom-pgp-e2e/build/
ls: dist/samples/copypaste-socks-chromeapp/lib/freedom-pgp-e2e/build/: No such file or directory

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/223)

<!-- Reviewable:end -->
