### PR TITLE
add SocketCloseKind to TCP server onceClosed, with cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/echo/tcp-echo-server.ts
+++ b/src/echo/tcp-echo-server.ts
@@ -15,18 +15,16 @@ class TcpEchoServer {
   public static CTRL_D_HEX_STR_CODE = '4'
 
   constructor(public endpoint:net.Endpoint) {
-    log.info('Starting TcpEchoServer(' + JSON.stringify(endpoint) + ')...');
     this.server = new tcp.Server(endpoint);
 
     // Start listening to connections.
     this.server.listen().then((listeningEndpoint) => {
-      log.info('TCP echo server listening on ' +
-          JSON.stringify(listeningEndpoint));
-    })
-    .catch((e:Error) => {
-      log.error('Failed to listen to: ' + JSON.stringify(endpoint) +
-          e.toString);
-      this.server.shutdown();
+      log.info('listening on %1', listeningEndpoint);
+      this.server.onceShutdown().then((kind:tcp.SocketCloseKind) => {
+        log.info('server shutdown: %1', tcp.SocketCloseKind[kind]);
+      });
+    }).catch((e:Error) => {
+      log.error('failed to listen on %1: %2', endpoint, e.toString);
     });
 
     // Handle any new connections using |this.onConnection_|.

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -226,12 +226,9 @@ export class Server {
   }
 
   public toString = () : string => {
-    var s = 'Tcp.Server(' + JSON.stringify(this.endpoint_) +
-        ') ' + this.connectionsCount() + ' connections: {';
-    for (var socketId in this.connections_) {
-      s += '  ' + this.connections_[socketId].toString() + '\n';
-    }
-    return s += '}';
+    return 'TCP server ' + this.id_ + ': ' + JSON.stringify(this.endpoint_) +
+        ', ' + this.connectionsCount() + ' connections: ' +
+        this.connections().join(', ');
   }
 }
 

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -93,9 +93,7 @@ export class Server {
   });
 
   constructor(private endpoint_ :net.Endpoint,
-      private maxConnections_ ?:number) {
-    this.maxConnections_ = this.maxConnections_ || DEFAULT_MAX_CONNECTIONS;
-
+      private maxConnections_ :number = DEFAULT_MAX_CONNECTIONS) {
     this.onceListening_.then((unused:any) => {
       this.isListening_ = true;
     }, (e:Error) => {

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -211,8 +211,8 @@ export class Server {
   // Returns all active connections.
   public connections = () : Connection[] => {
     var connections : Connection[] = [];
-    for (var i in this.connections_) {
-      connections.push(this.connections_[i]);
+    for (var socketId in this.connections_) {
+      connections.push(this.connections_[socketId]);
     }
     return connections;
   }

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -69,7 +69,7 @@ export class Server {
 
   // Active connections to the server.
   // TODO: index by connectionId rather than socketID
-  private connections_:{[socketId:number] : Connection} = {};
+  private connections_ :{[socketId:number] : Connection} = {};
 
   public connectionsQueue :handler.Queue<Connection, void> =
       new handler.Queue<Connection, void>();

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -188,8 +188,8 @@ export class Server {
     log.debug('closing all connections');
 
     var promises :Promise<SocketCloseKind>[] = [];
-    for (var i in this.connections_) {
-      var connection = this.connections_[i];
+    for (var socketId in this.connections_) {
+      var connection = this.connections_[socketId];
       promises.push(connection.close());
     }
 

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -3,17 +3,13 @@
 /// <reference path='../../../third_party/freedom-typings/freedom-module-env.d.ts' />
 /// <reference path='../../../third_party/freedom-typings/tcp-socket.d.ts' />
 
-/*
- * This is a TCP server based on Freedom's sockets API.
- */
-
 import logging = require('../../../third_party/uproxy-lib/logging/logging');
 import handler = require('../../../third_party/uproxy-lib/handler/queue');
 import net = require('./net.types');
 
 var log :logging.Log = new logging.Log('tcp');
 
-// Code for how a Tcp Connection is closed.
+// Indicates how a socket (server or client) terminated.
 export enum SocketCloseKind {
   WE_CLOSED_IT,
   REMOTELY_CLOSED,
@@ -26,11 +22,10 @@ export interface ConnectionInfo {
   remote ?:net.Endpoint;
 }
 
-// A limit on the max number of TCP connections before we start rejecting
-// new ones.
+// Maximum per-server number of TCP connections.
 var DEFAULT_MAX_CONNECTIONS = 1048576;
 
-// Private function, exported only for unit tests
+// Public only for unit tests.
 export function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
     : ConnectionInfo {
   var retval :ConnectionInfo = {};
@@ -51,198 +46,204 @@ export function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
   return retval;
 }
 
-// A static helper function to close a freedom socket object and then
-// appropriately deallocate it's interface object.
-function destroyFreedomSocket_(socket:freedom_TcpSocket.Socket)
-    : Promise<void> {
-  // Note that :
-  // freedom['core.tcpsocket'].close != freedom['core.tcpsocket']().close
+// Closes a socket, along with its freedomjs interface object.
+function destroyFreedomSocket_(socket:freedom_TcpSocket.Socket) : Promise<void> {
+  // Note:
+  //   freedom['core.tcpsocket'].close != freedom['core.tcpsocket']().close
   // The former destroys the freedom interface & communication channels.
   // The latter is a method on the constructed interface object that is on
-  // the instance of the freedom tcp-socket's API.
-  return socket.close().then(
-    () => { freedom['core.tcpsocket'].close(socket); },
-    (e) => { freedom['core.tcpsocket'].close(socket); return e; });
+  // the instance of the freedomjs TCP socket API.
+  var destroy = () => {
+    freedom['core.tcpsocket'].close(socket);
+  };
+  return socket.close().then(destroy, (e:Error) => {
+    destroy();
+    return e;
+  });
 }
 
-// Tcp.Server: a TCP Server. This listens for connections when listen is
-// called, and handles the new connection as specified by the onConnection
-// argument to the constructor.
+// Promise and handler queue-based TCP server with freedomjs sockets.
+// TODO: protection against multiple calls to methods such as listen
 export class Server {
-  private serverSocket_ :freedom_TcpSocket.Socket;
-  // TODO: index by connectionId not socketID. More stable & string based.
-  private conns:{[socketId:number] : Connection} = {};
+  private socket_ :freedom_TcpSocket.Socket;
 
-  public connectionsQueue :handler.Queue<Connection, void>;
+  // Active connections to the server.
+  // TODO: index by connectionId rather than socketID
+  private connections_:{[socketId:number] : Connection} = {};
 
-  // The address and port that the tcp server is told to listening on. The
-  // initial assignment may set the port to 0, which indicates that the port
-  // is being dynamically allocated. When the port is actually assigned
-  // (right before the listen promise fulfills), the endpoint is set to the
-  // port that is actually being listened on.
-  private endpoint_ :net.Endpoint;
+  public connectionsQueue :handler.Queue<Connection, void> =
+      new handler.Queue<Connection, void>();
 
-  // The |onceShutdown| promise is fulfilled when the server is shutdown and
-  // no longer listening.
-  private onceShutdown_ :Promise<void>;
-  public onceShutdown = () : Promise<void> => { return this.onceShutdown_; }
-  // isShutdown can become true, but never false again. It gives synchronous
-  // access to test if |onceShutdown_| fulfilled.
+  private isListening_ :boolean = false;
+
+  private fulfillListening_ :(endpoint:net.Endpoint) => void;
+  private rejectListening_ :(e:Error) => void;
+
+  private onceListening_ = new Promise<net.Endpoint>((F, R) => {
+    this.fulfillListening_ = F;
+    this.rejectListening_ = R;
+  });
+
   private isShutdown_ :boolean = false;
-  public isShutdown = () : boolean => { return this.isShutdown_; }
 
-  private onceListening_ :Promise<net.Endpoint>;
-  public onceListening = () : Promise<net.Endpoint> => {
+  private fulfillShutdown_ :(kind:SocketCloseKind) => void;
+
+  private onceShutdown_ = new Promise<SocketCloseKind>((F, R) => {
+    this.fulfillShutdown_ = F;
+  });
+
+  constructor(private endpoint_ :net.Endpoint,
+      private maxConnections_ ?:number) {
+    this.maxConnections_ = this.maxConnections_ || DEFAULT_MAX_CONNECTIONS;
+
+    this.onceListening_.then((unused:any) => {
+      this.isListening_ = true;
+    }, (e:Error) => {
+      this.fulfillShutdown_(SocketCloseKind.NEVER_CONNECTED);
+    });
+
+    this.onceShutdown_.then((unused:any) => {
+      this.isShutdown_ = true;
+    });
+
+    this.socket_ = freedom['core.tcpsocket']();
+    this.socket_.on('onConnection', this.onConnectionHandler_);
+    this.socket_.on('onDisconnect', this.onDisconnectHandler_);
+  }
+
+  // Invoked when the socket terminates.
+  private onDisconnectHandler_ = (info:freedom_TcpSocket.DisconnectInfo) : void => {
+    log.debug('disconnected: %1', JSON.stringify(info));
+    if (info.errcode === 'SUCCESS') {
+      this.fulfillShutdown_(SocketCloseKind.WE_CLOSED_IT);
+    } else {
+      // TODO: investigate which other values occur
+      this.fulfillShutdown_(SocketCloseKind.UNKOWN);
+    }
+  }
+
+  // Listens for connections, returning onceListening.
+  // Should only be called once.
+  public listen = () : Promise<net.Endpoint> => {
+    this.socket_.listen(this.endpoint_.address,
+        this.endpoint_.port).then(this.socket_.getInfo).then(
+        (info:freedom_TcpSocket.SocketInfo) => {
+      this.endpoint_ = {
+        address: info.localAddress,
+        port: info.localPort
+      };
+      this.fulfillListening_(this.endpoint_);
+    }).catch((e:Error) => {
+      this.rejectListening_(new Error('failed to listen: ' + e.message));
+    });
+
     return this.onceListening_;
   }
-  private fulfillListening_ :(endpoint:net.Endpoint) => void;
-  private isListening_ :boolean = false;
-  public isListening = () : boolean => { return this.isListening_; };
 
-  // Create TCP server.
-  // `endpoint` = Address and port to be listening on. Port 0 is used for
-  // dynamic port allocation.
-  // `port` = the port to listen on; 0 = dynamic allocation.
-  // `onConnection` = the handler for new TCP Connections.
-  // `maxConnections` = the number of connections after which all new ones
-  // will be closed as soon as they connect.
-  constructor(endpoint :net.Endpoint,
-              public maxConnections ?:number) {
-    this.endpoint_ = endpoint;
-    this.maxConnections = maxConnections || DEFAULT_MAX_CONNECTIONS;
-    this.serverSocket_ = freedom['core.tcpsocket']();
-    // When `serverSocket_` gets new connections, handle them. This only
-    // happens after the server's listen function is called.
-    this.serverSocket_.on('onConnection', this.onConnectionHandler_);
-    this.connectionsQueue = new handler.Queue<Connection, void>();
-    this.onceShutdown_ = new Promise<void>((F,R) => {
-      this.serverSocket_.on('onDisconnect', () => {
-        F();
-        this.isShutdown_ = true;
-      });
-    });
-    this.onceListening_ = new Promise<net.Endpoint>((F,R) => {
-      this.fulfillListening_ = F;
-    });
-  }
-
-  // CONSIDER: use a generic util class for better object management, e.g.
-  // below should just be return conns.values().
-  public connections = () => {
-    var allConnectionsList : Connection[] = [];
-    for (var i in this.conns) { allConnectionsList.push(this.conns[i]); }
-    return allConnectionsList;
-  }
-
-  public connectionsCount = () => {
-    return Object.keys(this.conns).length;
-  }
-
-
-  // Listens on the serverSocket_ to `address:port` for new TCP connections.
-  // Returns a Promise that this server is now listening with the endpoint it
-  // is listening on. If 0 was passed as the port, a dynamic port is chosen.
-  public listen = () : Promise<net.Endpoint> => {
-    if (this.isShutdown_) {
-      return Promise.reject(new Error('Cannot listen on a shutdown server.'));
-    }
-    return this.serverSocket_.listen(this.endpoint_.address,
-                                     this.endpoint_.port)
-        .then(this.serverSocket_.getInfo)
-        .then((info : freedom_TcpSocket.SocketInfo) => {
-          this.endpoint_ = { address: info.localAddress,
-                             port: info.localPort };
-          this.fulfillListening_(this.endpoint_);
-          this.isListening_ = true;
-          return this.endpoint_;
-        });
-  }
-
-  // onConnectionHandler_ is more or less TCP Accept: it is called when a new
-  // TCP connection is established.
-  private onConnectionHandler_ =
-      (acceptValue:freedom_TcpSocket.ConnectInfo) : void => {
+  // Invoked each time a new connection is established with the server.
+  private onConnectionHandler_ = (
+      acceptValue:freedom_TcpSocket.ConnectInfo) : void => {
+    log.debug('new connection');
     var socketId = acceptValue.socket;
 
-    // Check that we haven't reach the maximum number of connections
-    var connectionsCount = Object.keys(this.conns).length;
-    if (connectionsCount >= this.maxConnections) {
-      // Stop too many connections.  We create a new socket here from the
-      // incoming Id and immediately close it, because we don't yet have a
-      // reference to the incomming socket.
+    if (this.connectionsCount() >= this.maxConnections_) {
+      log.warn('hit maximum connections count, dropping new connection');
       destroyFreedomSocket_(freedom['core.tcpsocket'](socketId));
-      //log.error('Too many connections: ' + connectionsCount);
       return;
     }
 
-    // Create new connection.
-    //log.debug('Tcp.Server accepted connection on socket id ' + socketId);
-    var conn = new Connection({existingSocketId:socketId});
-    // When the connection is disconnected correctly, or by error, remove
-    // from the server's list of connections.
-    conn.onceClosed.then(
-      () => {
-        delete this.conns[socketId];
-        //log.debug('Tcp.Server(' + JSON.stringify(this.endpoint) +
-        //    ') : connection closed (' + socketId + '). Conn Count: ' +
-        //    Object.keys(this.conns).length + ']');
-      },
-      (e) => {
-        delete this.conns[socketId];
-        //log.warn('Tcp.Server(' + JSON.stringify(this.endpoint) +
-        //    ') : connection closed by error (' + socketId + '): ' +
-        //    e.toString() + ' . Conn Count: ' +
-        //    Object.keys(this.conns).length + ']');
-      })
-    this.conns[socketId] = conn;
-    //log.debug(this.toString());
-    this.connectionsQueue.handle(conn);
-  }
-
-  // Mostly useful fro debugging
-  public toString = () : string => {
-    var s = 'Tcp.Server(' + JSON.stringify(this.endpoint_) +
-        ') connections: ' + Object.keys(this.conns).length + '\n{';
-    for(var socketId in this.conns) {
-      s += '  ' + this.conns[socketId].toString() + '\n';
-    }
-    return s += '}';
-  }
-
-  // Closes all active connections.
-  public closeAll = () : Promise<void> => {
-    var allPromises :Promise<SocketCloseKind>[] = [];
-
-    // Close all Tcp connections.
-    for (var i in this.conns) {
-      var c = this.conns[i];
-      allPromises.push(c.close());
-    }
-
-    // Wait for all promises to complete.
-    return Promise.all(allPromises).then(() => {
-      //log.debug('successfully closed all Tcp Connections.');
+    var connection = new Connection({
+      existingSocketId: socketId
     });
+    this.connections_[socketId] = connection;
+
+    var discard = () => {
+      delete this.connections_[socketId];
+      log.debug('discarded connection (%1 remaining)', this.connectionsCount());
+    };
+    connection.onceClosed.then(discard, (e:Error) => {
+      log.error('connection %1 rejected on close: %2', socketId, e.message);
+      discard();
+    });
+
+    this.connectionsQueue.handle(connection);
   }
 
-  public stopListening = () : Promise<void> => {
-    // Close the server socket. Note: freedom doesn't give a socket Id for a
-    // listening socket, so we just pass 0 back here: it's only for
-    // debugging/console logging, so it doesn't matter.
-    return destroyFreedomSocket_(this.serverSocket_).then(() => {
-      this.isListening_ = false;
-    })
-    //.then(() => {
-      //log.debug('successfully stopped listening for more connections.');
-    //});
-  }
-
+  // Closes the server socket then closes all active connections.
+  // Equivalent to calling stopListening followed by closeAll.
   public shutdown = () : Promise<void> => {
+    log.debug('shutdown');
     // This order is important: make sure no new connections happen while
     // we're trying to close all the connections.
     return this.stopListening().then(this.closeAll);
   }
-}  // class Tcp.Server
+
+  // Closes the server socket, preventing any new connections.
+  // Does not affect active connections to the server.
+  public stopListening = () : Promise<void> => {
+    log.debug('closing socket, no new connections will be accepted');
+    return destroyFreedomSocket_(this.socket_);
+  }
+
+  // Closes all active connections.
+  public closeAll = () : Promise<void> => {
+    log.debug('closing all connections');
+
+    var promises :Promise<SocketCloseKind>[] = [];
+    for (var i in this.connections_) {
+      var connection = this.connections_[i];
+      promises.push(connection.close());
+    }
+
+    return Promise.all(promises).then((unused:any) => {});
+  }
+
+  // Returns all active connections.
+  public connections = () : Connection[] => {
+    var connections : Connection[] = [];
+    for (var i in this.connections_) {
+      connections.push(this.connections_[i]);
+    }
+    return connections;
+  }
+
+  // Returns the number of the active connections.
+  public connectionsCount = () => {
+    return Object.keys(this.connections_).length;
+  }
+
+  // Returns true iff the promise returned by onceListening has fulfilled.
+  public isListening = () : boolean => {
+    return this.isListening_;
+  };
+
+  // Returns a promise which fulfills once the socket is accepting
+  // connections and rejects if there is any error creating the socket
+  // or listening for connections.
+  public onceListening = () : Promise<net.Endpoint> => {
+    return this.onceListening_;
+  }
+
+  // Returns true iff the promise returned by onceShutdown has fulfilled.
+  public isShutdown = () : boolean => {
+    return this.isShutdown_;
+  }
+
+  // Returns a promise which fulfills once the socket has stopped
+  // accepting new connections, or the call to listen has failed.
+  public onceShutdown = () : Promise<SocketCloseKind> => {
+    return this.onceShutdown_;
+  }
+
+  public toString = () : string => {
+    var s = 'Tcp.Server(' + JSON.stringify(this.endpoint_) +
+        ') ' + this.connectionsCount() + ' connections: {';
+    for (var socketId in this.connections_) {
+      s += '  ' + this.connections_[socketId].toString() + '\n';
+    }
+    return s += '}';
+  }
+}
 
 // Tcp.Connection - Manages up a single TCP connection.
 export class Connection {

--- a/src/socks-to-rtc/socks-to-rtc.ts
+++ b/src/socks-to-rtc/socks-to-rtc.ts
@@ -161,13 +161,9 @@ module SocksToRtc {
       // Shutdown if startup fails or when the server socket or
       // peerconnection terminates.
       onceReady.catch(this.fulfillStopping_);
-      this.tcpServer_.onceShutdown()
-        .then(() => {
-          log.info('server socket closed');
-        }, (e:Error) => {
-          log.error('server socket closed with error: %1', [e.message]);
-        })
-        .then(this.fulfillStopping_);
+      this.tcpServer_.onceShutdown().then((kind:tcp.SocketCloseKind) => {
+        log.info('server socket closed: %1', tcp.SocketCloseKind[kind]);
+      }).then(this.fulfillStopping_);
       this.peerConnection_.onceDisconnected
         .then(() => {
           log.info('peerconnection terminated');


### PR DESCRIPTION
While investigating seemingly-spontaneous Simple SOCKS shutdowns today, I had reason to suspect the TCP server was the real culprit.

It's currently poorly instrumented, so this is an effort to address that. Aside from the formatting cleanup, this adds `SocketCloseKind` to `onceClosed`. I think that's worth doing but am curious to hear your thoughts.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/247)

<!-- Reviewable:end -->
