### PR TITLE
workaround for core.udpsocket.getInfo address reporting issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/churn-pipe/churn-pipe.ts
+++ b/src/churn-pipe/churn-pipe.ts
@@ -144,7 +144,10 @@ class Pipe {
   public getLocalEndpoint = () : Promise<net.Endpoint> => {
     return this.socket_.getInfo().then((socketInfo:freedom_UdpSocket.SocketInfo) => {
       return {
-        address: socketInfo.localAddress,
+        // freedom-for-firefox currently reports the bound address as 'localhost',
+        // which is unsupported in candidate lines by Firefox:
+        //   https://github.com/freedomjs/freedom-for-firefox/issues/62
+        address: '127.0.0.1',
         port: socketInfo.localPort
       }
     });


### PR DESCRIPTION
Fixes:
https://github.com/uProxy/uproxy/issues/1263

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/256)

<!-- Reviewable:end -->
