### PR TITLE
defensive programming: onDisconnect should check the supplied value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uproxy-networking",
   "description": "uProxy's networking library: SOCKS5 over WebRTC",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/uProxy/uproxy-networking"

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -108,13 +108,17 @@ export class Server {
 
   // Invoked when the socket terminates.
   private onDisconnectHandler_ = (info:freedom_TcpSocket.DisconnectInfo) : void => {
-    log.debug('%1: disconnected: %2', this.id_, JSON.stringify(info));
+    if (info) {
+      log.debug('%1: onDisconnect: %2', this.id_, info);
+    } else {
+      log.warn('%1: onDisconnect without info', this.id_);
+    }
 
     this.counter_.discard();
 
     this.counter_.onceDestroyed().then(() => {
       log.debug('%1: closed socket channel', this.id_);
-      if (info.errcode === 'SUCCESS') {
+      if (info && info.errcode === 'SUCCESS') {
         this.fulfillShutdown_(SocketCloseKind.WE_CLOSED_IT);
       } else {
         // TODO: investigate which other values occur
@@ -389,12 +393,14 @@ export class Connection {
   // Invoked when the socket is closed for any reason.
   // Fulfills onceClosed.
   private onDisconnectHandler_ = (info:freedom_TcpSocket.DisconnectInfo) : void => {
-    log.debug('%1: onDisconnect: %2', [
-        this.connectionId,
-        JSON.stringify(info)]);
+    if (info) {
+      log.debug('%1: onDisconnect: %2', this.connectionId, info);
+    } else {
+      log.warn('%1: onDisconnect without info', this.connectionId);
+    }
 
     if (this.state_ === Connection.State.CLOSED) {
-      log.warn('%1: Got onDisconnect in closed state', [this.connectionId]);
+      log.warn('%1: Got onDisconnect in closed state', this.connectionId);
       return;
     }
 
@@ -409,9 +415,9 @@ export class Connection {
       // CONSIDER: can this happen after a onceConnected promise rejection? if so,
       // do we want to preserve the SocketCloseKind.NEVER_CONNECTED result for
       // onceClosed?
-      if (info.errcode === 'SUCCESS') {
+      if (info && info.errcode === 'SUCCESS') {
         this.fulfillClosed_(SocketCloseKind.WE_CLOSED_IT);
-      } else if (info.errcode === 'CONNECTION_CLOSED') {
+      } else if (info && info.errcode === 'CONNECTION_CLOSED') {
         this.fulfillClosed_(SocketCloseKind.REMOTELY_CLOSED);
       } else {
         this.fulfillClosed_(SocketCloseKind.UNKOWN);

--- a/src/net/tcp.ts
+++ b/src/net/tcp.ts
@@ -111,6 +111,8 @@ export class Server {
     if (info) {
       log.debug('%1: onDisconnect: %2', this.id_, info);
     } else {
+      // TODO: Consider removing this check when this issue is fixed:
+      //         https://github.com/freedomjs/freedom-for-firefox/issues/63
       log.warn('%1: onDisconnect without info', this.id_);
     }
 


### PR DESCRIPTION
Just a little thing arising from:
https://github.com/freedomjs/freedom-for-firefox/issues/63

Still on the fence about how defensive we want to be...in this case, it's a clear bug in the provider but easy to workaround.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/uproxy/uproxy-networking/257)

<!-- Reviewable:end -->
