### PR TITLE
fix bad style for freedom module creation

### DIFF
--- a/src/echo/freedom-module.ts
+++ b/src/echo/freedom-module.ts
@@ -10,8 +10,9 @@ import net = require('../net/net.types');
 import loggingTypes = require('../../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
 
 // Example of how to add custom setting for the logging controller's filtering.
-freedom['loggingcontroller']().setDefaultFilter(loggingTypes.Destination.console,
-                                                loggingTypes.Level.debug);
+var loggingController = freedom['loggingcontroller']();
+loggingController.setDefaultFilter(loggingTypes.Destination.console,
+                                   loggingTypes.Level.debug);
 
 // The underlying TCP echo server.
 var tcpServer :TcpEchoServer;

--- a/src/integration-tests/socks-echo/freedom-module.ts
+++ b/src/integration-tests/socks-echo/freedom-module.ts
@@ -6,8 +6,9 @@ import loggingTypes = require('../../../../third_party/uproxy-lib/loggingprovide
 
 // Example of how to set custom logging level: we set everything to debug for
 // testing echo server.
-freedom['loggingcontroller']().setDefaultFilter(loggingTypes.Destination.console,
-                                                loggingTypes.Level.debug);
+var loggingController = freedom['loggingcontroller']();
+loggingController.setDefaultFilter(loggingTypes.Destination.console,
+                                   loggingTypes.Level.debug);
 
 if (typeof freedom !== 'undefined') {
   freedom().providePromises(ProxyIntegrationTestClass);

--- a/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-churn-chat-chromeapp/freedom-module.ts
@@ -8,8 +8,9 @@ import churn = require('../../churn/churn');
 
 import loggingTypes = require('../../../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
 
-freedom['loggingcontroller']().setDefaultFilter(loggingTypes.Destination.console,
-                                                loggingTypes.Level.debug);
+var loggingController = freedom['loggingcontroller']();
+loggingController.setDefaultFilter(loggingTypes.Destination.console,
+                                   loggingTypes.Level.debug);
 
 import logging = require('../../../../third_party/uproxy-lib/logging/logging');
 var log :logging.Log = new logging.Log('copypaste churn chat');

--- a/src/samples/copypaste-socks-chromeapp/freedom-module.ts
+++ b/src/samples/copypaste-socks-chromeapp/freedom-module.ts
@@ -16,9 +16,12 @@ import loggingTypes = require('../../../../third_party/uproxy-lib/loggingprovide
 // you're debugging. Since the proxy outputs quite a lot of messages, show only
 // warnings by default from the rest of the system.  Note that the proxy is
 // extremely slow in debug mode.
-freedom['loggingcontroller']().setDefaultFilter(loggingTypes.Destination.console,
-                                                loggingTypes.Level.info);
-freedom['loggingcontroller']().setFilters(loggingTypes.Destination.console, {
+var loggingController = freedom['loggingcontroller']();
+
+loggingController.setDefaultFilter(loggingTypes.Destination.console,
+                                   loggingTypes.Level.info);
+
+loggingController.setFilters(loggingTypes.Destination.console, {
   'SocksToRtc': loggingTypes.Level.info,
   'RtcToNet': loggingTypes.Level.info
 });

--- a/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
+++ b/src/samples/simple-churn-chat-chromeapp/freedom-module.ts
@@ -10,9 +10,11 @@ import ChurnSignallingMessage = churn_types.ChurnSignallingMessage;
 
 import logging = require('../../../../third_party/uproxy-lib/logging/logging');
 
-// Example of how to configure logging level
-// freedom['loggingcontroller']().setDefaultFilter(loggingTypes.Destination.console,
-//     loggingTypes.Level.info);
+// Example of how to configure logging level:
+//
+//   var loggingController = freedom['loggingcontroller']();
+//   loggingController.setDefaultFilter(loggingTypes.Destination.console,
+//                                      loggingTypes.Level.info);
 
 export var log :logging.Log = new logging.Log('simple churn chat');
 

--- a/src/samples/simple-turn-chromeapp/freedom-module.ts
+++ b/src/samples/simple-turn-chromeapp/freedom-module.ts
@@ -10,8 +10,9 @@ import net = require('../../net/net.types');
 import logging = require('../../../../third_party/uproxy-lib/logging/logging');
 import loggingTypes = require('../../../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
 
-freedom['loggingcontroller']().setDefaultFilter(loggingTypes.Destination.console,
-                                                loggingTypes.Level.info);
+var loggingController = freedom['loggingcontroller']();
+loggingController = setDefaultFilter(loggingTypes.Destination.console,
+                                     loggingTypes.Level.info);
 
 var log :logging.Log = new logging.Log('simple TURN');
 

--- a/src/samples/simple-turn-chromeapp/freedom-module.ts
+++ b/src/samples/simple-turn-chromeapp/freedom-module.ts
@@ -11,8 +11,9 @@ import logging = require('../../../../third_party/uproxy-lib/logging/logging');
 import loggingTypes = require('../../../../third_party/uproxy-lib/loggingprovider/loggingprovider.types');
 
 var loggingController = freedom['loggingcontroller']();
-loggingController = setDefaultFilter(loggingTypes.Destination.console,
-                                     loggingTypes.Level.info);
+loggingController = loggingController.setDefaultFilter(
+    loggingTypes.Destination.console,
+    loggingTypes.Level.info);
 
 var log :logging.Log = new logging.Log('simple TURN');
 


### PR DESCRIPTION
This pull request fixes the object creation style for logging controllers. 

Context: Freedom module creation is an operation that requires cleanup. So it's better style to name the object that gets created so that you have the ability to clean it up, and so that you don't end up creating multiple stubs in memory (e.g. when you want to add more/different logging filters). 

This pull request is also helpful as it lets you find the appropriate object in the webworker in case you want to interactively set/change filter levels. 

TESTED: 
grunt dist

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/245)

<!-- Reviewable:end -->
