### PR TITLE
Add a DefinitelyTyped rule for circular-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/third_party/tsd.json
+++ b/third_party/tsd.json
@@ -22,6 +22,9 @@
     },
     "request/request.d.ts": {
       "commit": "338059f48e4e32ef11472bd5a54ad91fb67f8c36"
+    },
+    "circular-json/circular-json.d.ts": {
+      "commit": "9c2d795cc1d98cd3e11186de9290776c66578ea0"
     }
   }
 }


### PR DESCRIPTION
We have the really annoying dependency rule that we need to pull in
typings for any child repo since the files get copied to our third_party
directory instead of living in their build directories that have the
typings specified.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/253)

<!-- Reviewable:end -->
