### PR TITLE
move to return-promise-on-close versions of uproxy-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"
@@ -42,7 +42,7 @@
     "socks5-http-client": "^0.1.6",
     "tsd": "^0.5.7",
     "typescript": "^1.4.1",
-    "uproxy-lib": "^20.1.0",
+    "uproxy-lib": "^22.0.0",
     "utransformers": "^0.2.1",
     "wup": "^1.0.0",
     "yargs": "^3.0.4"

--- a/src/churn/churn.ts
+++ b/src/churn/churn.ts
@@ -474,8 +474,8 @@ var log :logging.Log = new logging.Log('churn');
       return this.obfuscatedConnection_.openDataChannel(channelLabel);
     }
 
-    public close = () : void => {
-      this.obfuscatedConnection_.close();
+    public close = () : Promise<void> => {
+      return this.obfuscatedConnection_.close();
     }
 
     public toString = () : string => {


### PR DESCRIPTION
Just a couple of simple updates se we can make use of:
- https://github.com/uProxy/uproxy-lib/pull/150
- https://github.com/uProxy/uproxy-lib/pull/149

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/229)

<!-- Reviewable:end -->
