### PR TITLE
remove last remnants of nextTick hack

### DIFF
--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -280,10 +280,6 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
   export class Session {
     private tcpConnection_ :tcp.Connection;
 
-    // TODO: There's no equivalent of datachannel.isClosed():
-    //         https://github.com/uProxy/uproxy/issues/1075
-    private isChannelClosed_ :boolean = false;
-
     // Fulfills once a connection has been established with the remote peer.
     // Rejects if a connection cannot be made for any reason.
     public onceReady :Promise<void>;
@@ -348,15 +344,10 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
 
       this.onceReady.then(this.linkSocketAndChannel_, this.fulfillStopping_);
 
-      // Shutdown once the data channel terminates and has drained.
+      // Shutdown once the data channel terminates.
       this.dataChannel_.onceClosed.then(() => {
-        this.isChannelClosed_ = true;
-        if (this.dataChannel_.dataFromPeerQueue.getLength() === 0) {
-          log.info('%1: channel closed, all incoming data processed', this.longId());
-          this.fulfillStopping_();
-        } else {
-          log.info('%1: channel closed, still processing incoming data', this.longId());
-        }
+        log.info('%1: channel closed', this.longId());
+        this.fulfillStopping_();
       });
 
       this.onceStopped_ = this.onceStopping_.then(this.stopResources_);
@@ -536,24 +527,9 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
         this.fulfillStopping_();
       });
 
-      // Session.nextTick_ (i.e. setTimeout) is used to preserve system
-      // responsiveness when large amounts of data are being sent:
-      //   https://github.com/uProxy/uproxy/issues/967
-      var channelReadLoop = (data:peerconnection.Data) : void => {
+      var channelReader = (data:peerconnection.Data) : void => {
         this.sendOnSocket_(data).then((writeInfo:freedom_TcpSocket.WriteInfo) => {
           this.socketSentBytes_ += data.buffer.byteLength;
-          // Shutdown once the data channel terminates and has drained,
-          // otherwise keep draining.
-          if (this.isChannelClosed_ &&
-              this.dataChannel_.dataFromPeerQueue.getLength() === 0) {
-            log.info('%1: channel drained', this.longId());
-            this.fulfillStopping_();
-          } else {
-            Session.nextTick_(() => {
-              this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
-                  channelReadLoop);
-            });
-          }
         }, (e:{ errcode: string }) => {
           // TODO: e is actually a freedom.Error (uproxy-lib 20+)
           // errcode values are defined here:
@@ -571,8 +547,7 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
           }
         });
       };
-      this.dataChannel_.dataFromPeerQueue.setSyncNextHandler(
-          channelReadLoop);
+      this.dataChannel_.dataFromPeerQueue.setSyncHandler(channelReader);
 
       // The TCP connection starts in the paused state.  However, in extreme
       // cases, enough data can arrive before the pause takes effect to put

--- a/src/rtc-to-net/rtc-to-net.ts
+++ b/src/rtc-to-net/rtc-to-net.ts
@@ -346,7 +346,12 @@ import logging = require('../../../third_party/uproxy-lib/logging/logging');
 
       // Shutdown once the data channel terminates.
       this.dataChannel_.onceClosed.then(() => {
-        log.info('%1: channel closed', this.longId());
+        if (this.dataChannel_.dataFromPeerQueue.getLength() > 0) {
+          log.warn('%1: channel closed with %2 unprocessed incoming messages',
+              this.longId(), this.dataChannel_.dataFromPeerQueue.getLength());
+        } else {
+          log.info('%1: channel closed', this.longId());
+        }
         this.fulfillStopping_();
       });
 

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -349,7 +349,12 @@ module SocksToRtc {
 
         // Shutdown once the data channel terminates.
         this.dataChannel_.onceClosed.then(() => {
-          log.info('%1: channel closed', this.longId());
+          if (this.dataChannel_.dataFromPeerQueue.getLength() > 0) {
+            log.warn('%1: channel closed with %2 unprocessed incoming messages',
+                this.longId(), this.dataChannel_.dataFromPeerQueue.getLength());
+          } else {
+            log.info('%1: channel closed', this.longId());
+          }
           this.fulfillStopping_();
         });
       }, this.fulfillStopping_);


### PR DESCRIPTION
This removes the last few remaining uses of `nextTick`. Testing locally, this just doesn't seem to be necessary anymore, even in the `dev` branch. I'm able to leave an ISO downloading in the background while browsing just fine.

I'm not sure exactly when this hack became obsolete - although TCP backpressure is the most likely candidate - but since we were hazy about why it ever worked in the first place, I'm more than happy to remove it -- especially since the raw download speed on my machine with this branch is >2x that of dev (~1900Kb/sec vs. ~850Kb/sec).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/246)

<!-- Reviewable:end -->
