### PR TITLE
Never close an RTCDataChannel

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -128,7 +128,6 @@ taskManager.add 'socksEchoIntegrationTestModule', [
 taskManager.add 'socksEchoIntegrationTest', [
   'socksEchoIntegrationTestModule'
   'jasmine_chromeapp:socksEcho'
-  #'jasmine_chromeapp:socksEchoChurn'
 ]
 
 taskManager.add 'tcpIntegrationTestModule', [
@@ -511,23 +510,7 @@ module.exports = (grunt) ->
         files: [
           {
             cwd: devBuildPath + '/integration-tests/socks-echo/',
-            src: ['**/*', '!jasmine_chromeapp/**/*']
-            dest: './',
-            expand: true
-          }
-        ]
-        scripts: [
-          'freedom-for-chrome/freedom-for-chrome.js'
-          'nochurn.core-env.spec.static.js'
-        ]
-        options:
-          outDir: devBuildPath + '/integration-tests/socks-echo/jasmine_chromeapp/'
-          keepRunner: false
-      socksEchoChurn:
-        files: [
-          {
-            cwd: devBuildPath + '/integration-tests/socks-echo/',
-            src: ['**/*', '!jasmine_chromeapp/**/*']
+            src: ['**/*', '!jasmine_chromeapp*/**']
             dest: './',
             expand: true
           }
@@ -535,6 +518,7 @@ module.exports = (grunt) ->
         scripts: [
           'freedom-for-chrome/freedom-for-chrome.js'
           'churn.core-env.spec.static.js'
+          'nochurn.core-env.spec.static.js'
         ]
         options:
           outDir: devBuildPath + '/integration-tests/socks-echo/jasmine_chromeapp/'
@@ -543,7 +527,7 @@ module.exports = (grunt) ->
         files: [
           {
             cwd: devBuildPath + '/integration-tests/socks-echo/',
-            src: ['**/*', '!jasmine_chromeapp']
+            src: ['**/*', '!jasmine_chromeapp*/**']
             dest: '/uproxy-networking/',
             expand: true
           }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "8.0.3",
+  "version": "9.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/churn-pipe/freedom-module.json
+++ b/src/churn-pipe/freedom-module.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "logginglistener": {
-      "url": "uproxy-lib/loggingprovider/freedom-module.json",
+      "url": "../../uproxy-lib/loggingprovider/freedom-module.json",
       "api": "logginglistener"
     }
   },

--- a/src/pool/pool.ts
+++ b/src/pool/pool.ts
@@ -1,0 +1,327 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+
+// This module provides a pool for managing data channels.  It mimics the
+// interface for creating data channels in uproxy-lib's PeerConnection,
+// but the channel objects it produces are actually "virtual channels",
+// which wrap an actual DataChannel.  The key difference is that when the
+// virtual channel is closed, the underlying DataChannel remains open, and
+// is returned to the pool, to be released again upon a later call to
+// CreateDataChannel.
+
+// This class was written principally as a workaround for bugs related to
+// RTCDataChannel.close behavior, such as https://crbug.com/474688.
+// However, it should also help to reduce startup latency, by removing a
+// roundtrip from each connection request (waiting for the "open ack").
+// It may therefore be worth preserving even after any platform bugs are
+// resolved.
+
+import peerconnection = require('../../../third_party/uproxy-lib/webrtc/peerconnection');
+import datachannel = require('../../../third_party/uproxy-lib/webrtc/datachannel');
+import handler = require('../../../third_party/uproxy-lib/handler/queue');
+import queue = require('../../../third_party/uproxy-lib/queue/queue');
+
+import logging = require('../../../third_party/uproxy-lib/logging/logging');
+
+var log :logging.Log = new logging.Log('pool');
+
+// This is the only exported class in this module.  It mimics the data channel
+// aspects of the PeerConnection interface.  Internally, it provides a pool
+// of channels that keeps old channels for reuse instead of closing them, and
+// makes new channels as needed when the pool runs dry.  Crucially, the local
+// and remote pools do not interfere with each other, even if they use the
+// same labels, because the browser ensures that data channels created by each
+// peer are drawn from separate ID spaces (odd vs. even).
+class Pool {
+  public peerOpenedChannelQueue
+      :handler.QueueHandler<datachannel.DataChannel, void>;
+
+  private localPool_ :LocalPool;
+
+  constructor(
+      pc:peerconnection.PeerConnection<Object>,
+      name_:string) {
+    this.localPool_ = new LocalPool(pc, name_);
+    var remotePool = new RemotePool(pc, name_);
+    this.peerOpenedChannelQueue = remotePool.peerOpenedChannelQueue;
+  }
+
+  public openDataChannel = () : Promise<datachannel.DataChannel> => {
+    return this.localPool_.openDataChannel();
+  }
+}
+
+// Manages a pool of data channels opened by this peer.  The only public method
+// is openDataChannel.
+class LocalPool {
+  private numChannels_ = 0;
+
+  // Channels which have been closed, and may be re-opened.
+  private pool_ = new queue.Queue<PoolChannel>();
+
+  constructor(
+      private pc_:peerconnection.PeerConnection<Object>,
+      private name_:string) {}
+
+  public openDataChannel = () : Promise<PoolChannel> => {
+    return this.reuseOrCreate_().then((channel:PoolChannel) => {
+      return channel.open().then(() => {
+        // When this channel closes, reset it and return it to the pool.
+        channel.onceClosed.then(() => {
+          this.onChannelClosed_(channel);
+        });
+        return channel;
+      });
+    });
+  }
+
+  private reuseOrCreate_ = () : Promise<PoolChannel> => {
+    // If there are no channels available right now, open a new one.
+    // TODO: limit the number of channels (probably should be <=256).
+    if (this.pool_.length > 0) {
+      var channel = this.pool_.shift();
+      log.debug('%1: channel requested, pulled %2 from pool (%3 remaining)',
+          this.name_, channel.getLabel(), this.pool_.length);
+      return Promise.resolve(channel);
+    } else {
+      log.debug('%1: channel requested, creating new', this.name_);
+      return this.openNewChannel_();
+    }
+  }
+
+  // Creates and returns a new channel, wrapping it.
+  private openNewChannel_ = () : Promise<PoolChannel> => {
+    return this.pc_.openDataChannel('p' + this.numChannels_++).
+        then((dc:datachannel.DataChannel) => {
+          return dc.onceOpened.then(() => {
+            return new PoolChannel(dc);
+          });
+        });
+  }
+
+  // Resets the channel, making it ready for use again, and adds it
+  // to the pool.
+  private onChannelClosed_ = (poolChannel:PoolChannel) : void => {
+    poolChannel.reset();
+    this.pool_.push(poolChannel);
+    log.debug('%1: returned channel %2 to the pool (new size: %3)',
+        this.name_, poolChannel.getLabel(), this.pool_.length);
+  }
+}
+
+// Tracks a pool of channels that were opened by the remote peer.
+class RemotePool {
+  public peerOpenedChannelQueue = new handler.Queue<PoolChannel,void>();
+
+  constructor(
+      private pc_:peerconnection.PeerConnection<Object>,
+      private name_:string) {
+    this.pc_.peerOpenedChannelQueue.setSyncHandler(this.onNewChannel_);
+  }
+
+  private onNewChannel_ = (dc:datachannel.DataChannel) => {
+    log.debug('%1: remote side created new channel: %2',
+        this.name_, dc.getLabel());
+    dc.onceOpened.then(() => {
+      var poolChannel = new PoolChannel(dc);
+      this.listenForOpenAndClose_(poolChannel);
+    });
+  }
+
+  private listenForOpenAndClose_ = (poolChannel:PoolChannel) : void => {
+    poolChannel.onceOpened.then(() => {
+      this.peerOpenedChannelQueue.handle(poolChannel);
+    });
+    poolChannel.onceClosed.then(() => {
+      poolChannel.reset();
+      this.listenForOpenAndClose_(poolChannel);
+    });
+  }
+}
+
+// These are the two control messages used.  To help debugging, and
+// improve forward-compatibility, we send the string name on the wire,
+// not the numerical enum value.  Therefore, these names are part of
+// the normative protocol, and will break compatibility if changed.
+enum ControlMessage {
+  OPEN,
+  CLOSE
+}
+
+enum State {
+  OPEN,
+  CLOSING,  // Waiting for CLOSE ack
+  CLOSED
+}
+
+// Each PoolChannel wraps an actual DataChannel, and provides behavior
+// that is intended to be indistinguishable to the caller.  However,
+// close() does not actually close the underlying channel.  Instead,
+// it sends an in-band control message indicating the close, and the
+// channel is returned to the pool of inactive channels, ready for
+// reuse when the client asks for a new channel.
+class PoolChannel implements datachannel.DataChannel {
+  private fulfillOpened_ :() => void;
+  public onceOpened : Promise<void>;
+
+  private fulfillClosed_ :() => void;
+  public onceClosed : Promise<void>;
+
+  // Every call to dataFromPeerQueue.handle() must also set
+  // lastDataFromPeerHandled_ to the new return value, so that we can
+  // tell when all pending data from the peer has been drained.
+  public dataFromPeerQueue :handler.Queue<datachannel.Data,void>;
+  private lastDataFromPeerHandled_ : Promise<void>;
+
+  private state_ :State;
+
+  // dc_.onceOpened must already have resolved
+  constructor(private dc_:datachannel.DataChannel) {
+    this.reset();
+    this.dc_.dataFromPeerQueue.setSyncHandler(this.onDataFromPeer_);
+  }
+
+  public reset = () => {
+    this.dataFromPeerQueue = new handler.Queue<datachannel.Data,void>();
+    this.lastDataFromPeerHandled_ = Promise.resolve<void>();
+    this.onceOpened = new Promise<void>((F, R) => {
+      this.fulfillOpened_ = F;
+    });
+    this.onceClosed = new Promise<void>((F, R) => {
+      this.fulfillClosed_ = F;
+    });
+
+    this.state_ = State.CLOSED;
+    this.onceOpened.then(() => {
+      this.state_ = State.OPEN;
+    });
+    this.onceClosed.then(() => {
+      this.state_ = State.CLOSED;
+    });
+  }
+
+  public getLabel = () : string => {
+    return this.dc_.getLabel();
+  }
+
+  public send = (data:datachannel.Data) : Promise<void> => {
+    if (this.state_ !== State.OPEN) {
+      return Promise.reject(new Error('Can\'t send while closed'));
+    }
+
+    // To distinguish control messages from application data, all string
+    // messages are encapsulated in a JSON layer. Binary messages are unaffected.
+    if (data.str) {
+      return this.dc_.send({
+        str: JSON.stringify({
+          data: data.str
+        })
+      });
+    }
+    return this.dc_.send(data);
+  }
+
+  private sendControlMessage_ = (controlMessage:ControlMessage) : Promise<void> => {
+    log.debug('%1: sending control message: %2',
+              this.getLabel(), ControlMessage[controlMessage]);
+    return this.dc_.send({
+      str: JSON.stringify({
+        control: ControlMessage[controlMessage]
+      })
+    });
+  }
+
+  private onDataFromPeer_ = (data:datachannel.Data) : void => {
+    if (data.str) {
+      try {
+        var msg = JSON.parse(data.str);
+      } catch (e) {
+        log.error('%1: Got non-JSON string: %2', this.getLabel(), data.str);
+        return;
+      }
+      if (typeof msg.data === 'string') {
+        this.lastDataFromPeerHandled_ =
+            this.dataFromPeerQueue.handle({str: msg.data});
+      } else if (typeof msg.control === 'string') {
+        this.onControlMessage_(msg.control);
+      } else {
+        log.error('No data or control message found');
+      }
+      return;
+    }
+    this.lastDataFromPeerHandled_ = this.dataFromPeerQueue.handle(data);
+  }
+
+  private onControlMessage_ = (controlMessage:string) : void => {
+    log.debug('%1: received control message: %2',
+              this.getLabel(), controlMessage);
+    if (controlMessage === ControlMessage[ControlMessage.OPEN]) {
+      if (this.state_ === State.OPEN) {
+        log.warn('%1: Got redundant open message', this.getLabel());
+      }
+      this.fulfillOpened_();
+    } else if (controlMessage === ControlMessage[ControlMessage.CLOSE]) {
+      if (this.state_ === State.OPEN) {
+        this.state_ = State.CLOSING;
+        // Drain messages, then ack the close.
+        this.lastDataFromPeerHandled_.then(() => {
+          return this.sendControlMessage_(ControlMessage.CLOSE);
+        }).then(this.fulfillClosed_);
+      } else if (this.state_ === State.CLOSING) {
+        // We both sent a "close" command at the same time.
+        this.fulfillClosed_();
+      } else if (this.state_ === State.CLOSED) {
+        log.warn('%1: Got redundant close message', this.getLabel());
+      }
+    } else {
+      log.error('%1: unknown control message: %2',
+          this.getLabel(), controlMessage);
+    }
+  }
+
+  public getBrowserBufferedAmount = () : Promise<number> => {
+    return this.dc_.getBrowserBufferedAmount();
+  }
+
+  public getJavascriptBufferedAmount = () : number => {
+    return this.dc_.getJavascriptBufferedAmount();
+  }
+
+  public isInOverflow = () : boolean => {
+    return this.dc_.isInOverflow();
+  }
+
+  public setOverflowListener = (listener:(overflow:boolean) => void) : void => {
+    this.dc_.setOverflowListener(listener);
+  }
+
+  // New method for PoolChannel, not present in the DataChannel interface.
+  public open = () : Promise<void> => {
+    log.debug(this.getLabel() + ': open');
+    if (this.state_ === State.OPEN) {
+      return Promise.reject(new Error('channel is already open'));
+    }
+
+    this.sendControlMessage_(ControlMessage.OPEN);
+    // Immediate open; there is no open-ack
+    this.fulfillOpened_();
+
+    return this.onceOpened;
+  }
+
+  public close = () : Promise<void> => {
+    log.debug('%1: close', this.getLabel());
+    if (this.state_ !== State.OPEN) {
+      return;
+    }
+    this.state_ = State.CLOSING;
+
+    this.sendControlMessage_(ControlMessage.CLOSE);
+    return this.onceClosed;
+  }
+
+  public toString = () : string => {
+    return 'PoolChannel(' + this.dc_.toString() + ')';
+  }
+}
+
+export = Pool;

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -19,6 +19,7 @@ import churn = require('../churn/churn');
 import net = require('../net/net.types');
 import tcp = require('../net/tcp');
 import socks = require('../socks-common/socks-headers');
+import Pool = require('../pool/pool');
 
 import logging = require('../../../third_party/uproxy-lib/logging/logging');
 
@@ -105,6 +106,9 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
     private peerConnection_
         :peerconnection.PeerConnection<signals.Message> = null;
 
+    // This pool manages the data channels for the PeerConnection.
+    private pool_ :Pool;
+
     // The |sessions_| map goes from WebRTC data-channel labels to the Session.
     // Most of the wiring to manage this relationship happens via promises. We
     // need this only for data being received from a peer-connection data
@@ -142,10 +146,11 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
         throw new Error('already configured');
       }
       this.peerConnection_ = peerconnection;
+      this.pool_ = new Pool(peerconnection, 'RtcToNet');
       this.proxyConfig = proxyConfig;
 
       this.signalsForPeer = this.peerConnection_.signalForPeerQueue;
-      this.peerConnection_.peerOpenedChannelQueue.setSyncHandler(
+      this.pool_.peerOpenedChannelQueue.setSyncHandler(
           this.onPeerOpenedChannel_);
 
       // TODO: this.onceReady should reject if |this.onceStopping_|
@@ -275,10 +280,6 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
   export class Session {
     private tcpConnection_ :tcp.Connection;
 
-    // TODO: There's no equivalent of datachannel.isClosed():
-    //         https://github.com/uProxy/uproxy/issues/1075
-    private isChannelClosed_ :boolean = false;
-
     // Fulfills once a connection has been established with the remote peer.
     // Rejects if a connection cannot be made for any reason.
     public onceReady :Promise<void>;
@@ -343,15 +344,15 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
 
       this.onceReady.then(this.linkSocketAndChannel_, this.fulfillStopping_);
 
-      // Shutdown once the data channel terminates and has drained.
+      // Shutdown once the data channel terminates.
       this.dataChannel_.onceClosed.then(() => {
-        this.isChannelClosed_ = true;
-        if (this.dataChannel_.dataFromPeerQueue.getLength() === 0) {
-          log.info('%1: channel closed, all incoming data processed', this.longId());
-          this.fulfillStopping_();
+        if (this.dataChannel_.dataFromPeerQueue.getLength() > 0) {
+          log.warn('%1: channel closed with %2 unprocessed incoming messages',
+              this.longId(), this.dataChannel_.dataFromPeerQueue.getLength());
         } else {
-          log.info('%1: channel closed, still processing incoming data', this.longId());
+          log.info('%1: channel closed', this.longId());
         }
+        this.fulfillStopping_();
       });
 
       this.onceStopped_ = this.onceStopping_.then(this.stopResources_);
@@ -486,9 +487,6 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
     // Sends a packet over the data channel.
     // Invoked when a packet is received over the TCP socket.
     private sendOnChannel_ = (data:ArrayBuffer) : Promise<void> => {
-      log.debug('%1: socket received %2 bytes', [
-          this.longId(),
-          data.byteLength]);
       this.socketReceivedBytes_ += data.byteLength;
 
       return this.dataChannel_.send({buffer: data});
@@ -502,9 +500,6 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
         return Promise.reject(new Error(
             'received non-buffer data from datachannel'));
       }
-      log.debug('%1: datachannel received %2 bytes', [
-          this.longId(),
-          data.buffer.byteLength]);
       this.bytesReceivedFromPeer_.handle(data.buffer.byteLength);
       this.channelReceivedBytes_ += data.buffer.byteLength;
 
@@ -540,24 +535,9 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
         this.fulfillStopping_();
       });
 
-      // Session.nextTick_ (i.e. setTimeout) is used to preserve system
-      // responsiveness when large amounts of data are being sent:
-      //   https://github.com/uProxy/uproxy/issues/967
-      var channelReadLoop = (data:peerconnection.Data) : void => {
+      var channelReader = (data:peerconnection.Data) : void => {
         this.sendOnSocket_(data).then((writeInfo:freedom_TcpSocket.WriteInfo) => {
           this.socketSentBytes_ += data.buffer.byteLength;
-          // Shutdown once the data channel terminates and has drained,
-          // otherwise keep draining.
-          if (this.isChannelClosed_ &&
-              this.dataChannel_.dataFromPeerQueue.getLength() === 0) {
-            log.info('%1: channel drained', this.longId());
-            this.fulfillStopping_();
-          } else {
-            Session.nextTick_(() => {
-              this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
-                  channelReadLoop);
-            });
-          }
         }, (e:{ errcode: string }) => {
           // TODO: e is actually a freedom.Error (uproxy-lib 20+)
           // errcode values are defined here:
@@ -575,8 +555,7 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
           }
         });
       };
-      this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
-          channelReadLoop);
+      this.dataChannel_.dataFromPeerQueue.setSyncHandler(channelReader);
 
       // The TCP connection starts in the paused state.  However, in extreme
       // cases, enough data can arrive before the pause takes effect to put

--- a/src/socks-to-rtc/socks-to-rtc.spec.ts
+++ b/src/socks-to-rtc/socks-to-rtc.spec.ts
@@ -73,6 +73,7 @@ describe('SOCKS server', function() {
 
     mockPeerConnection = <any>{
       dataChannels: {},
+      peerOpenedChannelQueue: new handler.Queue<signals.Message, void>(),
       signalForPeerQueue: new handler.Queue<signals.Message, void>(),
       negotiateConnection: jasmine.createSpy('negotiateConnection'),
       onceConnecting: noopPromise,


### PR DESCRIPTION
This branch moves to managing DataChannels as a reusable pool.  Once a channel is open, it stays open, and may be reused for multiple connections over time.  The pool grows as needed to serve all simultaneously active connections.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/241)

<!-- Reviewable:end -->
