### PR TITLE
Make PoolChannels respect closure of the underlying DataChannel.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -26,6 +26,7 @@ taskManager.add 'test', [
   'browserify:rtcToNetSpec'
   'browserify:turnFrontEndMessagesSpec'
   'browserify:turnFrontEndSpec'
+  'browserify:poolSpec'
   'jasmine'
 ]
 
@@ -415,6 +416,7 @@ module.exports = (grunt) ->
     jasmine:
       churn: Rule.jasmineSpec 'churn'
       net: Rule.jasmineSpec 'net'
+      pool: Rule.jasmineSpec 'pool'
       rtcToNet: Rule.jasmineSpec 'rtc-to-net'
       simpleTransformers: Rule.jasmineSpec 'simple-transformers'
       socksCommon: Rule.jasmineSpec('socks-common',
@@ -431,6 +433,7 @@ module.exports = (grunt) ->
       tcpSpec: Rule.browserifySpec 'net/tcp'
       turnFrontEndMessagesSpec: Rule.browserifySpec 'turn-frontend/messages'
       turnFrontEndSpec: Rule.browserifySpec 'turn-frontend/turn-frontend'
+      poolSpec: Rule.browserifySpec 'pool/pool'
 
       # Freedom Modules
       churnPipeFreedomModule: Rule.browserify(

--- a/src/pool/pool.spec.ts
+++ b/src/pool/pool.spec.ts
@@ -27,7 +27,6 @@ describe('pool', function() {
   beforeEach(function() {
     mockDataChannels = [];
 
-    var noopPromise = new Promise<void>((F, R) => {});
     mockPeerConnection = <any>{
       openDataChannel: jasmine.createSpy('openDataChannel').and.callFake(() => {
         var mockDataChannel = createMockDataChannel('foo' + mockDataChannels.length);

--- a/src/pool/pool.spec.ts
+++ b/src/pool/pool.spec.ts
@@ -1,0 +1,86 @@
+/// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
+
+import freedomMocker = require('../../../third_party/uproxy-lib/freedom/mocks/mock-freedom-in-module-env');
+freedom = freedomMocker.makeMockFreedomInModuleEnv();
+
+import peerconnection = require('../../../third_party/uproxy-lib/webrtc/peerconnection');
+import handler = require('../../../third_party/uproxy-lib/handler/queue');
+import Pool = require('./pool');
+
+describe('pool', function() {
+  var mockPeerConnection :peerconnection.PeerConnection<Object>;
+  var pool :Pool;
+  var mockDataChannels :peerconnection.DataChannel[];
+
+  var createMockDataChannel = (label:string) : peerconnection.DataChannel => {
+    var fulfillClosed :() => void;
+    return <any>{
+      getLabel: () => { return label; },
+      onceOpened: Promise.resolve(),
+      onceClosed: new Promise<void>((F, R) => { fulfillClosed = F; }),
+      dataFromPeerQueue: new handler.Queue<peerconnection.Data, void>(),
+      send: jasmine.createSpy('send'),
+      close: jasmine.createSpy('close').and.callFake(() => { fulfillClosed(); })
+    };
+  }
+
+  beforeEach(function() {
+    mockDataChannels = [];
+
+    var noopPromise = new Promise<void>((F, R) => {});
+    mockPeerConnection = <any>{
+      openDataChannel: jasmine.createSpy('openDataChannel').and.callFake(() => {
+        var mockDataChannel = createMockDataChannel('foo' + mockDataChannels.length);
+        mockDataChannels.push(mockDataChannel);
+        return Promise.resolve(mockDataChannel);
+      }),
+      peerOpenedChannelQueue: new handler.Queue<peerconnection.DataChannel, void>()
+    };
+      
+    pool = new Pool(mockPeerConnection, 'test');
+  });
+
+  it('check a single open and close sequence', (done) => {
+    pool.openDataChannel().then((poolChannel:peerconnection.DataChannel) => {
+      expect(mockDataChannels[0].send).toHaveBeenCalledWith({
+        str: JSON.stringify({control: 'OPEN'})
+      });
+      var realChannel = <any>(mockDataChannels[0]);
+      realChannel.send.calls.reset();
+
+      poolChannel.send({str: 'foo'});
+      expect(realChannel.send).toHaveBeenCalledWith({
+        str: JSON.stringify({data: 'foo'})
+      });
+      realChannel.send.calls.reset();
+
+      var buffer = new Uint8Array(0).buffer;
+      poolChannel.send({buffer: buffer});
+      expect(realChannel.send).toHaveBeenCalledWith({buffer: buffer});
+      realChannel.send.calls.reset();
+
+      var closeAcked = false;
+      poolChannel.close().then(() => {
+        expect(closeAcked).toBe(true);
+        expect(realChannel.close).not.toHaveBeenCalled();
+        done();
+      });
+
+      expect(realChannel.send).toHaveBeenCalledWith({
+        str: JSON.stringify({control: 'CLOSE'})
+      });
+      realChannel.send.calls.reset();
+
+      // Send the ACK
+      closeAcked = true;
+      realChannel.dataFromPeerQueue.handle({str: JSON.stringify({control: 'CLOSE'})});
+    });
+  });
+  
+  it('check that an underlying close propagates', (done) => {
+    pool.openDataChannel().then((poolChannel:peerconnection.DataChannel) => {
+      poolChannel.onceClosed.then(done);
+    });
+    mockDataChannels[0].close();
+  });
+});


### PR DESCRIPTION
This is needed to ensure that cleanup actions run when the
PeerConnection terminates.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/251)

<!-- Reviewable:end -->
