### PR TITLE
always destroy socket provider on disconnect, and fix type error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/integration-tests/tcp/freedom-module.ts
+++ b/src/integration-tests/tcp/freedom-module.ts
@@ -59,12 +59,12 @@ parentModule.on('shutdown', () => {
     var client = new tcp.Connection({endpoint: endpoint});
     server.connectionsQueue.setSyncHandler((connection:tcp.Connection) => {
       client.onceConnected.then(() => {
-    server.shutdown();
+        server.shutdown();
         return Promise.all<any>([connection.onceClosed, client.onceClosed,
             server.onceShutdown()]);
       })
       .then((values:any) => {
-    parentModule.emit('shutdown');
+        parentModule.emit('shutdown');
       });
     });
   });

--- a/src/integration-tests/tcp/freedom-module.ts
+++ b/src/integration-tests/tcp/freedom-module.ts
@@ -59,12 +59,12 @@ parentModule.on('shutdown', () => {
     var client = new tcp.Connection({endpoint: endpoint});
     server.connectionsQueue.setSyncHandler((connection:tcp.Connection) => {
       client.onceConnected.then(() => {
-        server.shutdown();
+    server.shutdown();
         return Promise.all<any>([connection.onceClosed, client.onceClosed,
             server.onceShutdown()]);
       })
       .then((values:any) => {
-        parentModule.emit('shutdown');
+    parentModule.emit('shutdown');
       });
     });
   });

