### PR TITLE
fix paths to loggingprovider in firefox samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/samples/echo-server-firefoxapp/lib/main.js
+++ b/src/samples/echo-server-firefoxapp/lib/main.js
@@ -5,7 +5,7 @@ var {setTimeout} = require("sdk/timers");
 Cu.import(self.data.url("freedom-for-firefox/freedom-for-firefox.jsm"));
 
 var manifest = self.data.url("uproxy-networking/echo/freedom-module.json");
-var loggingProviderManifest = self.data.url("uproxy-lib/loggingprovider/loggingprovider.json");
+var loggingProviderManifest = self.data.url("uproxy-lib/loggingprovider/freedom-module.json");
 freedom(manifest, {
   'logger': loggingProviderManifest,
   'debug': 'debug'

--- a/src/samples/simple-socks-firefoxapp/lib/main.js
+++ b/src/samples/simple-socks-firefoxapp/lib/main.js
@@ -5,7 +5,7 @@ var {setTimeout} = require("sdk/timers");
 Cu.import(self.data.url("freedom-for-firefox/freedom-for-firefox.jsm"));
 
 var manifest = self.data.url("uproxy-networking/simple-socks/freedom-module.json");
-var loggingProviderManifest = self.data.url("uproxy-lib/loggingprovider/loggingprovider.json");
+var loggingProviderManifest = self.data.url("uproxy-lib/loggingprovider/freedom-module.json");
 freedom(manifest, {
   'logger': loggingProviderManifest,
   'debug': 'debug'


### PR DESCRIPTION
Gives us timestamps, and other custom goodness, in the logs.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/250)

<!-- Reviewable:end -->
