### PR TITLE
Gruntfile tweak

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -35,7 +35,7 @@ taskManager.add 'integration', [
 ]
 
 taskManager.add 'dist', [
-  'base', 'samples', 'test', 'integration', 'copy:dist'
+  'base', 'samples', 'test', 'copy:dist', 'integration'
 ]
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Fix to avoid grunt-jasmine-chromeapp race condition (it exits before it has really finished, which resulted in copy:dist rule failing). This is better anyway as it gives a dist directory independently of integration tests passing/failing (which is occasionally useful)

TESTED: 
- grunt dist

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/237)

<!-- Reviewable:end -->
