### PR TITLE
fixed rtc-to-net and socks-to-rtc for freedom moduleification

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -34,6 +34,10 @@ taskManager.add 'integration', [
   'socksEchoIntegrationTest'
 ]
 
+taskManager.add 'dist', [
+  'base', 'samples', 'test', 'integration', 'copy:dist'
+]
+
 # -----------------------------------------------------------------------------
 # Sample Apps
 
@@ -260,7 +264,8 @@ module.exports = (grunt) ->
               cwd: devBuildPath,
               src: ['**/*',
                     '!**/*.spec.js',
-                    '!**/*.spec.*.js'],
+                    '!**/*.spec.*.js',
+                    '!samples/**/*',],
               dest: 'build/dist/',
               onlyIf: 'modified'
           }

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -128,6 +128,7 @@ taskManager.add 'socksEchoIntegrationTestModule', [
 taskManager.add 'socksEchoIntegrationTest', [
   'socksEchoIntegrationTestModule'
   'jasmine_chromeapp:socksEcho'
+  #'jasmine_chromeapp:socksEchoChurn'
 ]
 
 taskManager.add 'tcpIntegrationTestModule', [
@@ -512,6 +513,21 @@ module.exports = (grunt) ->
         scripts: [
           'freedom-for-chrome/freedom-for-chrome.js'
           'nochurn.core-env.spec.static.js'
+        ]
+        options:
+          outDir: devBuildPath + '/integration-tests/socks-echo/jasmine_chromeapp/'
+          keepRunner: true
+      socksEchoChurn:
+        files: [
+          {
+            cwd: devBuildPath + '/integration-tests/socks-echo/',
+            src: ['**/*', '!jasmine_chromeapp/**/*']
+            dest: './',
+            expand: true
+          }
+        ]
+        scripts: [
+          'freedom-for-chrome/freedom-for-chrome.js'
           'churn.core-env.spec.static.js'
         ]
         options:

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -29,6 +29,11 @@ taskManager.add 'test', [
   'jasmine'
 ]
 
+taskManager.add 'integration', [
+  'tcpIntegrationTest'
+  'socksEchoIntegrationTest'
+]
+
 # -----------------------------------------------------------------------------
 # Sample Apps
 
@@ -107,11 +112,6 @@ taskManager.add 'sampleSimpleTurnChromeApp', [
 # -----------------------------------------------------------------------------
 # Integration tests
 
-taskManager.add 'integration', [
-  'tcpIntegrationTest'
-  'socksEchoIntegrationTest'
-]
-
 taskManager.add 'socksEchoIntegrationTestModule', [
   'base'
   'copy:libsForIntegrationSocksEcho'
@@ -174,7 +174,6 @@ browserifyIntegrationTest = (path) ->
   });
 
 #-------------------------------------------------------------------------
-
 freedomForChromePath = path.dirname(require.resolve('freedom-for-chrome/package.json'))
 uproxyLibPath = path.dirname(require.resolve('uproxy-lib/package.json'))
 #ipaddrjsPath = path.dirname(require.resolve('ipaddr.js/package.json'))
@@ -538,12 +537,11 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-browserify'
   grunt.loadNpmTasks 'grunt-contrib-clean'
   grunt.loadNpmTasks 'grunt-contrib-copy'
-  grunt.loadNpmTasks 'grunt-contrib-symlink'
   grunt.loadNpmTasks 'grunt-contrib-jasmine'
+  grunt.loadNpmTasks 'grunt-contrib-symlink'
   grunt.loadNpmTasks 'grunt-jasmine-chromeapp'
-  grunt.loadNpmTasks 'grunt-vulcanize'
-
   grunt.loadNpmTasks 'grunt-ts'
+  grunt.loadNpmTasks 'grunt-vulcanize'
 
   #-------------------------------------------------------------------------
   # Register the tasks

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "request": "^2.53.0",
     "socks5-http-client": "^0.1.6",
     "tsd": "^0.5.7",
-    "uproxy-lib": "^21.0.0",
+    "uproxy-lib": "^23.0.0",
     "utransformers": "^0.2.1",
     "wup": "^1.0.0",
     "yargs": "^3.0.4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"
@@ -41,8 +41,7 @@
     "request": "^2.53.0",
     "socks5-http-client": "^0.1.6",
     "tsd": "^0.5.7",
-    "typescript": "^1.4.1",
-    "uproxy-lib": "^20.0.0",
+    "uproxy-lib": "^21.0.0",
     "utransformers": "^0.2.1",
     "wup": "^1.0.0",
     "yargs": "^3.0.4"

--- a/setup.sh
+++ b/setup.sh
@@ -16,8 +16,8 @@ function runAndAssertCmd ()
     set -e && cd $ROOT_DIR && eval $1
 }
 
-# Just run the command, ignore errors (e.g. cp fails if a file already exists
-# with "set -e")
+# Just run the command, ignore errors (e.g. with "set -e", the "cp" command
+# fails if a file already exists in the destination)
 function runCmd ()
 {
     echo "Running: $1"
@@ -46,8 +46,6 @@ function installThirdParty ()
 function installDevDependencies ()
 {
   runAndAssertCmd "npm install"
-  # TODO: remove this line when uproxy-lib is npm published.
-  # runAndAssertCmd "cd node_modules/uproxy-lib && ./setup.sh install && grunt dist"
   installTools
   installThirdParty
 }

--- a/src/churn/churn.types.ts
+++ b/src/churn/churn.types.ts
@@ -1,10 +1,10 @@
-import peerconnection = require('../../../third_party/uproxy-lib/webrtc/peerconnection');
+import signals = require('../../../third_party/uproxy-lib/webrtc/signals');
 import net = require('../net/net.types');
 
 // This file holds the common signalling message type that may be referenced
 // from both module environment as well as the core environment.
 
 export interface ChurnSignallingMessage {
-  webrtcMessage ?:peerconnection.SignallingMessage;
+  webrtcMessage ?:signals.Message;
   publicEndpoint ?:net.Endpoint;
 }

--- a/src/churn/churn.types.ts
+++ b/src/churn/churn.types.ts
@@ -1,10 +1,10 @@
-import peerconnection = require('../../../third_party/uproxy-lib/webrtc/peerconnection');
+import signal = require('../../../third_party/uproxy-lib/webrtc/signal');
 import net = require('../net/net.types');
 
 // This file holds the common signalling message type that may be referenced
 // from both module environment as well as the core environment.
 
 export interface ChurnSignallingMessage {
-  webrtcMessage ?:peerconnection.SignallingMessage;
+  webrtcMessage ?:signal.Message;
   publicEndpoint ?:net.Endpoint;
 }

--- a/src/integration-tests/socks-echo/proxy-integration-test.ts
+++ b/src/integration-tests/socks-echo/proxy-integration-test.ts
@@ -2,6 +2,7 @@
 
 import peerconnection = require('../../../../third_party/uproxy-lib/webrtc/peerconnection');
 
+import ProxyConfig = require('../../rtc-to-net/proxyconfig');
 import rtc_to_net = require('../../rtc-to-net/rtc-to-net');
 import socks_to_rtc = require('../../socks-to-rtc/socks-to-rtc');
 import net = require('../../net/net.types');
@@ -48,15 +49,16 @@ class ProxyIntegrationTestClass implements ProxyIntegrationTester {
     var rtcPcConfig :freedom_RTCPeerConnection.RTCConfiguration = {
       iceServers: [],
     };
-    var rtcToNetProxyConfig :rtc_to_net.ProxyConfig = {
+    var rtcToNetProxyConfig :ProxyConfig = {
       allowNonUnicast: !denyLocalhost  // Allow RtcToNet to contact the localhost server.
     };
 
     this.socksToRtc_ = new socks_to_rtc.SocksToRtc();
-    this.rtcToNet_ = new rtc_to_net.RtcToNet(rtcPcConfig, rtcToNetProxyConfig, obfuscate);
-    this.socksToRtc_.on('signalForPeer', this.rtcToNet_.handleSignalFromPeer);
+    this.rtcToNet_ = new rtc_to_net.RtcToNet();
+    this.rtcToNet_.startFromConfig(rtcToNetProxyConfig,rtcPcConfig,obfuscate);
     this.rtcToNet_.signalsForPeer.setSyncHandler(this.socksToRtc_.handleSignalFromPeer);
-    return this.socksToRtc_.start(socksToRtcEndpoint, rtcPcConfig, obfuscate);
+    this.socksToRtc_.on('signalForPeer', this.rtcToNet_.handleSignalFromPeer);
+    return this.socksToRtc_.startFromConfig(socksToRtcEndpoint, rtcPcConfig, obfuscate);
   }
 
   // Assumes webEndpoint is IPv4.

--- a/src/rtc-to-net/freedom-module-wrapper.ts
+++ b/src/rtc-to-net/freedom-module-wrapper.ts
@@ -1,0 +1,52 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-common.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
+
+import freedom_TransportToNet = require('./freedom-module.interface');
+import handler = require('../../../third_party/uproxy-lib/handler/queue');
+import signal = require('../../../third_party/uproxy-lib/webrtc/signal');
+
+import TransportToNet = require('./transport-to-net.interface');
+import ProxyConfig = require('./proxyconfig');
+
+
+class TransportToNetClass implements TransportToNet {
+  private freedomModule_ :freedom_TransportToNet;
+  public onceStopped :Promise<void>;
+
+  public signalsForPeer :handler.Queue<signal.Message, void>;
+  public bytesReceivedFromPeer :handler.Queue<number, void>;
+  public bytesSentToPeer :handler.Queue<number, void>;
+
+  public startFromConfig(
+      proxyConfig: ProxyConfig,
+      transportConfig:freedom_RTCPeerConnection.RTCConfiguration,
+      obfusacte:boolean) :Promise<void> {
+    return this.freedomModule_.startFromConfig(proxyConfig,
+        transportConfig, obfusacte);
+  }
+
+  public stop() :Promise<void> {
+    return this.freedomModule_.stop();
+  }
+
+  public handleSignalFromPeer(message:signal.Message) :void {
+    this.freedomModule_.handleSignalFromPeer(message);
+  }
+
+  constructor() {
+    this.signalsForPeer = new handler.Queue<signal.Message,void>();
+    this.bytesReceivedFromPeer = new handler.Queue<number,void>();
+    this.bytesSentToPeer = new handler.Queue<number,void>();
+
+    this.freedomModule_ = freedom['transportToNet']();
+    this.freedomModule_.on('signalForPeer', this.signalsForPeer.handle);
+    this.freedomModule_.on('bytesReceivedFromPeer', this.signalsForPeer.handle);
+    this.freedomModule_.on('bytesSentToPeer', this.signalsForPeer.handle);
+    this.onceStopped = new Promise<void>((F,R) => {
+      this.freedomModule_.on('stopped', F);
+    });
+  }
+}
+
+export = TransportToNetClass;

--- a/src/rtc-to-net/freedom-module.interface.ts
+++ b/src/rtc-to-net/freedom-module.interface.ts
@@ -1,0 +1,24 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-common.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
+
+import signal = require('../../../third_party/uproxy-lib/webrtc/signal');
+
+import ProxyConfig = require('./proxyconfig');
+
+interface freedom_TransportToNet {
+  startFromConfig(
+      proxyConfig: ProxyConfig,
+      transportConfig:freedom_RTCPeerConnection.RTCConfiguration,
+      obfusacte:boolean) :Promise<void>;
+  stop() :Promise<void>;
+  handleSignalFromPeer(message:signal.Message) :Promise<void>;
+
+  on(t:string, f:(...args:Object[])=>void) :void;
+  on(t:'signalForPeer', f:(message:signal.Message) => void) :void;
+  on(t:'bytesReceivedFromPeer', f:(byteCount:number) => void) :void;
+  on(t:'bytesSentToPeer', f:(byteCount:number) => void) :void;
+  on(t:'stopped', f:() => void) :void;
+}
+
+export = freedom_TransportToNet

--- a/src/rtc-to-net/freedom-module.json
+++ b/src/rtc-to-net/freedom-module.json
@@ -15,12 +15,11 @@
     "SocksToRtc"
   ],
   "api": {
-    "SocksToRtc": {
+    "transportToNet": {
       "start": {
         "value": [
           {
-            "address": "string",
-            "port": "number"
+            "allowNonUnicast": "boolean"
           },
           {
             "iceServers": ["array", {

--- a/src/rtc-to-net/freedom-module.ts
+++ b/src/rtc-to-net/freedom-module.ts
@@ -1,0 +1,54 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-common.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
+
+import signal = require('../../../third_party/uproxy-lib/webrtc/signal');
+
+import rtc_to_net = require('./rtc-to-net');
+
+import TransportToNet = require('./transport-to-net.interface');
+import ProxyConfig = require('./proxyconfig');
+
+// Freedom class for TransportToNet to wrap up freedom-style message passing.
+// Ince day this will be auto-generatable from the transport-to-net interface
+// file by the IDL compiler.
+class TransportToNetFreedomClass {
+  private rtcToNet_ :TransportToNet;
+
+  constructor(private dispatchEvent_?:(t:string, x?:Object) => void) {
+    this.rtcToNet_ = new rtc_to_net.RtcToNet();
+  }
+
+  public handleSignalFromPeer(message:signal.Message) :void{
+    this.rtcToNet_.handleSignalFromPeer(message);
+  }
+
+  public startFromConfig(
+      proxyConfig: ProxyConfig,
+      transportConfig:freedom_RTCPeerConnection.RTCConfiguration,
+      obfusacte:boolean) :Promise<void> {
+    return this.rtcToNet_.startFromConfig(proxyConfig,
+      transportConfig, obfusacte).then(() => {
+        this.rtcToNet_.signalsForPeer.setSyncHandler((message) => {
+          this.dispatchEvent_('signalForPeer', message);
+        });
+        // TODO: we probably want to throttle/time-limit the byte-count messages.
+        // Else we'll get a lot more messages between web-workers.
+        this.rtcToNet_.bytesReceivedFromPeer.setSyncHandler((byteCount) => {
+          this.dispatchEvent_('bytesReceivedFromPeer', byteCount);
+        });
+        this.rtcToNet_.bytesSentToPeer.setSyncHandler((byteCount) => {
+          this.dispatchEvent_('bytesSentToPeer', byteCount);
+        });
+        this.rtcToNet_.onceStopped.then(() => {
+          this.dispatchEvent_('stopped');
+        });
+      });
+  }
+
+  public stop() :Promise<void> {
+    return this.rtcToNet_.stop();
+  }
+}
+
+freedom['transportToNet']().providePomises(TransportToNetFreedomClass);

--- a/src/rtc-to-net/proxyconfig.ts
+++ b/src/rtc-to-net/proxyconfig.ts
@@ -1,0 +1,8 @@
+
+interface ProxyConfig {
+  // If |allowNonUnicast === false| then any proxy attempt that results
+  // in a non-unicast (e.g. local network) address will fail.
+  allowNonUnicast :boolean;
+}
+
+export = ProxyConfig;

--- a/src/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/rtc-to-net/rtc-to-net.spec.ts
@@ -7,6 +7,7 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
 import arraybuffers = require('../../../third_party/uproxy-lib/arraybuffers/arraybuffers');
 import peerconnection = require('../../../third_party/uproxy-lib/webrtc/peerconnection');
+import signals = require('../../../third_party/uproxy-lib/webrtc/signals');
 import handler = require('../../../third_party/uproxy-lib/handler/queue');
 
 import rtc_to_net = require('./rtc-to-net');

--- a/src/rtc-to-net/rtc-to-net.spec.ts
+++ b/src/rtc-to-net/rtc-to-net.spec.ts
@@ -7,6 +7,7 @@ freedom = freedomMocker.makeMockFreedomInModuleEnv();
 
 import arraybuffers = require('../../../third_party/uproxy-lib/arraybuffers/arraybuffers');
 import peerconnection = require('../../../third_party/uproxy-lib/webrtc/peerconnection');
+import signal = require('../../../third_party/uproxy-lib/webrtc/signal');
 import handler = require('../../../third_party/uproxy-lib/handler/queue');
 
 import rtc_to_net = require('./rtc-to-net');
@@ -16,6 +17,7 @@ import socks = require('../socks-common/socks-headers');
 
 import logging = require('../../../third_party/uproxy-lib/logging/logging');
 
+import ProxyConfig = require('./proxyconfig');
 
 var log :logging.Log = new logging.Log('socks-to-rtc spec');
 
@@ -27,7 +29,7 @@ var mockBoundEndpoint :net.Endpoint = {
 
 var voidPromise = Promise.resolve<void>();
 
-var mockProxyConfig :rtc_to_net.ProxyConfig = {
+var mockProxyConfig :ProxyConfig = {
   allowNonUnicast: false
 };
 
@@ -51,7 +53,7 @@ describe('RtcToNet', function() {
   var server :rtc_to_net.RtcToNet;
 
   var mockPeerconnection
-      :peerconnection.PeerConnection<peerconnection.SignallingMessage>;
+      :peerconnection.PeerConnection<signal.Message>;
 
   beforeEach(function() {
     server = new rtc_to_net.RtcToNet();
@@ -82,22 +84,22 @@ describe('RtcToNet', function() {
     server.start(mockProxyConfig, mockPeerconnection).catch(done);
   });
 
-  it('onceClosed fulfills on peerconnection termination', (done) => {
+  it('onceStopped fulfills on peerconnection termination', (done) => {
     mockPeerconnection.onceConnected = voidPromise;
     mockPeerconnection.onceDisconnected = <any>Promise.resolve();
 
     server.start(mockProxyConfig, mockPeerconnection)
-      .then(() => { return server.onceClosed; })
+      .then(() => { return server.onceStopped; })
       .then(done);
   });
 
-  it('onceClosed fulfills on call to stop', (done) => {
+  it('onceStopped fulfills on call to stop', (done) => {
     mockPeerconnection.onceConnected = voidPromise;
     // Calling stop() alone should be sufficient to initiate shutdown.
 
     server.start(mockProxyConfig, mockPeerconnection)
-      .then(server.close)
-      .then(() => { return server.onceClosed; })
+      .then(server.stop)
+      .then(() => { return server.onceStopped; })
       .then(done);
   });
 });
@@ -132,7 +134,6 @@ describe("RtcToNet session", function() {
       send: jasmine.createSpy('send')
     };
     (<any>mockDataChannel.send).and.returnValue(voidPromise);
-
 
     mockBytesReceived = new handler.Queue<number, void>();
     mockBytesSent = new handler.Queue<number, void>();

--- a/src/rtc-to-net/transport-to-net.interface.ts
+++ b/src/rtc-to-net/transport-to-net.interface.ts
@@ -1,0 +1,31 @@
+// The typescript description of the stub that is provided for a consumer of
+// freedom-module.json
+
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-common.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
+
+import signal = require('../../../third_party/uproxy-lib/webrtc/signal');
+import net = require('../net/net.types');
+import handler = require('../../../third_party/uproxy-lib/handler/queue');
+
+import ProxyConfig = require('./proxyconfig');
+
+interface TransportToNet {
+  startFromConfig(
+      proxyConfig:ProxyConfig,
+      transportConfig:freedom_RTCPeerConnection.RTCConfiguration,
+      obfuscate:boolean)
+    :Promise<void>;
+  stop() :Promise<void>;
+
+  handleSignalFromPeer(signal:signal.Message) :void;
+  signalsForPeer :handler.QueueHandler<signal.Message, void>;
+
+  bytesReceivedFromPeer :handler.QueueHandler<number, void>;
+  bytesSentToPeer :handler.QueueHandler<number, void>;
+
+  onceStopped :Promise<void>;
+}
+
+export = TransportToNet;

--- a/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
@@ -1,6 +1,7 @@
 /// <reference path='../../../../third_party/freedom-typings/freedom-common.d.ts' />
 
 import peerconnection = require('../../../../third_party/uproxy-lib/webrtc/peerconnection');
+import signal = require('../../../../third_party/uproxy-lib/webrtc/signal');
 import churn_types = require('../../churn/churn.types');
 import ChurnSignallingMessage = churn_types.ChurnSignallingMessage;
 import churn = require('../../churn/churn');
@@ -20,15 +21,15 @@ export var pc = new churn.Connection(freedomPc);
 export var freedomParentModule = freedom();
 
 // Forward signalling channel messages to the UI.
-pc.signalForPeerQueue.setSyncHandler((signal:peerconnection.SignallingMessage) => {
+pc.signalForPeerQueue.setSyncHandler((message:signal.Message) => {
   // FIXME: Does signalForPeer want a ChurnSignallingMessage?  How is the stage
   // value supposed to get filled in.
-  freedomParentModule.emit('signalForPeer', signal);
+  freedomParentModule.emit('signalForPeer', message);
 });
 
 // Receive signalling channel messages from the UI.
-freedomParentModule.on('handleSignalMessage', (signal:ChurnSignallingMessage) => {
-  pc.handleSignalMessage(signal);
+freedomParentModule.on('handleSignalMessage', (message:ChurnSignallingMessage) => {
+  pc.handleSignalMessage(message);
 });
 
 pc.onceConnecting.then(() => { log.info('connecting...'); });

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -7,7 +7,7 @@ import arraybuffers = require('../../../../third_party/uproxy-lib/arraybuffers/a
 import rtc_to_net = require('../../rtc-to-net/rtc-to-net');
 import socks_to_rtc = require('../../socks-to-rtc/socks-to-rtc');
 import net = require('../../net/net.types');
-import peerconnection = require('../../../../third_party/uproxy-lib/webrtc/peerconnection');
+import signal = require('../../../../third_party/uproxy-lib/webrtc/signal');
 
 import logging = require('../../../../third_party/uproxy-lib/logging/logging');
 
@@ -76,7 +76,7 @@ parentModule.on('start', () => {
     parentModule.emit('proxyingStopped');
   });
 
-  socksRtc.start(
+  socksRtc.startFromConfig(
       localhostEndpoint,
       pcConfig,
       false) // obfuscate
@@ -95,22 +95,21 @@ parentModule.on('start', () => {
 // Messages are dispatched to either the socks-to-rtc or rtc-to-net
 // modules depending on whether we're acting as the frontend or backend,
 // respectively.
-parentModule.on('handleSignalMessage', (signal:peerconnection.SignallingMessage) => {
+parentModule.on('handleSignalMessage', (message:signal.Message) => {
   if (socksRtc !== undefined) {
-    socksRtc.handleSignalFromPeer(signal);
+    socksRtc.handleSignalFromPeer(message);
   } else {
     if (rtcNet === undefined) {
-      rtcNet = new rtc_to_net.RtcToNet(
+      rtcNet = new rtc_to_net.RtcToNet();
+      rtcNet.startFromConfig(
+          { allowNonUnicast:true },
           pcConfig,
-          {
-            allowNonUnicast:true
-          },
           false); // obfuscate
       log.info('created rtc-to-net');
 
       // Forward signalling channel messages to the UI.
-      rtcNet.signalsForPeer.setSyncHandler((signal:peerconnection.SignallingMessage) => {
-          parentModule.emit('signalForPeer', signal);
+      rtcNet.signalsForPeer.setSyncHandler((message:signal.Message) => {
+          parentModule.emit('signalForPeer', message);
       });
 
       // Similarly to with SocksToRtc, emit the number of bytes sent/received
@@ -128,11 +127,11 @@ parentModule.on('handleSignalMessage', (signal:peerconnection.SignallingMessage)
         parentModule.emit('proxyingStarted', null);
       });
 
-      rtcNet.onceClosed.then(() => {
+      rtcNet.onceStopped.then(() => {
         parentModule.emit('proxyingStopped');
       });
     }
-    rtcNet.handleSignalFromPeer(signal);
+    rtcNet.handleSignalFromPeer(message);
   }
 });
 
@@ -166,6 +165,6 @@ parentModule.on('stop', () => {
   if (socksRtc !== undefined) {
     socksRtc.stop();
   } else if (rtcNet !== undefined) {
-    rtcNet.close();
+    rtcNet.stop();
   }
 });

--- a/src/samples/copypaste-socks-chromeapp/main.core-env.ts
+++ b/src/samples/copypaste-socks-chromeapp/main.core-env.ts
@@ -5,7 +5,7 @@
 /// <reference path='../../../../third_party/freedom-typings/freedom-core-env.d.ts' />
 
 import arraybuffers = require('../../../../third_party/uproxy-lib/arraybuffers/arraybuffers');
-import peerconnection = require('../../../../third_party/uproxy-lib/webrtc/peerconnection');
+import signal = require('../../../../third_party/uproxy-lib/webrtc/signal');
 import freedom_types = require('freedom.types');
 import net = require('../../net/net.types');
 import copypaste_api = require('./copypaste-api');
@@ -19,7 +19,7 @@ module copypaste_module {
       }).then((copypasteSocksFactory:() => freedom_types.OnAndEmit<any,any>) => {
     var copypaste :freedom_types.OnAndEmit<any,any> = copypasteSocksFactory();
 
-    copypaste.on('signalForPeer', (signal:peerconnection.SignallingMessage) => {
+    copypaste.on('signalForPeer', (message:signal.Message) => {
       model.readyForStep2 = true;
 
       // Append the new signalling message to the previous message(s), if any.
@@ -28,7 +28,7 @@ module copypaste_module {
       // into emoticons, whereas the base64 alphabet is much less prone to such
       // unintended transformation.
       var oldConcatenatedJson = base64Decode(model.outboundMessageValue.trim());
-      var newConcatenatedJson = oldConcatenatedJson + '\n' + JSON.stringify(signal);
+      var newConcatenatedJson = oldConcatenatedJson + '\n' + JSON.stringify(message);
       if (model.usingCrypto) {
         copypaste.emit('friendKey', model.friendPublicKey);
         copypaste.emit('signEncrypt', base64Encode(newConcatenatedJson));
@@ -95,7 +95,7 @@ module copypaste_module {
 
   // Stores the parsed messages for use later, if & when the user clicks the
   // button for consuming the messages.
-  var parsedInboundMessages :peerconnection.SignallingMessage[];
+  var parsedInboundMessages :signal.Message[];
 
 
   // Define basee64 helper functions that are type-annotated and meaningfully
@@ -124,22 +124,22 @@ module copypaste_module {
 
     var signals :string[] = signalsString.trim().split('\n');
 
-    // Each line should be a JSON representation of a peerconnection.SignallingMessage.
+    // Each line should be a JSON representation of a signal.Message.
     // Parse the lines here.
-    var parsedSignals :peerconnection.SignallingMessage[] = [];
+    var parsedSignals :signal.Message[] = [];
     for (var i = 0; i < signals.length; i++) {
       var s :string = signals[i].trim();
 
       // TODO: Consider detecting the error if the text is well-formed JSON but
-      // does not represent a peerconnection.SignallingMessage.
-      var signal :peerconnection.SignallingMessage;
+      // does not represent a signal.Message.
+      var message :signal.Message;
       try {
-        signal = JSON.parse(s);
+        message = JSON.parse(s);
       } catch (e) {
         parsedSignals = null;
         break;
       }
-      parsedSignals.push(signal);
+      parsedSignals.push(message);
     }
 
     // Enable/disable, as appropriate, the button for consuming the messages.

--- a/src/simple-socks/freedom-module.ts
+++ b/src/simple-socks/freedom-module.ts
@@ -1,8 +1,6 @@
 /// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
 /// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
 
-import peerconnection = require('../../../third_party/uproxy-lib/webrtc/peerconnection');
-
 import rtc_to_net = require('../rtc-to-net/rtc-to-net');
 import socks_to_rtc = require('../socks-to-rtc/socks-to-rtc');
 import net = require('../net/net.types');
@@ -35,17 +33,13 @@ var pcConfig :freedom_RTCPeerConnection.RTCConfiguration = {
                {urls: ['stun:stun1.l.google.com:19302']}]
 };
 
-export var rtcNet = new rtc_to_net.RtcToNet(
-    pcConfig,
-    {
-      allowNonUnicast: true
-    },
-    true); // obfuscate
+export var rtcNet = new rtc_to_net.RtcToNet();
+rtcNet.startFromConfig({ allowNonUnicast: true }, pcConfig, true); // obfuscate
 
 //-----------------------------------------------------------------------------
 export var socksRtc = new socks_to_rtc.SocksToRtc();
 socksRtc.on('signalForPeer', rtcNet.handleSignalFromPeer);
-socksRtc.start(
+socksRtc.startFromConfig(
     localhostEndpoint,
     pcConfig,
     true) // obfuscate

--- a/src/socks-to-rtc/socks-to-transport.interface.ts
+++ b/src/socks-to-rtc/socks-to-transport.interface.ts
@@ -1,0 +1,27 @@
+// The typescript description of the stub that is provided for a consumer of
+// freedom-module.json
+
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-common.d.ts' />
+/// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
+
+import signal = require('../../../third_party/uproxy-lib/webrtc/signal');
+import net = require('../net/net.types');
+
+interface SocksToTransport {
+  startFromConfig(
+    localSocksServerEndpoint :net.Endpoint,
+    transportConfig :freedom_RTCPeerConnection.RTCConfiguration,
+    obfuscate ?:boolean) :Promise<net.Endpoint>;
+  stop() :Promise<void>;
+
+  handleSignalFromPeer(message:signal.Message) :void;
+
+  on(t:string, f:(...args:Object[]) => void) :void;
+  on(t:'signalForPeer', f:(message:signal.Message) => void) :void;
+  on(t:'bytesSentToPeer', f:(n:number) => void) :void;
+  on(t:'bytesReceivedFromPeer', f:(n:number) => void) :void;
+  on(t:'stopped', f:() => void) :void;
+}
+
+export = SocksToTransport;


### PR DESCRIPTION
to be reviewed after: https://github.com/uProxy/uproxy-lib/pull/146 Also worth a discussion; this is the quick and simple way to do the freedom moduleification; it results in more, but simpler code than the approach in socks-rtc. I'd like to discuss the two approaches various merits and long term strategy for this stuff. Especially because I think the better longer term approach is probably to separate out the transport part into its own module (that's the bit we actually want to be swappable).
- Provides a freedom module for rtc-to-net
- Uses the signal structure instead of peerconnection to improve browserified imports. 
- Update to using uproxy-lib v23
- Various comment tweaks, and package dependency minimizations
- Adds a `dist` build for uproxy-networking

TESTED: 
- grunt test
- Manually run the sample apps

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/224)

<!-- Reviewable:end -->