--- a/src/net/counter.spec.ts
+++ b/src/net/counter.spec.ts
@@ -11,17 +11,17 @@ describe('socket call counter', function() {
     };
 
     var callCounter = new counter.Counter(destructor);
-    spyOn(callCounter, 'before').and.callThrough();
-    spyOn(callCounter, 'after').and.callThrough();
+    var beforeSpy = spyOn(callCounter, 'before_').and.callThrough();
+    var afterSpy = spyOn(callCounter, 'after_').and.callThrough();
 
-    counter.wrap(callCounter, () => {
-      expect(callCounter.before).toHaveBeenCalled();
-      expect(callCounter.after).not.toHaveBeenCalled();
+    callCounter.wrap(() => {
+      expect(beforeSpy).toHaveBeenCalled();
+      expect(afterSpy).not.toHaveBeenCalled();
 
       return Promise.resolve(1);
     }).then((result:number) => {
       expect(result).toEqual(1);
-      expect(callCounter.after).toHaveBeenCalled();
+      expect(afterSpy).toHaveBeenCalled();
       expect(destroyCalled).toBeFalsy();
 
       callCounter.discard();

--- a/src/net/counter.spec.ts
+++ b/src/net/counter.spec.ts
@@ -1,0 +1,35 @@
+/// <reference path='../../../third_party/typings/jasmine/jasmine.d.ts' />
+
+import counter = require('./counter');
+
+describe('socket call counter', function() {
+  // One wrapped call, then destroy.
+  it('simple wrap', (done) => {
+    var destroyCalled = false;
+    var destructor = () => {
+      destroyCalled = true;
+    };
+
+    var callCounter = new counter.Counter(destructor);
+    spyOn(callCounter, 'before').and.callThrough();
+    spyOn(callCounter, 'after').and.callThrough();
+
+    counter.wrap(callCounter, () => {
+      expect(callCounter.before).toHaveBeenCalled();
+      expect(callCounter.after).not.toHaveBeenCalled();
+
+      return Promise.resolve(1);
+    }).then((result:number) => {
+      expect(result).toEqual(1);
+      expect(callCounter.after).toHaveBeenCalled();
+      expect(destroyCalled).toBeFalsy();
+
+      callCounter.discard();
+    });
+
+    callCounter.onceDestroyed().then(() => {
+      expect(destroyCalled).toBeTruthy();
+      done();
+    });
+  });
+});

--- a/src/net/counter.ts
+++ b/src/net/counter.ts
@@ -1,0 +1,63 @@
+/// <reference path='../../../third_party/typings/es6-promise/es6-promise.d.ts' />
+
+// Counts calls to an object with asynchronous functions, running some
+// function once that counter reaches zero *and* a discard() function
+// has been called.
+// Intended for safely destroying freedomjs providers, which may emit
+// disconnect notifications before all outstanding calls have resolved.
+
+// Sandwiches a call, using the given call counter.
+export function wrap<T>(
+    counter:Counter,
+    f:() => Promise<T>) : Promise<T> {
+  // expect() should never throw.
+  counter.before();
+  return f().then((result:T) => {
+    counter.after();
+    return result;
+  }, (e:Error) => {
+    counter.after();
+    throw e;
+  });
+}
+
+// Counts calls, notifying when discard() has been called and there are no
+// more calls inflight.
+export class Counter {
+  private counter_ = 0;
+
+  private fulfillDestroyed_ :() => void;
+  private rejectDestroyed_ :(e:Error) => void;
+  private onceDestroyed_ = new Promise<void>((F, R) => {
+    this.fulfillDestroyed_ = F;
+    this.rejectDestroyed_ = R;
+  });
+
+  constructor(private destructor_ :() => void) {}
+
+  public discard = () : void => {
+    this.after();
+  }
+
+  public onceDestroyed = () : Promise<void> => {
+    return this.onceDestroyed_;
+  }
+
+  // Intended for use only by wrap().
+  public before = () : void => {
+    this.counter_++;
+  }
+
+  // Intended for use only by wrap().
+  public after = () : void => {
+    this.counter_--;
+    if (this.counter_ < 0) {
+      try {
+        this.destructor_();
+        this.fulfillDestroyed_();
+      } catch (e) {
+        this.rejectDestroyed_(e);
+      }
+    }
+  }
+}

--- a/src/net/counter.ts
+++ b/src/net/counter.ts
@@ -36,6 +36,8 @@ export class Counter {
   constructor(private destructor_ :() => void) {}
 
   public discard = () : void => {
+    // By decrementing the counter without first incrementing it, this will
+    // help drive the counter to -1, which is the termination condition.
     this.after();
   }
 

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -46,13 +46,10 @@ export function endpointOfSocketInfo(info:freedom_TcpSocket.SocketInfo)
   return retval;
 }
 
-// Closes a socket's freedomjs interface object, i.e.:
-//   freedom['core.tcpsocket']().close
-//
-// This is different from:
+// Closes a TCP socket provider's communication channel, causing freedomjs
+// to "forget" about the instance, i.e.:
 //   freedom['core.tcpsocket'].close
-// The former is a method on freedomjs TCP socket API while the latter destroys
-// the freedomjs interface and communication channels.
+// This is different from calling close on the provider instance.
 function destroyFreedomSocket_(socket:freedom_TcpSocket.Socket) : void {
   freedom['core.tcpsocket'].close(socket);
 }

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -403,7 +403,8 @@ export class Connection {
     this.onceConnected.then(() => {
       this.dataToSocketQueue.setHandler((buffer:ArrayBuffer) => {
         return wrap(this.preSocketOp_, this.postSocketOp_,
-            this.connectionSocket_.write.bind(undefined, buffer));
+            this.connectionSocket_.write.bind(
+                this.connectionSocket_, buffer));
       });
     });
     this.onceConnected.catch((e:Error) => {

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -60,19 +60,24 @@ function destroyFreedomSocket_(socket:freedom_TcpSocket.Socket) : void {
 // provider's communication channel is destroyed while the call is
 // pending (this can happen even on a normal call to the provider's
 // close method).
+// Throws synchronously if the before function raises an error; the
+// returned promise rejects if the after function raises an error.
 function wrap<T>(
     before:() => void,
     after:() => void,
     f:() => Promise<T>) : Promise<T> {
-  return new Promise<T>((F, R) => {
+  try {
     before();
-    return f().then((result:T) => {
-      after();
-      F(result);
-    }).catch((e:Error) => {
-      after();
-      R(e);
-    })
+  } catch (e) {
+    after();
+    throw e;
+  }
+  return f().then((result:T) => {
+    after();
+    return result;
+  }, (e:Error) => {
+    after();
+    throw e;
   });
 }
 

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -133,6 +133,8 @@ export class Server {
   private onDisconnectHandler_ = (info:freedom_TcpSocket.DisconnectInfo) : void => {
     log.debug('%1: disconnected: %2', this.id_, JSON.stringify(info));
 
+    // Call this without incrementing this.inflight_ to drive the counter
+    // below zero, which is the termination condition.
     this.postSocketOp_();
 
     if (info.errcode === 'SUCCESS') {
@@ -430,6 +432,8 @@ export class Connection {
       return;
     }
 
+    // Call this without incrementing this.inflight_ to drive the counter
+    // below zero, which is the termination condition.
     this.postSocketOp_();
 
     this.state_ = Connection.State.CLOSED;

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -129,7 +129,7 @@ export class Server {
   // Listens for connections, returning onceListening.
   // Should only be called once.
   public listen = () : Promise<net.Endpoint> => {
-    counter.wrap(this.counter_, () => {
+    this.counter_.wrap(() => {
       return this.socket_.listen(this.endpoint_.address,
           this.endpoint_.port).then(() => {
         return this.socket_.getInfo();
@@ -204,7 +204,7 @@ export class Server {
   public stopListening = () : Promise<void> => {
     log.debug('%1: closing socket, no new connections will be accepted',
         this.id_);
-    return counter.wrap(this.counter_, this.socket_.close);
+    return this.counter_.wrap(this.socket_.close);
   }
 
   // Closes all active connections.
@@ -310,7 +310,7 @@ export class Connection {
           freedom['core.tcpsocket'](connectionKind.existingSocketId);
       this.counter_ = new counter.Counter(destroyFreedomSocket_.bind(
           undefined, this.connectionSocket_));
-      this.onceConnected = counter.wrap(this.counter_,
+      this.onceConnected = this.counter_.wrap(
           this.connectionSocket_.getInfo).then(endpointOfSocketInfo);
       this.state_ = Connection.State.CONNECTED;
       this.connectionId = this.connectionId + '.A' +
@@ -324,7 +324,7 @@ export class Connection {
       // which we have connected.  To speed this process up, we immediately
       // pause the socket as soon as it's connected, so that CPU time is not
       // wasted sending events that we can't pass on until getInfo returns.
-      this.onceConnected = counter.wrap(this.counter_, () => {
+      this.onceConnected = this.counter_.wrap(() => {
         return this.connectionSocket_
               .connect(connectionKind.endpoint.address,
                        connectionKind.endpoint.port)
@@ -368,7 +368,7 @@ export class Connection {
     // queuing data to be send to the socket.
     this.onceConnected.then(() => {
       this.dataToSocketQueue.setHandler((buffer:ArrayBuffer) => {
-        return counter.wrap(this.counter_, this.connectionSocket_.write.bind(
+        return this.counter_.wrap(this.connectionSocket_.write.bind(
                 this.connectionSocket_, buffer));
       });
     });
@@ -423,11 +423,11 @@ export class Connection {
   }
 
   public pause = () => {
-    counter.wrap(this.counter_, this.connectionSocket_.pause);
+    this.counter_.wrap(this.connectionSocket_.pause);
   }
 
   public resume = () => {
-    counter.wrap(this.counter_, this.connectionSocket_.resume);
+    this.counter_.wrap(this.connectionSocket_.resume);
   }
 
   // This is called to close the underlying socket. This fulfills the
@@ -439,7 +439,7 @@ export class Connection {
       log.debug('%1: close called when already closed', [
           this.connectionId]);
     } else {
-      counter.wrap(this.counter_, this.connectionSocket_.close);
+      this.counter_.wrap(this.connectionSocket_.close);
     }
 
     // The onDisconnect handler (which should only


### PR DESCRIPTION
A new version of the TypeScript compiler highlighted this type error:
https://github.com/uProxy/uproxy-networking/blob/dev/src/net/tcp.ts#L61

Fixing it, I realised two things:
1. `close` throws an error when the socket is already closed
2. we have only been destroying the provider when we explicitly call `close`

I believe it's more appropriate to destroy the provider once we receive an `onDisconnect` event. This may fix:
https://github.com/uProxy/uproxy/issues/1303

@willscott could you also take a tiny quick look at this?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/254)

<!-- Reviewable:end -->
